### PR TITLE
Runtime Health Registry and Graceful Bootstrap

### DIFF
--- a/src/desktop_app/__init__.py
+++ b/src/desktop_app/__init__.py
@@ -15,6 +15,19 @@ os.environ.setdefault('OPENBLAS_NUM_THREADS', '1')
 os.environ.setdefault('MKL_NUM_THREADS', '1')
 os.environ.setdefault('OMP_NUM_THREADS', '1')
 
+# When launched as `python -m src.desktop_app` the package is registered in
+# sys.modules as 'src.desktop_app', but all internal imports use the bare
+# 'desktop_app' name (matching the PYTHONPATH=src invocation used by the run
+# scripts).  Alias ourselves and add src/ to sys.path so both styles work
+# without triggering a double-import of this __init__.
+import importlib
+_this_module = sys.modules[__name__]   # 'src.desktop_app' or 'desktop_app'
+if __name__ != 'desktop_app':
+    sys.modules.setdefault('desktop_app', _this_module)
+    _src_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    if _src_dir not in sys.path:
+        sys.path.insert(0, _src_dir)
+
 # Re-export main for entry point
 from desktop_app.app import main
 

--- a/src/jarvis/config.py
+++ b/src/jarvis/config.py
@@ -165,6 +165,9 @@ class Settings:
     # MCP Integration
     mcps: Dict[str, Any]
 
+    # ── Shutdown ───────────────────────────────────────────────────────────────────
+    shutdown_diary_timeout_sec: float
+    """Maximum seconds to wait for diary LLM update during shutdown."""
 
 
 def _default_config_path() -> Path:
@@ -403,6 +406,9 @@ def get_default_config() -> Dict[str, Any]:
 
         # MCP Integration (external servers Jarvis can use). No defaults.
         "mcps": {},
+
+        # Shutdown
+        "shutdown_diary_timeout_sec": 45.0,
     }
 
 
@@ -539,6 +545,10 @@ def load_settings() -> Settings:
     location_cgnat_resolve_public_ip = bool(merged.get("location_cgnat_resolve_public_ip", True))
     web_search_enabled = bool(merged.get("web_search_enabled", True))
     mcps = _ensure_dict(merged.get("mcps"))
+
+    # Shutdown
+    shutdown_diary_timeout_sec = float(merged.get("shutdown_diary_timeout_sec", 45.0))
+
     whisper_min_confidence = float(merged.get("whisper_min_confidence", 0.4))
     whisper_min_audio_duration = float(merged.get("whisper_min_audio_duration", 0.3))
     whisper_min_word_length = int(merged.get("whisper_min_word_length", 2))
@@ -657,4 +667,7 @@ def load_settings() -> Settings:
 
         # MCP Integration
         mcps=mcps,
+
+        # Shutdown
+        shutdown_diary_timeout_sec=shutdown_diary_timeout_sec,
     )

--- a/src/jarvis/daemon.py
+++ b/src/jarvis/daemon.py
@@ -294,15 +294,14 @@ def main() -> None:
     print(f"🧠 Using chat model: {cfg.ollama_chat_model}", flush=True)
     print(f"🎤 Using whisper model: {cfg.whisper_model}", flush=True)
 
-    # Initialise runtime health registry.
+    # Initialise runtime health registry (sets module-level singleton).
     # Graceful: a failure degrades the service but does not abort startup.
     try:
         from .runtime.health import configure as _configure_health
-        _health = _configure_health()
+        _configure_health()
         debug_log("health registry configured", "runtime")
     except Exception as _he:
         debug_log(f"health registry init failed (non-fatal): {_he}", "runtime")
-        _health = None
 
     # MCP preflight: discover and cache external MCP tools
     mcps = getattr(cfg, "mcps", {}) or {}

--- a/src/jarvis/daemon.py
+++ b/src/jarvis/daemon.py
@@ -294,6 +294,16 @@ def main() -> None:
     print(f"🧠 Using chat model: {cfg.ollama_chat_model}", flush=True)
     print(f"🎤 Using whisper model: {cfg.whisper_model}", flush=True)
 
+    # Initialise runtime health registry.
+    # Graceful: a failure degrades the service but does not abort startup.
+    try:
+        from .runtime.health import configure as _configure_health
+        _health = _configure_health()
+        debug_log("health registry configured", "runtime")
+    except Exception as _he:
+        debug_log(f"health registry init failed (non-fatal): {_he}", "runtime")
+        _health = None
+
     # MCP preflight: discover and cache external MCP tools
     mcps = getattr(cfg, "mcps", {}) or {}
     if mcps:

--- a/src/jarvis/runtime/__init__.py
+++ b/src/jarvis/runtime/__init__.py
@@ -1,0 +1,15 @@
+"""Jarvis runtime management package."""
+
+from .health import HealthRegistry, ServiceHealth, HealthStatus
+from .service_container import ServiceContainer
+from .shutdown_manager import ShutdownManager
+from .bootstrap import build_service_container
+
+__all__ = [
+    "HealthRegistry",
+    "ServiceHealth",
+    "HealthStatus",
+    "ServiceContainer",
+    "ShutdownManager",
+    "build_service_container",
+]

