### PR TITLE
refactor: move mocked greeting/tool tests from evals to unit tests

### DIFF
--- a/evals/conftest.py
+++ b/evals/conftest.py
@@ -57,7 +57,6 @@ CLASS_DESCRIPTIONS = {
     "TestTopicSwitching": "Tests correct tool selection when conversation topic changes",
     "TestFollowUpContext": "Tests context retention for follow-up questions",
     "TestMultiTurnExtended": "Extended multi-turn scenarios with longer conversations",
-    "TestGreetingNoTools": "Tests that greetings don't trigger tool calls (mocked)",
     "TestGreetingNoToolsLive": "Live tests that greetings don't trigger tool calls",
 }
 
@@ -89,10 +88,9 @@ TEST_DESCRIPTIONS = {
     "test_follow_up_references_previous_context": "Follow-up references previous turn context",
     "test_three_turn_topic_changes": "3-turn conversation with topic changes",
     "test_rapid_topic_switching": "Rapid back-and-forth topic switching",
-    # Greeting no-tools tests
-    "test_greeting_no_tool_calls": "Greeting should not trigger tool calls",
-    "test_tool_queries_still_work": "Tool-requiring queries still trigger tools",
+    # Greeting no-tools live tests
     "test_greeting_no_tools_live": "Live: greeting should not trigger tool calls",
+    "test_user_instructions_no_tools_live": "Live: user instructions don't trigger tool calls",
     "test_weather_still_triggers_tools_live": "Live: weather query triggers tools",
 }
 

--- a/evals/test_greeting_no_tools.py
+++ b/evals/test_greeting_no_tools.py
@@ -1,11 +1,8 @@
 """
-Greeting No-Tools Evaluations
+Greeting No-Tools Evaluations (Live)
 
-Tests that greetings and simple conversation don't trigger tool calls,
-while tool-requiring queries still do.
-
-This is critical for small models (3b) which may incorrectly call tools
-for simple greetings when prompted to "proactively use tools."
+Live tests that verify greetings don't trigger tool calls with real LLM inference.
+Mocked equivalents live in tests/test_greeting_no_tools.py as unit tests.
 
 Run: ./scripts/run_evals.sh test_greeting
 """
@@ -25,8 +22,6 @@ from unittest.mock import patch
 
 from helpers import (
     MockConfig,
-    create_mock_llm_response,
-    create_tool_call,
     is_judge_llm_available,
 )
 
@@ -35,50 +30,6 @@ requires_judge_llm = pytest.mark.skipif(
     not _JUDGE_LLM_AVAILABLE,
     reason="Judge LLM not available"
 )
-
-
-# =============================================================================
-# Test Data
-# =============================================================================
-
-# Greetings in multiple languages - should NOT trigger tools
-GREETING_TEST_CASES = [
-    pytest.param("hello", False, id="Greeting: hello"),
-    pytest.param("hi there", False, id="Greeting: hi there"),
-    pytest.param("hey", False, id="Greeting: hey"),
-    pytest.param("ni hao", False, id="Greeting: ni hao (Chinese)"),
-    pytest.param("bonjour", False, id="Greeting: bonjour (French)"),
-    pytest.param("hola", False, id="Greeting: hola (Spanish)"),
-    pytest.param("merhaba", False, id="Greeting: merhaba (Turkish)"),
-    pytest.param("ciao", False, id="Greeting: ciao (Italian)"),
-    pytest.param("guten tag", False, id="Greeting: guten tag (German)"),
-    pytest.param("how are you", False, id="Greeting: how are you"),
-    pytest.param("thank you", False, id="Greeting: thank you"),
-    pytest.param("thanks", False, id="Greeting: thanks"),
-    pytest.param("goodbye", False, id="Greeting: goodbye"),
-    pytest.param("good morning", False, id="Greeting: good morning"),
-    pytest.param("good night", False, id="Greeting: good night"),
-]
-
-# User instructions about behaviour - should NOT trigger tools
-USER_INSTRUCTION_TEST_CASES = [
-    pytest.param("always use Celsius when telling me temperatures", False, id="Instruction: use Celsius"),
-    pytest.param("remember to always tell me things in Celsius", False, id="Instruction: remember Celsius"),
-    pytest.param("be more brief in your responses", False, id="Instruction: be more brief"),
-    pytest.param("speak in French from now on", False, id="Instruction: speak in French"),
-    pytest.param("always give me the short version", False, id="Instruction: short version"),
-    pytest.param("don't use emojis in your responses", False, id="Instruction: no emojis"),
-    pytest.param("note that I prefer metric units", False, id="Instruction: prefer metric"),
-]
-
-# Queries that SHOULD trigger tools
-TOOL_REQUIRED_TEST_CASES = [
-    pytest.param("what's the weather", True, id="Tool query: weather"),
-    pytest.param("search for python tutorials", True, id="Tool query: web search"),
-    pytest.param("what's the weather in Tokyo", True, id="Tool query: weather with location"),
-    pytest.param("look up the news today", True, id="Tool query: news search"),
-    pytest.param("what did I eat yesterday", True, id="Tool query: meal recall"),
-]
 
 
 # =============================================================================
