### PR TITLE
fix: hot window false activation on non-directed speech after expiry

### DIFF
--- a/src/jarvis/listening/listener.py
+++ b/src/jarvis/listening/listener.py
@@ -481,8 +481,9 @@ class VoiceListener(threading.Thread):
                     (utterance_start_time > 0 and utterance_start_time < last_tts_finish_time) or
                     # Case 2: Utterance ended within grace period after TTS
                     (utterance_end_time > 0 and utterance_end_time - last_tts_finish_time < grace_period) or
-                    # Case 3: Fallback - processing happening within grace period
-                    (time.time() - last_tts_finish_time < grace_period)
+                    # Case 3: Fallback - only when utterance timing is unavailable
+                    (utterance_start_time == 0 and utterance_end_time == 0 and
+                     time.time() - last_tts_finish_time < grace_period)
                 ))
             )
 
@@ -533,13 +534,16 @@ class VoiceListener(threading.Thread):
                             return
                     else:
                         # Hot window mode - no wake word needed
-                        debug_log(f"✅ Intent judge accepted ({intent_judgment.confidence}): \"{intent_judgment.query}\"", "voice")
+                        # Use actual user text as query: in hot window there's no wake word
+                        # to strip, and the intent judge's extraction can lose words
+                        # (e.g. extracting "I" from "No, I'm good.")
+                        hot_query = text_lower
+                        debug_log(f"✅ Intent judge accepted ({intent_judgment.confidence}): \"{hot_query}\"", "voice")
                         self.state_manager.cancel_hot_window_activation()
                         self._transcript_buffer.mark_segment_processed(text_lower)
                         self._clear_audio_buffers()
 
-                        # Use the extracted query (cleaned of pre-wake-word chatter)
-                        self.state_manager.start_collection(intent_judgment.query)
+                        self.state_manager.start_collection(hot_query)
 
                         # Start thinking tune and show processing message
                         self._start_thinking_tune()

--- a/tests/test_listening_ux_overhaul.py
+++ b/tests/test_listening_ux_overhaul.py
@@ -372,8 +372,44 @@ class TestHotWindowTimingWithUtteranceTime:
 
         started_during_tts = utterance_start_time > 0 and utterance_start_time < tts_finish_time
         ended_within_grace = utterance_end_time > 0 and utterance_end_time - tts_finish_time < grace_period
-        processing_within_grace = current_time - tts_finish_time < grace_period
+        # Case 3 only fires when utterance timing is unavailable
+        processing_within_grace = (
+            utterance_start_time == 0 and utterance_end_time == 0 and
+            current_time - tts_finish_time < grace_period
+        )
 
         # Falls back to processing time
         could_be_hot_window = started_during_tts or ended_within_grace or processing_within_grace
         assert could_be_hot_window is True
+
+    def test_processing_time_fallback_not_used_when_utterance_times_available(self):
+        """Case 3 fallback must not fire when utterance timing is available.
+
+        Regression test: previously, Case 3 (time.time() < grace_period) would
+        fire even when utterance timing showed the speech was after the hot window,
+        causing false activations on e.g. "No, I'm good." after hot window expired.
+        """
+        tts_finish_time = 1000.0
+        hot_window_seconds = 3.0
+        echo_tolerance = 0.3
+        grace_period = hot_window_seconds + echo_tolerance
+
+        # Utterance timing IS available and shows speech after hot window
+        utterance_start_time = tts_finish_time + 4.0  # After hot window
+        utterance_end_time = tts_finish_time + 5.0
+        current_time = tts_finish_time + 5.1  # Within grace_period from tts_finish
+
+        started_during_tts = utterance_start_time > 0 and utterance_start_time < tts_finish_time
+        ended_within_grace = utterance_end_time > 0 and utterance_end_time - tts_finish_time < grace_period
+        # Case 3 should NOT fire because utterance timing is available
+        processing_within_grace = (
+            utterance_start_time == 0 and utterance_end_time == 0 and
+            current_time - tts_finish_time < grace_period
+        )
+
+        assert started_during_tts is False
+        assert ended_within_grace is False
+        assert processing_within_grace is False
+
+        could_be_hot_window = started_during_tts or ended_within_grace or processing_within_grace
+        assert could_be_hot_window is False

--- a/tests/test_query_validation.py
+++ b/tests/test_query_validation.py
@@ -209,6 +209,21 @@ class TestIntentJudgeWakeWordValidation:
 
         assert should_accept is True, "Should accept - hot window mode"
 
+    def test_hot_window_uses_actual_text_not_intent_judge_query(self):
+        """In hot window mode, the actual user text should be used as the query.
+
+        Regression test: previously the intent judge's extracted query was used,
+        which could lose words (e.g. extracting "I" from "No, I'm good.").
+        Per spec: "Hot window input should reflect what the user actually said."
+        """
+        text_lower = "no, i'm good."
+        intent_judgment_query = "I"  # Bad extraction by small LLM
+
+        # In hot window mode, we should use text_lower, not intent_judgment_query
+        hot_query = text_lower
+        assert hot_query == "no, i'm good."
+        assert hot_query != intent_judgment_query
+
 
 class TestStateTimingScenarios:
     """Tests for state timing and transitions.


### PR DESCRIPTION
Two fixes for a bug where "No, I'm good." triggered query "I":

1. Tighten could_be_hot_window Case 3 fallback: the time-based fallback now only fires when utterance timing data is unavailable, preventing false positives when timing shows speech was after the hot window.

2. Use actual user text as query in hot window mode instead of intent judge extraction. Per spec: "Hot window input should reflect what the user actually said." The 3b model can lose words during extraction (e.g. "I" from "No, I'm good.").