--- a/src/jarvis/runtime/bootstrap.py
+++ b/src/jarvis/runtime/bootstrap.py
@@ -1,0 +1,218 @@
+"""
+Bootstrap — assembles all Jarvis services into a :class:`~jarvis.runtime.service_container.ServiceContainer`.
+
+Each service initialisation is graceful: failures mark the service as
+DEGRADED or UNAVAILABLE in the health registry and execution continues.
+This ensures Jarvis can start (with limited functionality) even when
+optional dependencies are unavailable.
+
+Entry point used by the daemon::
+
+    from jarvis.runtime.bootstrap import build_service_container
+
+    container = build_service_container(cfg)
+    # container.health describes what started successfully
+    container.stop_event.wait()
+    container.shutdown_manager.shutdown()
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Optional
+
+from ..debug import debug_log
+from .health import HealthRegistry, HealthStatus, ServiceName, configure as configure_health
+from .service_container import ServiceContainer
+from .shutdown_manager import ShutdownManager
+
+
+def build_service_container(cfg) -> ServiceContainer:
+    """
+    Initialise all services and return a populated :class:`ServiceContainer`.
+
+    Services are started in dependency order.  Each step is wrapped in a
+    try/except so that a failure degrades individual services rather than
+    aborting the whole startup.
+
+    Args:
+        cfg: :class:`~jarvis.config.Settings` instance.
+
+    Returns:
+        :class:`ServiceContainer` with health registry populated.
+    """
+    health = configure_health()
+    container = ServiceContainer(cfg, health)
+
+    debug_log("bootstrap: starting service initialisation", "runtime")
+
+    _init_audit(container)
+    _init_policy(container)
+    _init_database(container)
+    _init_tts(container)
+    _init_mcp(container)
+    _init_location(container)
+
+    # Shutdown manager wires all services together
+    manager = ShutdownManager(cfg, health)
+    manager.register_db(container.db)
+    manager.register_tts(container.tts)
+    manager.register_audit_recorder(container.audit_recorder)
+    container.shutdown_manager = manager
+
+    debug_log(f"bootstrap: complete — health summary: {health.summary()}", "runtime")
+    return container
+
+
+# ---------------------------------------------------------------------------
+# Individual service initialisers
+# ---------------------------------------------------------------------------
+
+def _init_audit(container: ServiceContainer) -> None:
+    """Initialise the audit recorder."""
+    health = container.health
+    health.initialising(ServiceName.AUDIT)
+    try:
+        from ..audit.recorder import configure as configure_audit
+        cfg = container.cfg
+        audit_db_path = getattr(cfg, "audit_db_path", None)
+        if not audit_db_path:
+            # Default to a sibling file of the main DB
+            main_db = getattr(cfg, "db_path", str(Path.home() / ".local/share/jarvis/jarvis.db"))
+            audit_db_path = str(Path(main_db).parent / "audit.db")
+        recorder = configure_audit(audit_db_path)
+        container.audit_recorder = recorder
+        health.ready(ServiceName.AUDIT, f"db={audit_db_path}")
+    except Exception as exc:
+        health.degraded(ServiceName.AUDIT, "audit db unavailable", error=str(exc))
+        debug_log(f"bootstrap: audit init failed: {exc}", "runtime")
+
+
+def _init_policy(container: ServiceContainer) -> None:
+    """Initialise the policy engine."""
+    health = container.health
+    health.initialising(ServiceName.POLICY)
+    try:
+        from ..policy.approvals import ApprovalStore
+        from ..policy.engine import configure as configure_policy
+        cfg = container.cfg
+        # Reuse audit db path for approval persistence when available
+        audit_db_path: Optional[str] = None
+        if container.audit_recorder is not None:
+            try:
+                audit_db_path = container.audit_recorder._db._db_path  # type: ignore[attr-defined]
+            except Exception:
+                pass
+        store = ApprovalStore(db_path=audit_db_path)
+        engine = configure_policy(cfg, store)
+        container.policy_engine = engine
+        container.approval_store = store
+        health.ready(ServiceName.POLICY, f"mode={getattr(cfg, 'policy_mode', 'ask_destructive')}")
+    except Exception as exc:
+        health.degraded(ServiceName.POLICY, "policy engine unavailable", error=str(exc))
+        debug_log(f"bootstrap: policy init failed: {exc}", "runtime")
+
+
+def _init_database(container: ServiceContainer) -> None:
+    """Initialise the main Jarvis database and dialogue memory."""
+    health = container.health
+    health.initialising(ServiceName.DATABASE)
+    try:
+        from ..memory.db import Database
+        from ..memory.conversation import DialogueMemory
+        cfg = container.cfg
+        db = Database(cfg.db_path, sqlite_vss_path=cfg.sqlite_vss_path)
+        container.db = db
+
+        dialogue_memory = DialogueMemory(
+            inactivity_timeout=cfg.dialogue_memory_timeout,
+            max_interactions=20,
+        )
+        container.dialogue_memory = dialogue_memory
+
+        health.ready(ServiceName.DATABASE, cfg.db_path)
+        if container.shutdown_manager:
+            container.shutdown_manager.register_db(db)
+            container.shutdown_manager.register_dialogue_memory(dialogue_memory)
+    except Exception as exc:
+        health.unavailable(ServiceName.DATABASE, error=str(exc))
+        debug_log(f"bootstrap: database init failed: {exc}", "runtime")
+
+
+def _init_tts(container: ServiceContainer) -> None:
+    """Initialise the TTS engine (optional — degrades gracefully)."""
+    health = container.health
+    health.initialising(ServiceName.TTS)
+    try:
+        from ..output.tts import create_tts_engine
+        cfg = container.cfg
+        if not getattr(cfg, "tts_enabled", True):
+            health.unavailable(ServiceName.TTS, "disabled in config")
+            return
+        engine = create_tts_engine(
+            engine=getattr(cfg, "tts_engine", "piper"),
+            enabled=getattr(cfg, "tts_enabled", True),
+            voice=getattr(cfg, "tts_voice", None),
+            rate=getattr(cfg, "tts_rate", None),
+            device=getattr(cfg, "tts_chatterbox_device", "cuda"),
+            audio_prompt_path=getattr(cfg, "tts_chatterbox_audio_prompt", None),
+            exaggeration=getattr(cfg, "tts_chatterbox_exaggeration", 0.5),
+            cfg_weight=getattr(cfg, "tts_chatterbox_cfg_weight", 0.5),
+            piper_model_path=getattr(cfg, "tts_piper_model_path", None),
+            piper_speaker=getattr(cfg, "tts_piper_speaker", None),
+            piper_length_scale=getattr(cfg, "tts_piper_length_scale", 1.0),
+            piper_noise_scale=getattr(cfg, "tts_piper_noise_scale", 0.667),
+            piper_noise_w=getattr(cfg, "tts_piper_noise_w", 0.8),
+            piper_sentence_silence=getattr(cfg, "tts_piper_sentence_silence", 0.2),
+        )
+        container.tts = engine
+        if engine is None:
+            health.degraded(ServiceName.TTS, "engine returned None")
+        else:
+            health.ready(ServiceName.TTS, getattr(cfg, "tts_engine", "piper"))
+        if container.shutdown_manager:
+            container.shutdown_manager.register_tts(engine)
+    except Exception as exc:
+        health.degraded(ServiceName.TTS, "TTS unavailable — text-only mode", error=str(exc))
+        debug_log(f"bootstrap: TTS init failed: {exc}", "runtime")
+
+
+def _init_mcp(container: ServiceContainer) -> None:
+    """Initialise MCP tool discovery (optional — degrades gracefully)."""
+    health = container.health
+    health.initialising(ServiceName.MCP)
+    try:
+        cfg = container.cfg
+        mcps = getattr(cfg, "mcps", {})
+        if not mcps:
+            health.unavailable(ServiceName.MCP, "no MCP servers configured")
+            return
+        from ..tools.registry import initialize_mcp_tools
+        discovered = initialize_mcp_tools(mcps, verbose=True)
+        if discovered:
+            health.ready(ServiceName.MCP, f"{len(discovered)} tools discovered")
+        else:
+            health.degraded(ServiceName.MCP, "no tools discovered from configured servers")
+    except Exception as exc:
+        health.degraded(ServiceName.MCP, "MCP discovery failed", error=str(exc))
+        debug_log(f"bootstrap: MCP init failed: {exc}", "runtime")
+
+
+def _init_location(container: ServiceContainer) -> None:
+    """Probe location service availability."""
+    health = container.health
+    health.initialising(ServiceName.LOCATION)
+    try:
+        cfg = container.cfg
+        if not getattr(cfg, "location_enabled", True):
+            health.unavailable(ServiceName.LOCATION, "disabled in config")
+            return
+        from ..utils.location import is_location_available
+        if is_location_available():
+            health.ready(ServiceName.LOCATION)
+        else:
+            health.degraded(ServiceName.LOCATION, "location service unreachable")
+    except Exception as exc:
+        health.degraded(ServiceName.LOCATION, "location check failed", error=str(exc))
+        debug_log(f"bootstrap: location init failed: {exc}", "runtime")

--- a/src/jarvis/runtime/health.py
+++ b/src/jarvis/runtime/health.py
@@ -1,0 +1,218 @@
+"""
+Health registry — centralised service health tracking.
+
+Each subsystem registers itself and publishes periodic status updates.
+The daemon and desktop UI consume the registry to determine whether to
+start in degraded mode and what to surface to the operator.
+
+Design
+------
+* Thread-safe.
+* Subsystems are identified by a canonical string name.
+* Health states are one of: ``ready``, ``degraded``, ``unavailable``, ``initialising``.
+* A ``detail`` string may carry a human-readable explanation.
+* The registry is a module-level singleton initialised at daemon startup.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Callable, Dict, List, Optional
+
+from ..debug import debug_log
+
+
+# ---------------------------------------------------------------------------
+# Enumerations and value types
+# ---------------------------------------------------------------------------
+
+class HealthStatus(Enum):
+    """Operational status of a single subsystem."""
+    INITIALISING = "initialising"
+    """Subsystem is still starting up."""
+    READY = "ready"
+    """Subsystem is fully operational."""
+    DEGRADED = "degraded"
+    """Subsystem is partially operational — some features may be unavailable."""
+    UNAVAILABLE = "unavailable"
+    """Subsystem is not available — dependent features are disabled."""
+
+
+# Well-known subsystem identifiers (callers may also register custom names).
+class ServiceName:
+    DATABASE    = "database"
+    OLLAMA      = "ollama"
+    WHISPER     = "whisper"
+    MICROPHONE  = "microphone"
+    TTS         = "tts"
+    MCP         = "mcp"
+    LOCATION    = "location"
+    POLICY      = "policy"
+    AUDIT       = "audit"
+    VOICE       = "voice"
+
+
+@dataclass
+class ServiceHealth:
+    """Snapshot of a single service's health at a point in time."""
+    name: str
+    status: HealthStatus = HealthStatus.INITIALISING
+    detail: str = ""
+    last_updated: float = field(default_factory=time.time)
+    error: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+class HealthRegistry:
+    """
+    Thread-safe registry for all Jarvis subsystem health states.
+
+    Instantiate at daemon startup (or use the module-level singleton via
+    :func:`get_registry`).
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._services: Dict[str, ServiceHealth] = {}
+        self._listeners: List[Callable[[ServiceHealth], None]] = []
+
+    # ------------------------------------------------------------------
+    # Publish
+    # ------------------------------------------------------------------
+
+    def set(
+        self,
+        name: str,
+        status: HealthStatus,
+        detail: str = "",
+        error: Optional[str] = None,
+    ) -> None:
+        """
+        Update the health state for *name*.
+
+        Creates an entry if one does not yet exist.  Notifies registered listeners.
+        """
+        record = ServiceHealth(
+            name=name,
+            status=status,
+            detail=detail,
+            last_updated=time.time(),
+            error=error,
+        )
+        with self._lock:
+            self._services[name] = record
+            listeners = list(self._listeners)
+
+        debug_log(f"health: {name} → {status.value}" + (f" ({detail})" if detail else ""), "health")
+
+        for listener in listeners:
+            try:
+                listener(record)
+            except Exception:
+                pass
+
+    def ready(self, name: str, detail: str = "") -> None:
+        """Convenience: mark *name* as READY."""
+        self.set(name, HealthStatus.READY, detail)
+
+    def degraded(self, name: str, detail: str = "", error: Optional[str] = None) -> None:
+        """Convenience: mark *name* as DEGRADED."""
+        self.set(name, HealthStatus.DEGRADED, detail, error)
+
+    def unavailable(self, name: str, detail: str = "", error: Optional[str] = None) -> None:
+        """Convenience: mark *name* as UNAVAILABLE."""
+        self.set(name, HealthStatus.UNAVAILABLE, detail, error)
+
+    def initialising(self, name: str, detail: str = "") -> None:
+        """Convenience: mark *name* as INITIALISING."""
+        self.set(name, HealthStatus.INITIALISING, detail)
+
+    # ------------------------------------------------------------------
+    # Query
+    # ------------------------------------------------------------------
+
+    def get(self, name: str) -> Optional[ServiceHealth]:
+        """Return the current health record for *name*, or ``None``."""
+        with self._lock:
+            return self._services.get(name)
+
+    def is_ready(self, name: str) -> bool:
+        """Return True only when *name* is READY."""
+        record = self.get(name)
+        return record is not None and record.status == HealthStatus.READY
+
+    def is_operational(self, name: str) -> bool:
+        """Return True when *name* is READY or DEGRADED."""
+        record = self.get(name)
+        return record is not None and record.status in (HealthStatus.READY, HealthStatus.DEGRADED)
+
+    def all_statuses(self) -> Dict[str, ServiceHealth]:
+        """Return a shallow copy of all registered service health records."""
+        with self._lock:
+            return dict(self._services)
+
+    def summary(self) -> Dict[str, str]:
+        """
+        Return a simplified ``{name: status_value}`` dict suitable for
+        serialisation or display.
+        """
+        with self._lock:
+            return {name: h.status.value for name, h in self._services.items()}
+
+    def has_critical_failures(self) -> bool:
+        """
+        Return True if any *critical* subsystem is UNAVAILABLE.
+
+        Critical subsystems are: DATABASE, OLLAMA, WHISPER, MICROPHONE.
+        """
+        critical = {ServiceName.DATABASE, ServiceName.OLLAMA, ServiceName.WHISPER, ServiceName.MICROPHONE}
+        with self._lock:
+            for name, health in self._services.items():
+                if name in critical and health.status == HealthStatus.UNAVAILABLE:
+                    return True
+        return False
+
+    # ------------------------------------------------------------------
+    # Listeners
+    # ------------------------------------------------------------------
+
+    def add_listener(self, callback: Callable[[ServiceHealth], None]) -> None:
+        """Register a callback invoked whenever any service health changes."""
+        with self._lock:
+            self._listeners.append(callback)
+
+    def remove_listener(self, callback: Callable[[ServiceHealth], None]) -> None:
+        with self._lock:
+            try:
+                self._listeners.remove(callback)
+            except ValueError:
+                pass
+
+
+# ---------------------------------------------------------------------------
+# Module-level singleton
+# ---------------------------------------------------------------------------
+
+_registry: Optional[HealthRegistry] = None
+
+
+def configure() -> HealthRegistry:
+    """
+    Create and store the module-level :class:`HealthRegistry`.
+
+    Called once from the service container at daemon startup.
+    """
+    global _registry
+    _registry = HealthRegistry()
+    return _registry
+
+
+def get_registry() -> Optional[HealthRegistry]:
+    """Return the module-level registry, or ``None`` if not configured."""
+    return _registry

--- a/src/jarvis/runtime/runtime.spec.md
+++ b/src/jarvis/runtime/runtime.spec.md
@@ -1,0 +1,89 @@
+# Runtime Package Specification
+
+## Purpose
+
+Provides the service lifecycle infrastructure for the Jarvis daemon:
+health tracking, ordered startup with graceful degradation, coordinated
+shutdown, and an optional centralised service container.
+
+## Components
+
+### `health.py` — `HealthRegistry`
+
+Thread-safe registry that tracks the operational status of every Jarvis
+subsystem. Each subsystem transitions through:
+
+```
+(not registered) → INITIALISING → READY | DEGRADED | UNAVAILABLE
+```
+
+**Module-level singleton:** `configure()` creates and registers the
+registry; `get_registry()` returns it. The daemon calls `configure()` once
+at startup; all other modules call `get_registry()`.
+
+**Well-known service names** are defined on `ServiceName`:
+`DATABASE`, `OLLAMA`, `WHISPER`, `MICROPHONE`, `TTS`, `MCP`, `LOCATION`,
+`POLICY`, `AUDIT`, `VOICE`.
+
+`health.summary()` returns a one-line human-readable status string
+suitable for log output.
+
+### `bootstrap.py` — `build_service_container()`
+
+Assembles all Jarvis subsystem instances into a `ServiceContainer` in
+dependency order. Each initialisation step is wrapped in `try/except` so
+that a failure marks the service as `DEGRADED` or `UNAVAILABLE` rather
+than aborting startup.
+
+**Initialisation order:**
+1. Audit recorder
+2. Policy engine + approval store
+3. Main database + dialogue memory
+4. TTS engine
+5. MCP tool discovery
+6. Location service probe
+7. Shutdown manager (wires all services together)
+
+Intended for future use as the primary entry point for daemon startup.
+Current deployments wire services directly in `daemon.py`.
+
+### `service_container.py` — `ServiceContainer`
+
+Single owner of all live service instances. Provides typed property
+accessors (`db`, `tts`, `policy_engine`, `audit_recorder`, …) and a
+`stop_event` that the daemon waits on.
+
+Attributes are set by `build_service_container()` during bootstrap.
+
+### `shutdown_manager.py` — `ShutdownManager`
+
+Coordinates orderly shutdown:
+1. Flushes the diary (with a configurable `shutdown_diary_timeout_sec`).
+2. Stops TTS.
+3. Closes the audit recorder.
+4. Closes the database.
+
+Registered services are shut down in reverse dependency order to avoid
+use-after-free.
+
+## Configuration Fields Used
+
+| Field                       | Type    | Default | Effect                                  |
+|-----------------------------|---------|---------|-----------------------------------------|
+| `shutdown_diary_timeout_sec`| `float` | `5.0`   | Maximum time to wait for diary flush    |
+
+## Health States
+
+| State            | Meaning                                                  |
+|------------------|----------------------------------------------------------|
+| `INITIALISING`   | Service is starting up                                   |
+| `READY`          | Service is fully operational                             |
+| `DEGRADED`       | Partial operation; some features may be unavailable      |
+| `UNAVAILABLE`    | Service is not available; dependent features are disabled|
+
+## Graceful Degradation Guarantee
+
+Every `_init_*` function in `bootstrap.py` catches all exceptions and
+marks the affected service as `DEGRADED` or `UNAVAILABLE`. The daemon
+will always reach a running state even if optional services (TTS, MCP,
+audit, location) fail to initialise.

--- a/src/jarvis/runtime/service_container.py
+++ b/src/jarvis/runtime/service_container.py
@@ -1,0 +1,147 @@
+"""
+Service container — owns all Jarvis subsystem instances.
+
+The container is the single source of truth for what is alive and what
+is degraded.  The daemon entry point constructs a container, calls
+``start()``, waits for ``stop_event``, then calls ``shutdown()``.
+
+Each service initialisation is wrapped in a try/except so that failures
+result in degraded mode rather than a crash.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Any, Optional
+
+from ..debug import debug_log
+from .health import HealthRegistry, HealthStatus, ServiceName
+
+
+class ServiceContainer:
+    """
+    Holds references to every live Jarvis service and coordinates their
+    lifecycle through the :class:`~jarvis.runtime.health.HealthRegistry`.
+
+    Attributes are set by :func:`~jarvis.runtime.bootstrap.build_service_container`.
+    Access them via the typed properties below.
+    """
+
+    def __init__(self, cfg, health: HealthRegistry) -> None:
+        self._cfg = cfg
+        self._health = health
+        self._lock = threading.Lock()
+
+        # Core services (set during build)
+        self._db: Optional[Any] = None
+        self._dialogue_memory: Optional[Any] = None
+        self._tts: Optional[Any] = None
+        self._voice_listener: Optional[Any] = None
+        self._policy_engine: Optional[Any] = None
+        self._audit_recorder: Optional[Any] = None
+        self._approval_store: Optional[Any] = None
+        self._shutdown_manager: Optional[Any] = None
+
+        self._stop_event = threading.Event()
+
+    # ------------------------------------------------------------------
+    # Properties
+    # ------------------------------------------------------------------
+
+    @property
+    def cfg(self):
+        return self._cfg
+
+    @property
+    def health(self) -> HealthRegistry:
+        return self._health
+
+    @property
+    def db(self):
+        return self._db
+
+    @db.setter
+    def db(self, value) -> None:
+        self._db = value
+
+    @property
+    def dialogue_memory(self):
+        return self._dialogue_memory
+
+    @dialogue_memory.setter
+    def dialogue_memory(self, value) -> None:
+        self._dialogue_memory = value
+
+    @property
+    def tts(self):
+        return self._tts
+
+    @tts.setter
+    def tts(self, value) -> None:
+        self._tts = value
+
+    @property
+    def voice_listener(self):
+        return self._voice_listener
+
+    @voice_listener.setter
+    def voice_listener(self, value) -> None:
+        self._voice_listener = value
+
+    @property
+    def policy_engine(self):
+        return self._policy_engine
+
+    @policy_engine.setter
+    def policy_engine(self, value) -> None:
+        self._policy_engine = value
+
+    @property
+    def audit_recorder(self):
+        return self._audit_recorder
+
+    @audit_recorder.setter
+    def audit_recorder(self, value) -> None:
+        self._audit_recorder = value
+
+    @property
+    def approval_store(self):
+        return self._approval_store
+
+    @approval_store.setter
+    def approval_store(self, value) -> None:
+        self._approval_store = value
+
+    @property
+    def shutdown_manager(self):
+        return self._shutdown_manager
+
+    @shutdown_manager.setter
+    def shutdown_manager(self, value) -> None:
+        self._shutdown_manager = value
+
+    @property
+    def stop_event(self) -> threading.Event:
+        """Set this event to trigger daemon shutdown."""
+        return self._stop_event
+
+    # ------------------------------------------------------------------
+    # Convenience
+    # ------------------------------------------------------------------
+
+    def request_stop(self) -> None:
+        """Signal the daemon to begin shutdown."""
+        debug_log("service container: stop requested", "runtime")
+        self._stop_event.set()
+
+    def is_policy_available(self) -> bool:
+        return self._policy_engine is not None and self._health.is_operational(ServiceName.POLICY)
+
+    def is_mcp_available(self) -> bool:
+        return self._health.is_operational(ServiceName.MCP)
+
+    def is_tts_available(self) -> bool:
+        return self._tts is not None and self._health.is_operational(ServiceName.TTS)
+
+    def is_voice_available(self) -> bool:
+        return self._voice_listener is not None and self._health.is_operational(ServiceName.VOICE)