@@ -98,115 +49,6 @@ class ToolCallCapture:
 
     def tool_names(self) -> List[str]:
         return [c["name"] for c in self.calls]
-
-
-# =============================================================================
-# Greeting Behaviour Tests (Mocked)
-# =============================================================================
-
-class TestGreetingNoTools:
-    """
-    Tests that greetings don't trigger tool calls.
-
-    Uses mocked LLM to verify the prompt system works correctly.
-    """
-
-    @pytest.mark.eval
-    @pytest.mark.parametrize("query,should_use_tools", GREETING_TEST_CASES + USER_INSTRUCTION_TEST_CASES)
-    def test_greeting_no_tool_calls(
-        self,
-        query: str,
-        should_use_tools: bool,
-        mock_config,
-        eval_db,
-        eval_dialogue_memory
-    ):
-        """Greetings should not trigger tool calls."""
-        from jarvis.reply.engine import run_reply_engine
-
-        # Use small model to test conservative prompts
-        mock_config.ollama_chat_model = "gemma3n"
-        capture = ToolCallCapture()
-
-        def mock_tool_run(db, cfg, tool_name, tool_args, **kwargs):
-            from jarvis.tools.types import ToolExecutionResult
-            capture.record(tool_name, tool_args or {})
-            return ToolExecutionResult(success=True, reply_text="Tool result")
-
-        def mock_chat(base_url, chat_model, messages, timeout_sec, extra_options=None, tools=None):
-            # Simulate model correctly NOT calling tools for greetings
-            return create_mock_llm_response("Hello! How can I help you today?")
-
-        with patch('jarvis.reply.engine.run_tool_with_retries', side_effect=mock_tool_run), \
-             patch('jarvis.reply.engine.chat_with_messages', side_effect=mock_chat), \
-             patch('jarvis.reply.engine.extract_search_params_for_memory', return_value={"keywords": []}), \
-             patch('jarvis.reply.engine.select_profile_llm', return_value="life"):
-
-            response = run_reply_engine(
-                db=eval_db, cfg=mock_config, tts=None,
-                text=query, dialogue_memory=eval_dialogue_memory
-            )
-
-        print(f"\n  Query: '{query}'")
-        print(f"  Tools called: {capture.tool_names() or 'none'}")
-        print(f"  Response: {(response or '')[:80]}...")
-
-        assert not capture.has_any_tool(), \
-            f"Greeting '{query}' should NOT trigger tools. Called: {capture.tool_names()}"
-
-    @pytest.mark.eval
-    @pytest.mark.parametrize("query,should_use_tools", TOOL_REQUIRED_TEST_CASES)
-    def test_tool_queries_still_work(
-        self,
-        query: str,
-        should_use_tools: bool,
-        mock_config,
-        eval_db,
-        eval_dialogue_memory
-    ):
-        """Tool-requiring queries should still trigger tools."""
-        from jarvis.reply.engine import run_reply_engine
-
-        # Use small model
-        mock_config.ollama_chat_model = "gemma3n"
-        capture = ToolCallCapture()
-
-        def mock_tool_run(db, cfg, tool_name, tool_args, **kwargs):
-            from jarvis.tools.types import ToolExecutionResult
-            capture.record(tool_name, tool_args or {})
-            return ToolExecutionResult(success=True, reply_text="Weather: 20C sunny")
-
-        call_count = 0
-        def mock_chat(base_url, chat_model, messages, timeout_sec, extra_options=None, tools=None):
-            nonlocal call_count
-            call_count += 1
-
-            if call_count == 1:
-                # Model correctly identifies need for tool
-                if "weather" in query.lower():
-                    return create_mock_llm_response("", [create_tool_call("getWeather", {"location": "here"})])
-                elif "search" in query.lower() or "look up" in query.lower() or "news" in query.lower():
-                    return create_mock_llm_response("", [create_tool_call("webSearch", {"search_query": query})])
-                elif "eat" in query.lower() or "meal" in query.lower():
-                    return create_mock_llm_response("", [create_tool_call("fetchMeals", {})])
-            return create_mock_llm_response("Here's the information you requested.")
-
-        with patch('jarvis.reply.engine.run_tool_with_retries', side_effect=mock_tool_run), \
-             patch('jarvis.reply.engine.chat_with_messages', side_effect=mock_chat), \
-             patch('jarvis.reply.engine.extract_search_params_for_memory', return_value={"keywords": []}), \
-             patch('jarvis.reply.engine.select_profile_llm', return_value="life"):
-
-            response = run_reply_engine(
-                db=eval_db, cfg=mock_config, tts=None,
-                text=query, dialogue_memory=eval_dialogue_memory
-            )
-
-        print(f"\n  Query: '{query}'")
-        print(f"  Tools called: {capture.tool_names() or 'none'}")
-        print(f"  Response: {(response or '')[:80]}...")
-
-        assert capture.has_any_tool(), \
-            f"Query '{query}' SHOULD trigger tools but didn't. Response: {response}"
 
 
 # =============================================================================

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,9 @@
 import sys
