### PR TITLE
fix: suppress HuggingFace symlink cache warning on Windows

### DIFF
--- a/src/jarvis/__init__.py
+++ b/src/jarvis/__init__.py
@@ -44,6 +44,14 @@ if getattr(_sys, 'frozen', False) and _sys.platform == 'win32':
 del _os, _sys
 # =============================================================================
 
+# Suppress HuggingFace symlink cache warning on Windows.
+# Most Windows users don't have Developer Mode enabled, so HF falls back to
+# copying files instead of symlinking. This is fine — just noisier.
+import os as _os
+if not _os.environ.get("HF_HUB_DISABLE_SYMLINKS_WARNING"):
+    _os.environ["HF_HUB_DISABLE_SYMLINKS_WARNING"] = "1"
+del _os
+
 from .config import load_settings
 
 


### PR DESCRIPTION
## Summary
- Suppress the `HF_HUB_DISABLE_SYMLINKS_WARNING` that tells Windows users to enable Developer Mode
- The warning is cosmetic — HF cache works fine without symlinks, just uses slightly more disk space
- Set the env var early in `jarvis/__init__.py` so it applies before any HuggingFace imports

## Test plan
- [ ] Verify on Windows that the symlink warning no longer appears in logs during model downloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)