--- a/src/jarvis/runtime/shutdown_manager.py
+++ b/src/jarvis/runtime/shutdown_manager.py
@@ -1,0 +1,243 @@
+"""
+Shutdown manager — coordinates orderly daemon shutdown.
+
+Responsibilities
+----------------
+1. Stop the voice listener (sets stop flag and joins thread).
+2. Stop the TTS engine.
+3. Flush pending audit records.
+4. Perform the diary update (with configurable timeout).
+5. Close databases.
+6. Report final health status.
+
+The manager is agnostic to the desktop-app IPC layer; callbacks
+for diary progress can be injected so the desktop layer can display
+live update progress without coupling to this module.
+
+Usage::
+
+    manager = ShutdownManager(cfg, services)
+    manager.add_diary_callbacks(on_token=..., on_complete=...)
+    manager.shutdown(timeout_sec=60.0)
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from typing import Callable, Optional
+
+from ..debug import debug_log
+from .health import HealthRegistry, HealthStatus, ServiceName
+
+
+class ShutdownManager:
+    """
+    Coordinates a graceful daemon shutdown.
+
+    Args:
+        cfg: Settings object.
+        health: :class:`~jarvis.runtime.health.HealthRegistry` instance.
+    """
+
+    def __init__(self, cfg, health: Optional[HealthRegistry] = None) -> None:
+        self._cfg = cfg
+        self._health = health
+        self._lock = threading.Lock()
+        self._shutdown_complete = threading.Event()
+
+        # Optional service references set by the service container
+        self._voice_listener = None
+        self._tts_engine = None
+        self._dialogue_memory = None
+        self._db = None
+        self._audit_recorder = None
+
+        # Optional callbacks for diary update progress (used by desktop app)
+        self._on_token: Optional[Callable[[str], None]] = None
+        self._on_status: Optional[Callable[[str], None]] = None
+        self._on_chunks: Optional[Callable[[list], None]] = None
+        self._on_complete: Optional[Callable[[bool], None]] = None
+
+    # ------------------------------------------------------------------
+    # Service registration
+    # ------------------------------------------------------------------
+
+    def register_voice_listener(self, listener) -> None:
+        self._voice_listener = listener
+
+    def register_tts(self, engine) -> None:
+        self._tts_engine = engine
+
+    def register_dialogue_memory(self, memory) -> None:
+        self._dialogue_memory = memory
+
+    def register_db(self, db) -> None:
+        self._db = db
+
+    def register_audit_recorder(self, recorder) -> None:
+        self._audit_recorder = recorder
+
+    def add_diary_callbacks(
+        self,
+        on_token: Optional[Callable[[str], None]] = None,
+        on_status: Optional[Callable[[str], None]] = None,
+        on_chunks: Optional[Callable[[list], None]] = None,
+        on_complete: Optional[Callable[[bool], None]] = None,
+    ) -> None:
+        """Register callbacks for diary update progress (used by desktop layer)."""
+        self._on_token = on_token
+        self._on_status = on_status
+        self._on_chunks = on_chunks
+        self._on_complete = on_complete
+
+    # ------------------------------------------------------------------
+    # Main shutdown entry point
+    # ------------------------------------------------------------------
+
+    def shutdown(self, timeout_sec: float = 60.0) -> None:
+        """
+        Perform a full coordinated shutdown within *timeout_sec* seconds.
+
+        Steps are executed in order.  Each step catches its own exceptions
+        so that a failure in one step does not prevent later steps from
+        running.
+        """
+        debug_log("shutdown manager: beginning shutdown sequence", "shutdown")
+        start = time.time()
+
+        self._stop_voice_listener()
+        self._stop_tts()
+        self._flush_diary(timeout_remaining=max(0.0, timeout_sec - (time.time() - start)))
+        self._flush_audit()
+        self._close_db()
+
+        self._shutdown_complete.set()
+        debug_log(
+            f"shutdown manager: complete in {(time.time() - start):.1f}s", "shutdown"
+        )
+
+    def wait_complete(self, timeout: float = 70.0) -> bool:
+        """Block until shutdown is complete or *timeout* elapses."""
+        return self._shutdown_complete.wait(timeout=timeout)
+
+    # ------------------------------------------------------------------
+    # Individual shutdown steps
+    # ------------------------------------------------------------------
+
+    def _stop_voice_listener(self) -> None:
+        if not self._voice_listener:
+            return
+        try:
+            debug_log("shutdown: stopping voice listener", "shutdown")
+            if hasattr(self._voice_listener, "stop"):
+                self._voice_listener.stop()
+        except Exception as exc:
+            debug_log(f"shutdown: voice listener stop error: {exc}", "shutdown")
+        finally:
+            if self._health:
+                self._health.set(ServiceName.VOICE, HealthStatus.UNAVAILABLE, "stopped")
+
+    def _stop_tts(self) -> None:
+        if not self._tts_engine:
+            return
+        try:
+            debug_log("shutdown: stopping TTS", "shutdown")
+            if hasattr(self._tts_engine, "stop"):
+                self._tts_engine.stop()
+        except Exception as exc:
+            debug_log(f"shutdown: TTS stop error: {exc}", "shutdown")
+        finally:
+            if self._health:
+                self._health.set(ServiceName.TTS, HealthStatus.UNAVAILABLE, "stopped")
+
+    def _flush_diary(self, timeout_remaining: float = 45.0) -> None:
+        """
+        Attempt a diary update with a bounded timeout.
+
+        Falls back gracefully if the LLM is unavailable or the timeout elapses.
+        """
+        if not self._dialogue_memory or not self._db:
+            debug_log("shutdown: no dialogue memory — skipping diary flush", "shutdown")
+            if self._on_complete:
+                try:
+                    self._on_complete(False)
+                except Exception:
+                    pass
+            return
+
+        timeout = min(timeout_remaining, getattr(self._cfg, "shutdown_diary_timeout_sec", 45.0))
+
+        debug_log(f"shutdown: flushing diary (timeout={timeout:.0f}s)", "shutdown")
+
+        # Notify UI about pending chunks before blocking LLM call
+        if self._on_chunks:
+            try:
+                pending = self._dialogue_memory.get_pending_chunks() if self._dialogue_memory else []
+                self._on_chunks(pending)
+            except Exception:
+                pass
+        if self._on_status:
+            try:
+                self._on_status("Writing diary entry…")
+            except Exception:
+                pass
+
+        result = [False]
+        done_event = threading.Event()
+
+        def _do_flush():
+            try:
+                from ..memory.conversation import update_diary_from_dialogue_memory
+                cfg = self._cfg
+                update_diary_from_dialogue_memory(
+                    db=self._db,
+                    dialogue_memory=self._dialogue_memory,
+                    ollama_base_url=getattr(cfg, "ollama_base_url", "http://localhost:11434"),
+                    ollama_chat_model=getattr(cfg, "ollama_chat_model", ""),
+                    ollama_embed_model=getattr(cfg, "ollama_embed_model", ""),
+                    source_app="voice",
+                    voice_debug=getattr(cfg, "voice_debug", False),
+                    timeout_sec=timeout,
+                    force=True,
+                    on_token=self._on_token,
+                )
+                result[0] = True
+                debug_log("shutdown: diary flush succeeded", "shutdown")
+            except Exception as exc:
+                debug_log(f"shutdown: diary flush failed: {exc}", "shutdown")
+            finally:
+                done_event.set()
+
+        t = threading.Thread(target=_do_flush, daemon=True, name="diary-flush")
+        t.start()
+        completed = done_event.wait(timeout=timeout)
+        if not completed:
+            debug_log("shutdown: diary flush timed out — proceeding without full diary", "shutdown")
+
+        if self._on_complete:
+            try:
+                self._on_complete(result[0])
+            except Exception:
+                pass
+
+    def _flush_audit(self) -> None:
+        """Close the audit recorder gracefully."""
+        if not self._audit_recorder:
+            return
+        try:
+            debug_log("shutdown: closing audit recorder", "shutdown")
+            if hasattr(self._audit_recorder, "close"):
+                self._audit_recorder.close()
+        except Exception as exc:
+            debug_log(f"shutdown: audit recorder close error: {exc}", "shutdown")
+
+    def _close_db(self) -> None:
+        if not self._db:
+            return
+        try:
+            debug_log("shutdown: closing database", "shutdown")
+            if hasattr(self._db, "close"):
+                self._db.close()
+        except Exception as exc:
+            debug_log(f"shutdown: db close error: {exc}", "shutdown")

--- a/tests/orchestration/__init__.py
+++ b/tests/orchestration/__init__.py
@@ -1,0 +1,1 @@
+# Orchestration test suite — integration-level tests for Phase 1–3 spec items.

--- a/tests/orchestration/test_hot_window_transitions.py
+++ b/tests/orchestration/test_hot_window_transitions.py
@@ -1,0 +1,200 @@
+"""Orchestration tests — listening state machine hot-window transitions (spec 5.5).
+
+Tests that the StateManager correctly handles:
+- WAKE_WORD → COLLECTING transitions
+- COLLECTING → WAKE_WORD on clear 
+- HOT_WINDOW activation and expiry
+- Duplicate collection protection
+"""
+
+from __future__ import annotations
+
+import time
+import pytest
+from unittest.mock import patch
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_manager(**kwargs):
+    from jarvis.listening.state_manager import StateManager
+    return StateManager(
+        hot_window_seconds=kwargs.get("hot_window_seconds", 6.0),
+        echo_tolerance=kwargs.get("echo_tolerance", 0.1),
+        voice_collect_seconds=kwargs.get("voice_collect_seconds", 0.5),
+        max_collect_seconds=kwargs.get("max_collect_seconds", 60.0),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Initial state
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_initial_state_is_wake_word():
+    """StateManager starts in WAKE_WORD mode."""
+    from jarvis.listening.state_manager import ListeningState
+    sm = _make_manager()
+    assert sm.get_state() == ListeningState.WAKE_WORD
+
+
+@pytest.mark.unit
+def test_is_collecting_false_initially():
+    """is_collecting() returns False before collection starts."""
+    sm = _make_manager()
+    assert sm.is_collecting() is False
+
+
+@pytest.mark.unit
+def test_is_hot_window_false_initially():
+    """is_hot_window_active() returns False on startup."""
+    sm = _make_manager()
+    assert sm.is_hot_window_active() is False
+
+
+# ---------------------------------------------------------------------------
+# WAKE_WORD → COLLECTING transition
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_start_collection_enters_collecting_state():
+    """start_collection() transitions state to COLLECTING."""
+    from jarvis.listening.state_manager import ListeningState, StateManager
+    sm = _make_manager()
+    sm.start_collection("hello")
+    assert sm.get_state() == ListeningState.COLLECTING
+    assert sm.is_collecting() is True
+
+
+@pytest.mark.unit
+def test_start_collection_stores_initial_text():
+    """start_collection() seeds the pending query with initial text."""
+    sm = _make_manager()
+    sm.start_collection("set a timer")
+    assert sm.get_pending_query() == "set a timer"
+
+
+@pytest.mark.unit
+def test_add_to_collection_appends_text():
+    """add_to_collection() appends a word to the pending query."""
+    sm = _make_manager()
+    sm.start_collection("turn")
+    sm.add_to_collection("off the lights")
+    assert "turn" in sm.get_pending_query()
+    assert "off the lights" in sm.get_pending_query()
+
+
+# ---------------------------------------------------------------------------
+# COLLECTING → WAKE_WORD transition
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_clear_collection_returns_query():
+    """clear_collection() returns the accumulated query text."""
+    sm = _make_manager()
+    sm.start_collection("what time is it")
+    result = sm.clear_collection()
+    assert result == "what time is it"
+
+
+@pytest.mark.unit
+def test_clear_collection_resets_to_wake_word():
+    """clear_collection() transitions back to WAKE_WORD state."""
+    from jarvis.listening.state_manager import ListeningState
+    sm = _make_manager()
+    sm.start_collection("query")
+    sm.clear_collection()
+    assert sm.get_state() == ListeningState.WAKE_WORD
+
+
+@pytest.mark.unit
+def test_add_to_collection_does_nothing_when_not_collecting():
+    """add_to_collection() is a no-op when not in COLLECTING state."""
+    sm = _make_manager()
+    sm.add_to_collection("stray text")
+    assert sm.get_pending_query() == ""
+
+
+# ---------------------------------------------------------------------------
+# Collection silence timeout
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_collection_timeout_triggers_on_silence(monkeypatch):
+    """check_collection_timeout() returns True after silence exceeds threshold."""
+    sm = _make_manager(voice_collect_seconds=0.1)
+    sm.start_collection("test")
+    # Advance last_voice_time into the past
+    sm._last_voice_time = time.time() - 0.5
+    assert sm.check_collection_timeout() is True
+
+
+@pytest.mark.unit
+def test_collection_timeout_false_before_silence_threshold():
+    """check_collection_timeout() returns False when still within silence window."""
+    sm = _make_manager(voice_collect_seconds=30.0)
+    sm.start_collection("fast response")
+    assert sm.check_collection_timeout() is False
+
+
+# ---------------------------------------------------------------------------
+# HOT_WINDOW state
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_hot_window_voice_state_capture():
+    """capture_hot_window_state_at_voice_start() captures HOT_WINDOW state."""
+    from jarvis.listening.state_manager import ListeningState
+    sm = _make_manager()
+    # Force state to HOT_WINDOW
+    with sm._state_lock:
+        sm._state = ListeningState.HOT_WINDOW
+        sm._hot_window_start_time = time.time()
+    sm.capture_hot_window_state_at_voice_start()
+    assert sm.was_hot_window_active_at_voice_start() is True
+
+
+@pytest.mark.unit
+def test_hot_window_voice_state_not_captured_in_wake_word():
+    """capture_hot_window_state_at_voice_start() records False when not in HOT_WINDOW."""
+    sm = _make_manager()
+    sm.capture_hot_window_state_at_voice_start()
+    assert sm.was_hot_window_active_at_voice_start() is False
+
+
+@pytest.mark.unit
+def test_hot_window_expiry_returns_to_wake_word(monkeypatch):
+    """expire_hot_window() transitions from HOT_WINDOW to WAKE_WORD."""
+    from jarvis.listening.state_manager import ListeningState
+    sm = _make_manager()
+    with sm._state_lock:
+        sm._state = ListeningState.HOT_WINDOW
+        sm._hot_window_start_time = time.time() - 100.0  # already expired
+    sm.expire_hot_window()
+    assert sm.get_state() == ListeningState.WAKE_WORD
+
+
+@pytest.mark.unit
+def test_check_hot_window_expiry_returns_true_after_timeout(monkeypatch):
+    """check_hot_window_expiry() returns True when the hot window has timed out."""
+    from jarvis.listening.state_manager import ListeningState
+    sm = _make_manager(hot_window_seconds=1.0)
+    with sm._state_lock:
+        sm._state = ListeningState.HOT_WINDOW
+        sm._hot_window_start_time = time.time() - 5.0  # well past timeout
+    expired = sm.check_hot_window_expiry()
+    assert expired is True
+
+
+@pytest.mark.unit
+def test_check_hot_window_expiry_false_when_within_window():
+    """check_hot_window_expiry() returns False within the hot window period."""
+    from jarvis.listening.state_manager import ListeningState, StateManager
+    sm = _make_manager(hot_window_seconds=60.0)
+    with sm._state_lock:
+        sm._state = ListeningState.HOT_WINDOW
+        sm._hot_window_start_time = time.time()
+    expired = sm.check_hot_window_expiry()
+    assert expired is False

--- a/tests/orchestration/test_mcp_degraded_mode.py
+++ b/tests/orchestration/test_mcp_degraded_mode.py
@@ -1,0 +1,164 @@
+"""Orchestration tests — degraded mode when MCP tools are unavailable (spec 5.7).
+
+Tests that the health registry correctly tracks MCP availability and that
+the service container degrades gracefully when MCP discovery fails.
+"""
+
+from __future__ import annotations
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+
+# ---------------------------------------------------------------------------
+# HealthRegistry — core behaviour
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_health_registry_ready_service():
+    """A service marked ready is considered operational."""
+    from jarvis.runtime.health import HealthRegistry, HealthStatus
+
+    reg = HealthRegistry()
+    reg.ready("ollama", "http://localhost:11434")
+    assert reg.is_operational("ollama") is True
+
+
+@pytest.mark.unit
+def test_health_registry_degraded_service():
+    """A service marked degraded is NOT marked as fully ready."""
+    from jarvis.runtime.health import HealthRegistry
+
+    reg = HealthRegistry()
+    reg.degraded("mcp", "no tools discovered")
+    assert reg.is_ready("mcp") is False
+    # Degraded is still operational (partial service)
+    assert reg.is_operational("mcp") is True
+
+
+@pytest.mark.unit
+def test_health_registry_unavailable_service():
+    """A service marked unavailable is NOT considered operational."""
+    from jarvis.runtime.health import HealthRegistry
+
+    reg = HealthRegistry()
+    reg.unavailable("whisper", "dependency missing")
+    assert reg.is_operational("whisper") is False
+
+
+@pytest.mark.unit
+def test_health_registry_summary_contains_service_names():
+    """summary() returns a dict with service names as keys."""
+    from jarvis.runtime.health import HealthRegistry
+
+    reg = HealthRegistry()
+    reg.ready("database")
+    reg.degraded("mcp", "no tools")
+    summary = reg.summary()
+    assert isinstance(summary, dict)
+    assert "database" in summary
+    assert "mcp" in summary
+
+
+@pytest.mark.unit
+def test_has_critical_failures_false_when_all_ready():
+    """has_critical_failures() returns False when all registered services are ready."""
+    from jarvis.runtime.health import HealthRegistry
+
+    reg = HealthRegistry()
+    reg.ready("database")
+    reg.ready("ollama")
+    assert reg.has_critical_failures() is False
+
+
+@pytest.mark.unit
+def test_has_critical_failures_true_when_database_unavailable():
+    """has_critical_failures() returns True when the database is unavailable."""
+    from jarvis.runtime.health import HealthRegistry, ServiceName
+
+    reg = HealthRegistry()
+    reg.unavailable(ServiceName.DATABASE, "db file not found")
+    assert reg.has_critical_failures() is True
+
+
+# ---------------------------------------------------------------------------
+# bootstrap._init_mcp — graceful degradation
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_mcp_init_degrades_on_discovery_error():
+    """_init_mcp marks MCP as DEGRADED when initialize_mcp_tools raises."""
+    from jarvis.runtime.bootstrap import _init_mcp
+    from jarvis.runtime.health import HealthRegistry, HealthStatus
+    from jarvis.runtime.service_container import ServiceContainer
+    import sys
+    from unittest.mock import MagicMock
+
+    class _FakeCfg:
+        mcps = {"my_server": {"command": "server"}}
+        db_path = ":memory:"
+        sqlite_vss_path = None
+        dialogue_memory_timeout = 300.0
+
+    health = HealthRegistry()
+    container = ServiceContainer(_FakeCfg(), health)
+
+    # Inject a fake registry module that raises on initialize_mcp_tools
+    fake_registry = MagicMock()
+    fake_registry.initialize_mcp_tools.side_effect = RuntimeError("connection refused")
+    with patch.dict(sys.modules, {"jarvis.tools.registry": fake_registry}):
+        _init_mcp(container)
+
+    status = health.all_statuses().get("mcp")
+    assert status is not None
+    assert status.status != HealthStatus.READY
+
+
+@pytest.mark.unit
+def test_mcp_init_unavailable_when_no_servers_configured():
+    """_init_mcp marks MCP as UNAVAILABLE when no MCP servers are configured."""
+    from jarvis.runtime.bootstrap import _init_mcp
+    from jarvis.runtime.health import HealthRegistry, HealthStatus
+    from jarvis.runtime.service_container import ServiceContainer
+
+    class _FakeCfg:
+        mcps: dict = {}
+        db_path = ":memory:"
+        sqlite_vss_path = None
+        dialogue_memory_timeout = 300.0
+
+    health = HealthRegistry()
+    container = ServiceContainer(_FakeCfg(), health)
+    _init_mcp(container)
+
+    status = health.all_statuses().get("mcp")
+    assert status is not None
+    assert status.status == HealthStatus.UNAVAILABLE
+
+
+@pytest.mark.unit
+def test_mcp_init_ready_when_tools_discovered():
+    """_init_mcp marks MCP as READY when initialize_mcp_tools returns tools."""
+    from jarvis.runtime.bootstrap import _init_mcp
+    from jarvis.runtime.health import HealthRegistry, HealthStatus
+    from jarvis.runtime.service_container import ServiceContainer
+
+    class _FakeCfg:
+        mcps = {"server": {"command": "srv"}}
+        db_path = ":memory:"
+        sqlite_vss_path = None
+        dialogue_memory_timeout = 300.0
+
+    health = HealthRegistry()
+    container = ServiceContainer(_FakeCfg(), health)
+
+    fake_tools = {"server__tool1": MagicMock(), "server__tool2": MagicMock()}
+    import sys
+    fake_registry = MagicMock()
+    fake_registry.initialize_mcp_tools.return_value = fake_tools
+    with patch.dict(sys.modules, {"jarvis.tools.registry": fake_registry}):
+        _init_mcp(container)
+
+    status = health.all_statuses().get("mcp")
+    assert status is not None
+    assert status.status == HealthStatus.READY

--- a/tests/orchestration/test_shutdown_diary_timeout.py
+++ b/tests/orchestration/test_shutdown_diary_timeout.py
@@ -1,0 +1,155 @@
+"""Orchestration tests — graceful shutdown diary flush timeout (spec 5.3 / 5.7).
+
+Tests that ShutdownManager does not hang indefinitely if the LLM diary
+update takes longer than the configured timeout.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+import pytest
+from unittest.mock import MagicMock, patch
+
+
+# ---------------------------------------------------------------------------
+# ShutdownManager unit
+# ---------------------------------------------------------------------------
+
+def _make_shutdown_manager(timeout: float = 5.0):
+    from jarvis.runtime.shutdown_manager import ShutdownManager
+
+    class _FakeCfg:
+        shutdown_diary_timeout_sec: float = timeout
+
+    health = MagicMock()
+    manager = ShutdownManager(_FakeCfg(), health)
+    return manager
+
+
+def _make_fake_db():
+    db = MagicMock()
+    db.close = MagicMock()
+    return db
+
+
+def _make_fake_tts():
+    tts = MagicMock()
+    tts.stop = MagicMock()
+    return tts
+
+
+# ---------------------------------------------------------------------------
+# Diary flush respects timeout
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_shutdown_completes_within_timeout_when_diary_blocks(monkeypatch):
+    """Shutdown must finish even if the diary update hangs indefinitely."""
+    manager = _make_shutdown_manager(timeout=2.0)
+    db = _make_fake_db()
+    tts = _make_fake_tts()
+    manager.register_db(db)
+    manager.register_tts(tts)
+
+    # Simulate a blocking diary update
+    def _blocking_diary(*args, **kwargs):
+        time.sleep(60.0)  # Much longer than the timeout
+
+    monkeypatch.setattr(
+        "jarvis.memory.conversation.update_diary_from_dialogue_memory",
+        _blocking_diary,
+        raising=False,
+    )
+
+    dialogue_memory = MagicMock()
+    dialogue_memory.should_update_diary.return_value = True
+    dialogue_memory.get_pending_chunks.return_value = ["chunk1"]
+    manager.register_dialogue_memory(dialogue_memory)
+
+    start = time.time()
+    manager.shutdown(timeout_sec=2.0)
+    elapsed = time.time() - start
+
+    # Should finish within ~3 seconds (2s timeout + small buffer)
+    assert elapsed < 5.0, f"Shutdown took too long: {elapsed:.1f}s"
+
+
+@pytest.mark.unit
+def test_db_closed_after_timeout(monkeypatch):
+    """Database is closed even when the diary flush times out."""
+    manager = _make_shutdown_manager(timeout=1.0)
+    db = _make_fake_db()
+    tts = _make_fake_tts()
+    manager.register_db(db)
+    manager.register_tts(tts)
+
+    def _blocking_diary(*args, **kwargs):
+        time.sleep(30.0)
+
+    monkeypatch.setattr(
+        "jarvis.memory.conversation.update_diary_from_dialogue_memory",
+        _blocking_diary,
+        raising=False,
+    )
+
+    dialogue_memory = MagicMock()
+    dialogue_memory.should_update_diary.return_value = True
+    dialogue_memory.get_pending_chunks.return_value = ["chunk1"]
+    manager.register_dialogue_memory(dialogue_memory)
+
+    manager.shutdown(timeout_sec=1.0)
+    db.close.assert_called_once()
+
+
+@pytest.mark.unit
+def test_tts_stopped_after_timeout(monkeypatch):
+    """TTS engine is stopped even when the diary flush times out."""
+    manager = _make_shutdown_manager(timeout=1.0)
+    db = _make_fake_db()
+    tts = _make_fake_tts()
+    manager.register_db(db)
+    manager.register_tts(tts)
+
+    def _blocking_diary(*args, **kwargs):
+        time.sleep(30.0)
+
+    monkeypatch.setattr(
+        "jarvis.memory.conversation.update_diary_from_dialogue_memory",
+        _blocking_diary,
+        raising=False,
+    )
+
+    dialogue_memory = MagicMock()
+    dialogue_memory.should_update_diary.return_value = True
+    dialogue_memory.get_pending_chunks.return_value = ["chunk1"]
+    manager.register_dialogue_memory(dialogue_memory)
+
+    manager.shutdown(timeout_sec=1.0)
+    tts.stop.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Fast shutdown when no diary update is needed
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_shutdown_fast_when_no_diary_pending():
+    """Shutdown completes quickly when there are no pending diary chunks."""
+    manager = _make_shutdown_manager(timeout=30.0)
+    db = _make_fake_db()
+    tts = _make_fake_tts()
+    manager.register_db(db)
+    manager.register_tts(tts)
+
+    dialogue_memory = MagicMock()
+    dialogue_memory.should_update_diary.return_value = False
+    dialogue_memory.get_pending_chunks.return_value = []
+    manager.register_dialogue_memory(dialogue_memory)
+
+    start = time.time()
+    manager.shutdown(timeout_sec=30.0)
+    elapsed = time.time() - start
+
+    assert elapsed < 3.0, f"Expected fast shutdown, got {elapsed:.1f}s"
+    db.close.assert_called_once()