+from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import pytest
 
 # Robustly locate repository root (directory containing src/jarvis)
 _this_file = Path(__file__).resolve()
@@ -19,4 +23,66 @@ if str(ROOT) not in sys.path:
 # Also add the src directory (optional, for backwards compatibility with direct 'jarvis' imports)
 if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))
+
+
+@dataclass
+class MockConfig:
+    """Minimal config object for unit tests that need a config."""
+    ollama_base_url: str = "http://localhost:11434"
+    ollama_chat_model: str = "gemma3n"
+    ollama_embed_model: str = "nomic-embed-text"
+    db_path: str = ":memory:"
+    sqlite_vss_path: Optional[str] = None
+    voice_debug: bool = True
+    tts_enabled: bool = False
+    tts_engine: str = "piper"
+    tts_voice: Optional[str] = None
+    tts_rate: int = 200
+    tts_piper_model_path: Optional[str] = None
+    tts_piper_speaker: Optional[int] = None
+    tts_piper_length_scale: float = 1.0
+    tts_piper_noise_scale: float = 0.667
+    tts_piper_noise_w: float = 0.8
+    tts_piper_sentence_silence: float = 0.2
+    tts_chatterbox_device: str = "cpu"
+    tts_chatterbox_audio_prompt: Optional[str] = None
+    tts_chatterbox_exaggeration: float = 0.5
+    tts_chatterbox_cfg_weight: float = 0.5
+    web_search_enabled: bool = True
+    llm_profile_select_timeout_sec: float = 10.0
+    llm_tools_timeout_sec: float = 8.0
+    llm_embed_timeout_sec: float = 10.0
+    llm_chat_timeout_sec: float = 45.0
+    agentic_max_turns: int = 8
+    memory_enrichment_max_results: int = 5
+    active_profiles: List[str] = field(default_factory=lambda: ["developer", "business", "life"])
+    location_enabled: bool = True
+    location_ip_address: Optional[str] = None
+    location_auto_detect: bool = False
+    location_cgnat_resolve_public_ip: bool = False
+    dialogue_memory_timeout: int = 300
+    mcps: Dict[str, Any] = field(default_factory=dict)
+    use_stdin: bool = True
+
+
+@pytest.fixture
+def mock_config():
+    """Provide a mock configuration for unit tests."""
+    return MockConfig()
+
+
+@pytest.fixture
+def db():
+    """Provide an in-memory database for unit tests."""
+    from jarvis.memory.db import Database
+    database = Database(":memory:", sqlite_vss_path=None)
+    yield database
+    database.close()
+
+
+@pytest.fixture
+def dialogue_memory():
+    """Provide a dialogue memory instance for unit tests."""
+    from jarvis.memory.conversation import DialogueMemory
+    return DialogueMemory(inactivity_timeout=300, max_interactions=20)
 

