### PR TITLE
feat: add Tavily as configurable web search provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Jarvis starts listening automatically — just say "Jarvis" and talk!
 - **Conversational Awareness** - Understands ongoing discussions. Ask "Jarvis, what do you think?" and it knows what you're talking about. Works naturally in multi-person conversations.
 - **Unlimited Memory** - Never forgets. Searches across all your conversation history. Memory Viewer GUI included.
 - **Smart Personalities** - Adapts tone: Developer (debugging), Business (planning), Life Coach (health/wellness)
-- **Built-in Tools** - Screenshot OCR, web search (with auto-fetch), weather, file access, nutrition tracking, location awareness
+- **Built-in Tools** - Screenshot OCR, web search (DuckDuckGo or Tavily), weather, file access, nutrition tracking, location awareness
 - **Natural Voice** - Say "Jarvis" anywhere in your sentence, interrupt with "stop", follow up without repeating the wake word
 - **MCP Integration** - Connect to 500+ external tools (Home Assistant, GitHub, Slack, etc.)
 
@@ -211,6 +211,29 @@ Voice cloning with Chatterbox - add a 3-10 second .wav sample:
 {
   "tts_engine": "chatterbox",
   "tts_chatterbox_audio_prompt": "/path/to/voice.wav"
+}
+```
+
+</details>
+
+<details>
+<summary><strong>Web Search</strong></summary>
+
+Web search uses DuckDuckGo by default (no API key needed). You can optionally switch to [Tavily](https://app.tavily.com) for higher-quality, LLM-optimised results:
+
+```json
+{
+  "web_search_provider": "tavily",
+  "tavily_api_key": "tvly-YOUR_API_KEY"
+}
+```
+
+The API key can also be supplied via the `TAVILY_API_KEY` environment variable. If `web_search_provider` is set to `"tavily"` but no key is found, Jarvis falls back to DuckDuckGo automatically.
+
+To disable web search entirely (for full offline mode):
+```json
+{
+  "web_search_enabled": false
 }
 ```
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,7 @@ chatterbox-tts==0.1.2
 piper-tts>=1.3.0
 pygame>=2.1.0
 faiss-cpu>=1.7.4
+tavily-python>=0.3.0
 
 # MLX Whisper for Apple Silicon Macs (much faster than CPU-based faster-whisper)
 mlx-whisper>=0.4.0; sys_platform == "darwin" and platform_machine == "arm64"

--- a/src/jarvis/config.py
+++ b/src/jarvis/config.py
@@ -155,6 +155,8 @@ class Settings:
 
     # Web Search
     web_search_enabled: bool
+    web_search_provider: str  # "duckduckgo" (default) or "tavily"
+    tavily_api_key: str | None
 
     # MCP Integration
     mcps: Dict[str, Any]
@@ -394,6 +396,8 @@ def get_default_config() -> Dict[str, Any]:
 
         # Web Search
         "web_search_enabled": True,
+        "web_search_provider": "duckduckgo",  # "duckduckgo" (default) or "tavily"
+        "tavily_api_key": None,  # Set via TAVILY_API_KEY env var or config
 
         # MCP Integration (external servers Jarvis can use). No defaults.
         "mcps": {},
@@ -532,6 +536,11 @@ def load_settings() -> Settings:
     location_auto_detect = bool(merged.get("location_auto_detect", True))
     location_cgnat_resolve_public_ip = bool(merged.get("location_cgnat_resolve_public_ip", True))
     web_search_enabled = bool(merged.get("web_search_enabled", True))
+    web_search_provider = str(merged.get("web_search_provider", "duckduckgo")).lower()
+    if web_search_provider not in ("duckduckgo", "tavily"):
+        web_search_provider = "duckduckgo"
+    tavily_api_key_val = merged.get("tavily_api_key") or os.environ.get("TAVILY_API_KEY")
+    tavily_api_key = None if tavily_api_key_val in (None, "", "null") else str(tavily_api_key_val)
     mcps = _ensure_dict(merged.get("mcps"))
     whisper_min_confidence = float(merged.get("whisper_min_confidence", 0.4))
     whisper_min_audio_duration = float(merged.get("whisper_min_audio_duration", 0.3))
@@ -648,6 +657,8 @@ def load_settings() -> Settings:
 
         # Web Search
         web_search_enabled=web_search_enabled,
+        web_search_provider=web_search_provider,
+        tavily_api_key=tavily_api_key,
 
         # MCP Integration
         mcps=mcps,

--- a/src/jarvis/tools/builtin/web_search.py
+++ b/src/jarvis/tools/builtin/web_search.py
@@ -55,8 +55,11 @@ def _fetch_page_content(url: str, max_chars: int = 3000) -> Optional[str]:
         return None
 
 
-def _tavily_search(search_query: str, api_key: str) -> ToolExecutionResult:
-    """Execute web search using the Tavily API."""
+def _tavily_search(search_query: str, api_key: str) -> Tuple[ToolExecutionResult, int]:
+    """Execute web search using the Tavily API.
+
+    Returns a tuple of (ToolExecutionResult, result_count).
+    """
     from tavily import TavilyClient
 
     client = TavilyClient(api_key=api_key)
@@ -66,22 +69,24 @@ def _tavily_search(search_query: str, api_key: str) -> ToolExecutionResult:
         search_depth="basic",
     )
 
-    results: list[str] = []
-    for i, item in enumerate(response.get("results", []), start=1):
+    raw_results = response.get("results", [])
+    result_count = len(raw_results)
+    formatted: list[str] = []
+    for i, item in enumerate(raw_results, start=1):
         title = item.get("title", "")
         url = item.get("url", "")
         content = item.get("content", "")
-        results.append(f"{i}. **{title}**")
-        results.append(f"   Link: {url}")
+        formatted.append(f"{i}. **{title}**")
+        formatted.append(f"   Link: {url}")
         if content:
-            results.append(f"   {content}")
-        results.append("")
+            formatted.append(f"   {content}")
+        formatted.append("")
 
-    if results:
+    if formatted:
         reply_text = (
             f"Here are the web search results for '{search_query}'. "
             f"Use this information to reply to the user's query:\n\n"
-            + "\n".join(results)
+            + "\n".join(formatted)
         )
     else:
         reply_text = (
@@ -89,7 +94,7 @@ def _tavily_search(search_query: str, api_key: str) -> ToolExecutionResult:
             f"Let the user know you couldn't find results and suggest they try different search terms."
         )
 
-    return ToolExecutionResult(success=True, reply_text=reply_text)
+    return ToolExecutionResult(success=True, reply_text=reply_text), result_count
 
 
 class WebSearchTool(Tool):
@@ -139,8 +144,7 @@ class WebSearchTool(Tool):
                 if tavily_api_key:
                     debug_log("Using Tavily search provider", "web")
                     try:
-                        result = _tavily_search(search_query, tavily_api_key)
-                        count = result.reply_text.count("**") // 2
+                        result, count = _tavily_search(search_query, tavily_api_key)
                         if count > 0:
                             context.user_print(f"✅ Found {count} results.")
                         else:

--- a/src/jarvis/tools/builtin/web_search.py
+++ b/src/jarvis/tools/builtin/web_search.py
@@ -1,4 +1,4 @@
-"""Web search tool implementation using DuckDuckGo."""
+"""Web search tool implementation using DuckDuckGo or Tavily."""
 
 import requests
 from typing import Dict, Any, Optional, List, Tuple
@@ -55,8 +55,45 @@ def _fetch_page_content(url: str, max_chars: int = 3000) -> Optional[str]:
         return None
 
 
+def _tavily_search(search_query: str, api_key: str) -> ToolExecutionResult:
+    """Execute web search using the Tavily API."""
+    from tavily import TavilyClient
+
+    client = TavilyClient(api_key=api_key)
+    response = client.search(
+        query=search_query,
+        max_results=5,
+        search_depth="basic",
+    )
+
+    results: list[str] = []
+    for i, item in enumerate(response.get("results", []), start=1):
+        title = item.get("title", "")
+        url = item.get("url", "")
+        content = item.get("content", "")
+        results.append(f"{i}. **{title}**")
+        results.append(f"   Link: {url}")
+        if content:
+            results.append(f"   {content}")
+        results.append("")
+
+    if results:
+        reply_text = (
+            f"Here are the web search results for '{search_query}'. "
+            f"Use this information to reply to the user's query:\n\n"
+            + "\n".join(results)
+        )
+    else:
+        reply_text = (
+            f"The web search for '{search_query}' returned no results. "
+            f"Let the user know you couldn't find results and suggest they try different search terms."
+        )
+
+    return ToolExecutionResult(success=True, reply_text=reply_text)
+
+
 class WebSearchTool(Tool):
-    """Tool for performing web searches using DuckDuckGo."""
+    """Tool for performing web searches using DuckDuckGo or Tavily."""
 
     @property
     def name(self) -> str:
@@ -64,7 +101,7 @@ class WebSearchTool(Tool):
 
     @property
     def description(self) -> str:
-        return "Search the web using DuckDuckGo for current information, news, or general queries."
+        return "Search the web for current information, news, or general queries. Supports DuckDuckGo (default) and Tavily providers."
 
     @property
     def inputSchema(self) -> Dict[str, Any]:
@@ -77,7 +114,7 @@ class WebSearchTool(Tool):
         }
 
     def run(self, args: Optional[Dict[str, Any]], context: ToolContext) -> ToolExecutionResult:
-        """Execute web search using DuckDuckGo."""
+        """Execute web search using the configured provider."""
         context.user_print("🌐 Searching the web…")
         cfg = context.cfg
         try:
@@ -94,6 +131,31 @@ class WebSearchTool(Tool):
                 return ToolExecutionResult(success=False, reply_text="Please provide a search query for the web search.")
 
             debug_log(f"    🌐 searching for '{search_query}'", "web")
+
+            # Check if Tavily is the configured provider
+            provider = getattr(cfg, "web_search_provider", "duckduckgo")
+            tavily_api_key = getattr(cfg, "tavily_api_key", None)
+            if provider == "tavily":
+                if tavily_api_key:
+                    debug_log("Using Tavily search provider", "web")
+                    try:
+                        result = _tavily_search(search_query, tavily_api_key)
+                        count = result.reply_text.count("**") // 2
+                        if count > 0:
+                            context.user_print(f"✅ Found {count} results.")
+                        else:
+                            context.user_print("⚠️ No web results found.")
+                        return result
+                    except Exception as tavily_err:
+                        debug_log(f"Tavily search failed: {tavily_err}", "web")
+                        return ToolExecutionResult(
+                            success=False,
+                            reply_text=f"Tavily search failed for '{search_query}': {tavily_err}"
+                        )
+                else:
+                    debug_log("Tavily selected but TAVILY_API_KEY is missing, falling back to DuckDuckGo", "web")
+
+            # DuckDuckGo search (default fallback)
 
             # Gather instant answers
             instant_results = []

--- a/tests/tools/builtin/test_web_search.py
+++ b/tests/tools/builtin/test_web_search.py
@@ -120,10 +120,10 @@ class TestWebSearchTool:
         self.context.cfg.web_search_provider = "tavily"
         self.context.cfg.tavily_api_key = "tvly-test-key"
 
-        mock_tavily.return_value = ToolExecutionResult(
+        mock_tavily.return_value = (ToolExecutionResult(
             success=True,
             reply_text="Here are the web search results for 'test query'. Use this information to reply to the user's query:\n\n1. **Result Title**\n   Link: https://example.com\n   Some content\n"
-        )
+        ), 1)
 
         args = {"search_query": "test query"}
         result = self.tool.run(args, self.context)

--- a/tests/tools/builtin/test_web_search.py
+++ b/tests/tools/builtin/test_web_search.py
@@ -113,3 +113,57 @@ class TestWebSearchTool:
         assert isinstance(result, ToolExecutionResult)
         assert result.success is True  # still returns guidance
         assert "wasn't able to find" in result.reply_text.lower()
+
+    @patch('src.jarvis.tools.builtin.web_search._tavily_search')
+    def test_run_tavily_provider(self, mock_tavily):
+        """Test web search using Tavily provider."""
+        self.context.cfg.web_search_provider = "tavily"
+        self.context.cfg.tavily_api_key = "tvly-test-key"
+
+        mock_tavily.return_value = ToolExecutionResult(
+            success=True,
+            reply_text="Here are the web search results for 'test query'. Use this information to reply to the user's query:\n\n1. **Result Title**\n   Link: https://example.com\n   Some content\n"
+        )
+
+        args = {"search_query": "test query"}
+        result = self.tool.run(args, self.context)
+
+        assert result.success is True
+        assert "Result Title" in result.reply_text
+        mock_tavily.assert_called_once_with("test query", "tvly-test-key")
+
+    @patch('requests.get')
+    def test_tavily_fallback_when_no_api_key(self, mock_get):
+        """Test that Tavily falls back to DuckDuckGo when API key is missing."""
+        self.context.cfg.web_search_provider = "tavily"
+        self.context.cfg.tavily_api_key = None
+
+        # Set up DuckDuckGo mocks (instant + lite)
+        instant = Mock()
+        instant.status_code = 200
+        instant.json.return_value = {"Abstract": "Fallback answer"}
+        instant.raise_for_status = Mock()
+        lite = Mock()
+        lite.status_code = 200
+        lite.content = b'<html><body></body></html>'
+        mock_get.side_effect = [instant, lite]
+
+        args = {"search_query": "test query"}
+        result = self.tool.run(args, self.context)
+
+        assert result.success is True
+        assert "Fallback answer" in result.reply_text
+
+    @patch('src.jarvis.tools.builtin.web_search._tavily_search')
+    def test_tavily_error_returns_failure(self, mock_tavily):
+        """Test that Tavily errors are reported cleanly."""
+        self.context.cfg.web_search_provider = "tavily"
+        self.context.cfg.tavily_api_key = "tvly-test-key"
+
+        mock_tavily.side_effect = Exception("API rate limit exceeded")
+
+        args = {"search_query": "test query"}
+        result = self.tool.run(args, self.context)
+
+        assert result.success is False
+        assert "Tavily search failed" in result.reply_text


### PR DESCRIPTION
## Summary

- Adds Tavily as an opt-in web search provider alongside the existing DuckDuckGo scraper
- New config keys `web_search_provider` (default: `"duckduckgo"`) and `tavily_api_key` allow users to switch providers
- When `web_search_provider` is set to `"tavily"` but `TAVILY_API_KEY` is missing, gracefully falls back to DuckDuckGo with a debug log
- All existing DuckDuckGo functionality is fully preserved

## Files changed

- `requirements.txt` — added `tavily-python>=0.3.0`
- `src/jarvis/config.py` — added `web_search_provider` and `tavily_api_key` to Settings dataclass, defaults, and load_settings()
- `src/jarvis/tools/builtin/web_search.py` — added `_tavily_search()` helper and provider branching in `WebSearchTool.run()`
- `tests/tools/builtin/test_web_search.py` — added 3 tests for Tavily provider, fallback, and error handling

## Dependency changes

- Added `tavily-python>=0.3.0` to `requirements.txt`

## Environment variable changes

- Added `TAVILY_API_KEY` (optional; only needed when `web_search_provider` is set to `"tavily"`)

## Notes for reviewers

- This is an additive change — DuckDuckGo remains the default and no existing behaviour is altered
- Tavily is only activated when both `web_search_provider=tavily` and a valid `TAVILY_API_KEY` are present
- All 10 tests pass (7 existing + 3 new)


### Automated Review

- Passed after 2 attempt(s)
- Final review: The Tavily migration unit is correct and well-structured. Both review issues from attempt 1 are properly addressed: README now documents `web_search_provider`, `tavily_api_key`, and `TAVILY_API_KEY` env var with fallback behaviour; and `_tavily_search()` now returns `result_count` directly from `len(response.get("results", []))` — clean and accurate. Dependencies (`tavily-python>=0.3.0`) are in `requirements.txt`. Config fields are added to `Settings`, defaults, and loader with proper validation. Three new tests cover the Tavily provider path, missing-API-key fallback, and error reporting. No regressions to DuckDuckGo behaviour. Only minor style observations, none blocking.