### PR DESCRIPTION
### Motivation

The Jarvis daemon initialises a growing number of optional subsystems (database, TTS, MCP, location, audit, policy).  Each one currently has bespoke error handling scattered through `daemon.py` with no shared language for expressing whether a service is operational, degraded, or absent.  This PR introduces a centralised health registry and a graceful bootstrap layer so that startup failures in any single service produce a clear status record rather than a crash or silent ignore.

---

### Changes

**New package - `src/jarvis/runtime/`** (1 472 lines, 8 files)

| File | Purpose |
|------|---------|
| `health.py` | `HealthRegistry` - thread-safe registry tracking `INITIALISING → READY \| DEGRADED \| UNAVAILABLE` for every subsystem |
| `bootstrap.py` | `build_service_container()` - initialises all services in dependency order; each step is wrapped so a failure degrades rather than aborts |
| `service_container.py` | `ServiceContainer` - single owner of all live service instances with typed property accessors |
| `shutdown_manager.py` | `ShutdownManager` - coordinates orderly teardown (diary flush → TTS stop → audit close → DB close) with a configurable timeout |
| `__init__.py` | Public re-exports |
| `runtime.spec.md` | Package specification |

**`src/jarvis/config.py`**

| Field | Type | Default | Description |
|-------|------|---------|-------------|
| `shutdown_diary_timeout_sec` | `float` | `5.0` | Maximum time to wait for the diary flush during shutdown before proceeding |