--- a/tests/test_greeting_no_tools.py
+++ b/tests/test_greeting_no_tools.py
@@ -1,0 +1,190 @@
+"""
+Unit tests for greeting and instruction handling in the reply engine.
+
+Verifies that the model-size-aware prompt system correctly prevents
+tool calls for greetings and user instructions, while still allowing
+tools for queries that genuinely require them.
+
+These tests use a mocked LLM and do not require a real Ollama instance.
+"""
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List
+from unittest.mock import patch
+
+import pytest
+
+
+# =============================================================================
+# Test Data
+# =============================================================================
+
+# Greetings in multiple languages - should NOT trigger tools
+GREETING_TEST_CASES = [
+    pytest.param("hello", False, id="Greeting: hello"),
+    pytest.param("hi there", False, id="Greeting: hi there"),
+    pytest.param("hey", False, id="Greeting: hey"),
+    pytest.param("ni hao", False, id="Greeting: ni hao (Chinese)"),
+    pytest.param("bonjour", False, id="Greeting: bonjour (French)"),
+    pytest.param("hola", False, id="Greeting: hola (Spanish)"),
+    pytest.param("merhaba", False, id="Greeting: merhaba (Turkish)"),
+    pytest.param("ciao", False, id="Greeting: ciao (Italian)"),
+    pytest.param("guten tag", False, id="Greeting: guten tag (German)"),
+    pytest.param("how are you", False, id="Greeting: how are you"),
+    pytest.param("thank you", False, id="Greeting: thank you"),
+    pytest.param("thanks", False, id="Greeting: thanks"),
+    pytest.param("goodbye", False, id="Greeting: goodbye"),
+    pytest.param("good morning", False, id="Greeting: good morning"),
+    pytest.param("good night", False, id="Greeting: good night"),
+]
+
+# User instructions about behaviour - should NOT trigger tools
+USER_INSTRUCTION_TEST_CASES = [
+    pytest.param("always use Celsius when telling me temperatures", False, id="Instruction: use Celsius"),
+    pytest.param("remember to always tell me things in Celsius", False, id="Instruction: remember Celsius"),
+    pytest.param("be more brief in your responses", False, id="Instruction: be more brief"),
+    pytest.param("speak in French from now on", False, id="Instruction: speak in French"),
+    pytest.param("always give me the short version", False, id="Instruction: short version"),
+    pytest.param("don't use emojis in your responses", False, id="Instruction: no emojis"),
+    pytest.param("note that I prefer metric units", False, id="Instruction: prefer metric"),
+]
+
+# Queries that SHOULD trigger tools
+TOOL_REQUIRED_TEST_CASES = [
+    pytest.param("what's the weather", True, id="Tool query: weather"),
+    pytest.param("search for python tutorials", True, id="Tool query: web search"),
+    pytest.param("what's the weather in Tokyo", True, id="Tool query: weather with location"),
+    pytest.param("look up the news today", True, id="Tool query: news search"),
+    pytest.param("what did I eat yesterday", True, id="Tool query: meal recall"),
+]
+
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+@dataclass
+class ToolCallCapture:
+    """Captures tool calls made during a test run."""
+    calls: List[Dict[str, Any]] = field(default_factory=list)
+
+    def record(self, name: str, args: Dict[str, Any]):
+        self.calls.append({"name": name, "args": args})
+
+    def has_any_tool(self) -> bool:
+        return len(self.calls) > 0
+
+    def tool_names(self) -> List[str]:
+        return [c["name"] for c in self.calls]
+
+
+def _mock_llm_response(content: str, tool_calls=None):
+    """Build a minimal mock Ollama response dict."""
+    message = {"content": content, "role": "assistant"}
+    if tool_calls:
+        message["tool_calls"] = tool_calls
+    return {"message": message}
+
+
+def _tool_call(name: str, args: Dict[str, Any]):
+    """Build a mock tool-call entry in OpenAI format."""
+    return {
+        "id": f"call_{name}_001",
+        "function": {"name": name, "arguments": args},
+    }
+
+
+# =============================================================================
+# Tests
+# =============================================================================
+
+class TestGreetingNoTools:
+    """
+    Verifies that the model-size-aware prompt system does not trigger tool
+    calls for greetings or user instructions when using a mocked LLM.
+    """
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize("query,should_use_tools", GREETING_TEST_CASES + USER_INSTRUCTION_TEST_CASES)
+    def test_greeting_no_tool_calls(
+        self,
+        query: str,
+        should_use_tools: bool,
+        mock_config,
+        db,
+        dialogue_memory,
+    ):
+        """Greetings and user instructions should not trigger tool calls."""
+        from jarvis.reply.engine import run_reply_engine
+
+        mock_config.ollama_chat_model = "gemma3n"
+        capture = ToolCallCapture()
+
+        def mock_tool_run(db, cfg, tool_name, tool_args, **kwargs):  # noqa: F841 (shadows fixture)
+            from jarvis.tools.types import ToolExecutionResult
+            capture.record(tool_name, tool_args or {})
+            return ToolExecutionResult(success=True, reply_text="Tool result")
+
+        def mock_chat(base_url, chat_model, messages, timeout_sec, extra_options=None, tools=None):
+            return _mock_llm_response("Hello! How can I help you today?")
+
+        with patch('jarvis.reply.engine.run_tool_with_retries', side_effect=mock_tool_run), \
+             patch('jarvis.reply.engine.chat_with_messages', side_effect=mock_chat), \
+             patch('jarvis.reply.engine.extract_search_params_for_memory', return_value={"keywords": []}), \
+             patch('jarvis.reply.engine.select_profile_llm', return_value="life"):
+
+            run_reply_engine(
+                db=db, cfg=mock_config, tts=None,
+                text=query, dialogue_memory=dialogue_memory,
+            )
+
+        assert not capture.has_any_tool(), \
+            f"Greeting '{query}' should NOT trigger tools. Called: {capture.tool_names()}"
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize("query,should_use_tools", TOOL_REQUIRED_TEST_CASES)
+    def test_tool_queries_still_work(
+        self,
+        query: str,
+        should_use_tools: bool,
+        mock_config,
+        db,
+        dialogue_memory,
+    ):
+        """Queries that require tools should still trigger them."""
+        from jarvis.reply.engine import run_reply_engine
+
+        mock_config.ollama_chat_model = "gemma3n"
+        capture = ToolCallCapture()
+
+        def mock_tool_run(db, cfg, tool_name, tool_args, **kwargs):  # noqa: F841 (shadows fixture)
+            from jarvis.tools.types import ToolExecutionResult
+            capture.record(tool_name, tool_args or {})
+            return ToolExecutionResult(success=True, reply_text="Weather: 20C sunny")
+
+        call_count = 0
+
+        def mock_chat(base_url, chat_model, messages, timeout_sec, extra_options=None, tools=None):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                if "weather" in query.lower():
+                    return _mock_llm_response("", [_tool_call("getWeather", {"location": "here"})])
+                elif "search" in query.lower() or "look up" in query.lower() or "news" in query.lower():
+                    return _mock_llm_response("", [_tool_call("webSearch", {"search_query": query})])
+                elif "eat" in query.lower() or "meal" in query.lower():
+                    return _mock_llm_response("", [_tool_call("fetchMeals", {})])
+            return _mock_llm_response("Here's the information you requested.")
+
+        with patch('jarvis.reply.engine.run_tool_with_retries', side_effect=mock_tool_run), \
+             patch('jarvis.reply.engine.chat_with_messages', side_effect=mock_chat), \
+             patch('jarvis.reply.engine.extract_search_params_for_memory', return_value={"keywords": []}), \
+             patch('jarvis.reply.engine.select_profile_llm', return_value="life"):
+
+            response = run_reply_engine(
+                db=db, cfg=mock_config, tts=None,
+                text=query, dialogue_memory=dialogue_memory,
+            )
+
+        assert capture.has_any_tool(), \
+            f"Query '{query}' SHOULD trigger tools but didn't. Response: {response}"


### PR DESCRIPTION
## Summary

- `TestGreetingNoTools` used a fully mocked LLM and tested the mechanics of the model-size-aware prompt system — not LLM quality. It belongs in the unit test suite, not evals.
- Moved to `tests/test_greeting_no_tools.py` with `@pytest.mark.unit`, alongside `TestModelSizeDetection` and `TestPromptComponents`.
- Added shared `mock_config`, `db`, and `dialogue_memory` fixtures to `tests/conftest.py` for use by tests that need a config/db without spinning up a real Ollama instance.
- `TestGreetingNoToolsLive` (requires real LLM inference) stays in `evals/`.

## Test plan

- [ ] `python -m pytest tests/test_greeting_no_tools.py tests/test_prompts.py` → 55 passed
- [ ] Evals still collect only live tests under `TestGreetingNoToolsLive`

🤖 Generated with [Claude Code](https://claude.com/claude-code)