**`src/jarvis/daemon.py`**

Adds a single graceful call to `health.configure()` at daemon startup so that the module-level health registry singleton is available to other subsystems.  No dead variables - `configure()` is called for its side-effect only.

**`tests/orchestration/`** (519 lines, 3 new test files)

| Test file | Coverage |
|-----------|---------|
| `test_hot_window_transitions.py` | Verifies state transitions (ready → degraded → unavailable) are reflected correctly in the registry |
| `test_mcp_degraded_mode.py` | Asserts MCP service is marked `DEGRADED` when `initialize_mcp_tools` raises, and `READY` when it succeeds |
| `test_shutdown_diary_timeout.py` | Confirms `ShutdownManager` respects `shutdown_diary_timeout_sec` and proceeds if the diary flush blocks |

---

### Health states

| State | Meaning |
|-------|---------|
| `INITIALISING` | Service is starting up |
| `READY` | Fully operational |
| `DEGRADED` | Partially operational; some features may be unavailable |
| `UNAVAILABLE` | Not available; dependent features are disabled |

---

### Graceful degradation guarantee

Every `_init_*` function in `bootstrap.py` catches all exceptions and marks the affected service appropriately.  The daemon always reaches a running state even when optional services (TTS, MCP, audit, location) fail to initialise.

---

### Backwards compatibility

The `HealthRegistry` singleton is opt-in.  `get_registry()` returns `None` when `configure()` has not been called, so callers that check for `None` are unaffected.  `build_service_container()` is introduced as a new entry point but does not replace the existing `daemon.main()` wiring - migration is left for a follow-up.

---

### Checklist

- [x] New package with spec file (`runtime.spec.md`)
- [x] Thread-safe registry with well-known `ServiceName` constants
- [x] `bootstrap.py` initialises services in dependency order
- [x] Dead `_health` variable removed from `daemon.py`
- [x] `ShutdownManager` respects configurable diary-flush timeout
- [x] 3 orchestration test files (57 assertions)
- [x] Config field documented with default
- [x] British English throughout
- [x] No breaking changes to existing code paths