### PR TITLE
feat: replace profile system with smart per-query tool selection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,9 +21,7 @@ Any code change must either adhere to our spec files perfectly or you should ask
 
 Avoid hardcoded language patterns as this assistant needs to support an arbitrary amount of different languages.
 
-Tools define when/how to be used. Profiles define what to do after tools execute. Keep these concerns separate in `tools.py` and `profiles.py`.
-
-Tools return raw data without LLM processing. Profiles handle all response formatting and personality through the daemon's LLM loop. This ensures consistent response style across all profiles.
+Tools define when/how to be used and return raw data without LLM processing. The unified system prompt in `profiles.py` handles response formatting and personality through the daemon's LLM loop.
 
 ## Git Workflow
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ Any code change must either adhere to our spec files perfectly or you should ask
 
 Avoid hardcoded language patterns as this assistant needs to support an arbitrary amount of different languages.
 
-Tools define when/how to be used and return raw data without LLM processing. The unified system prompt in `profiles.py` handles response formatting and personality through the daemon's LLM loop.
+Tools define when/how to be used and return raw data without LLM processing. The unified system prompt in `src/jarvis/system_prompt.py` handles response formatting and personality through the daemon's LLM loop.
 
 ## Git Workflow
 

--- a/evals/test_tool_selection.py
+++ b/evals/test_tool_selection.py
@@ -1,0 +1,98 @@
+"""
+Tool Selection Evaluations
+
+Tests that the embedding-based tool selection strategy actually filters tools
+meaningfully — a weather query should select weather-related tools, not all tools.
+
+Run: .venv/bin/python -m pytest evals/test_tool_selection.py -v
+"""
+
+import pytest
+
+from conftest import requires_judge_llm
+
+
+# =============================================================================
+# Test Data
+# =============================================================================
+
+# Queries paired with the tools they MUST include and a maximum tool count.
+# The max count ensures the strategy actually filters rather than passing everything.
+TOOL_SELECTION_CASES = [
+    pytest.param(
+        "what's the weather like tomorrow",
+        ["getWeather"],
+        5,
+        id="weather query selects getWeather and few others",
+    ),
+    pytest.param(
+        "what's the weather in London this weekend",
+        ["getWeather"],
+        5,
+        id="location weather query selects getWeather and few others",
+    ),
+    pytest.param(
+        "log that I had a chicken salad for lunch",
+        ["logMeal"],
+        5,
+        id="meal logging selects logMeal and few others",
+    ),
+    pytest.param(
+        "what did I eat yesterday",
+        ["fetchMeals"],
+        5,
+        id="meal recall selects fetchMeals and few others",
+    ),
+    pytest.param(
+        "search the web for Python tutorials",
+        ["webSearch"],
+        5,
+        id="web search query selects webSearch and few others",
+    ),
+]
+
+
+@pytest.mark.eval
+class TestToolSelectionFiltering:
+    """Validates that embedding tool selection meaningfully filters tools."""
+
+    @requires_judge_llm
+    @pytest.mark.parametrize("query, must_include, max_tools", TOOL_SELECTION_CASES)
+    def test_embedding_selects_relevant_tools(
+        self,
+        mock_config,
+        query,
+        must_include,
+        max_tools,
+    ):
+        """Embedding strategy should select relevant tools, not all of them."""
+        from jarvis.tools.selection import select_tools, ToolSelectionStrategy
+        from jarvis.tools.registry import BUILTIN_TOOLS
+
+        selected = select_tools(
+            query=query,
+            builtin_tools=BUILTIN_TOOLS,
+            mcp_tools={},
+            strategy=ToolSelectionStrategy.EMBEDDING,
+            llm_base_url=mock_config.ollama_base_url,
+            embed_model=mock_config.ollama_embed_model,
+            embed_timeout_sec=10.0,
+        )
+
+        total_builtin = len(BUILTIN_TOOLS)
+
+        # Must include the expected tools
+        for tool in must_include:
+            assert tool in selected, (
+                f"Expected '{tool}' in selected tools but got: {selected}"
+            )
+
+        # Must include 'stop' (always included)
+        assert "stop" in selected, f"'stop' should always be included, got: {selected}"
+
+        # Must NOT include everything — that means filtering isn't working
+        assert len(selected) <= max_tools, (
+            f"Expected at most {max_tools} tools but got {len(selected)}/{total_builtin}: {selected}"
+        )
+
+        print(f"  ✅ Selected {len(selected)}/{total_builtin} tools: {selected}")

--- a/src/jarvis/config.py
+++ b/src/jarvis/config.py
@@ -561,7 +561,7 @@ def load_settings() -> Settings:
     memory_enrichment_max_results = int(merged.get("memory_enrichment_max_results", 10))
     memory_search_max_results = int(merged.get("memory_search_max_results", 15))
     agentic_max_turns = int(merged.get("agentic_max_turns", 8))
-    tool_selection_strategy = str(merged.get("tool_selection_strategy", "all")).lower()
+    tool_selection_strategy = str(merged.get("tool_selection_strategy", "embedding")).lower()
     if tool_selection_strategy not in ("all", "keyword", "embedding", "llm"):
         tool_selection_strategy = "embedding"
     location_enabled = bool(merged.get("location_enabled", True))

--- a/src/jarvis/config.py
+++ b/src/jarvis/config.py
@@ -408,7 +408,7 @@ def get_default_config() -> Dict[str, Any]:
 
         # Agentic Loop
         "agentic_max_turns": 8,
-        "tool_selection_strategy": "all",
+        "tool_selection_strategy": "embedding",
 
         # Stop Commands
         "stop_commands": ["stop", "quiet", "shush", "silence", "enough", "shut up"],
@@ -563,7 +563,7 @@ def load_settings() -> Settings:
     agentic_max_turns = int(merged.get("agentic_max_turns", 8))
     tool_selection_strategy = str(merged.get("tool_selection_strategy", "all")).lower()
     if tool_selection_strategy not in ("all", "keyword", "embedding", "llm"):
-        tool_selection_strategy = "all"
+        tool_selection_strategy = "embedding"
     location_enabled = bool(merged.get("location_enabled", True))
     location_cache_minutes = int(merged.get("location_cache_minutes", 60))
     location_ip_address_val = merged.get("location_ip_address")

--- a/src/jarvis/config.py
+++ b/src/jarvis/config.py
@@ -166,6 +166,7 @@ class Settings:
 
     # Agentic Loop
     agentic_max_turns: int
+    tool_selection_strategy: str  # "all", "keyword", or "llm"
 
     # Location Services
     location_enabled: bool
@@ -407,6 +408,7 @@ def get_default_config() -> Dict[str, Any]:
 
         # Agentic Loop
         "agentic_max_turns": 8,
+        "tool_selection_strategy": "all",
 
         # Stop Commands
         "stop_commands": ["stop", "quiet", "shush", "silence", "enough", "shut up"],
@@ -559,6 +561,9 @@ def load_settings() -> Settings:
     memory_enrichment_max_results = int(merged.get("memory_enrichment_max_results", 10))
     memory_search_max_results = int(merged.get("memory_search_max_results", 15))
     agentic_max_turns = int(merged.get("agentic_max_turns", 8))
+    tool_selection_strategy = str(merged.get("tool_selection_strategy", "all")).lower()
+    if tool_selection_strategy not in ("all", "keyword", "llm"):
+        tool_selection_strategy = "all"
     location_enabled = bool(merged.get("location_enabled", True))
     location_cache_minutes = int(merged.get("location_cache_minutes", 60))
     location_ip_address_val = merged.get("location_ip_address")
@@ -672,6 +677,7 @@ def load_settings() -> Settings:
         memory_enrichment_max_results=memory_enrichment_max_results,
         memory_search_max_results=memory_search_max_results,
         agentic_max_turns=agentic_max_turns,
+        tool_selection_strategy=tool_selection_strategy,
 
         # Location Services
         location_enabled=location_enabled,

--- a/src/jarvis/config.py
+++ b/src/jarvis/config.py
@@ -166,7 +166,7 @@ class Settings:
 
     # Agentic Loop
     agentic_max_turns: int
-    tool_selection_strategy: str  # "all", "keyword", or "llm"
+    tool_selection_strategy: str  # "all", "keyword", "embedding", or "llm"
 
     # Location Services
     location_enabled: bool
@@ -562,7 +562,7 @@ def load_settings() -> Settings:
     memory_search_max_results = int(merged.get("memory_search_max_results", 15))
     agentic_max_turns = int(merged.get("agentic_max_turns", 8))
     tool_selection_strategy = str(merged.get("tool_selection_strategy", "all")).lower()
-    if tool_selection_strategy not in ("all", "keyword", "llm"):
+    if tool_selection_strategy not in ("all", "keyword", "embedding", "llm"):
         tool_selection_strategy = "all"
     location_enabled = bool(merged.get("location_enabled", True))
     location_cache_minutes = int(merged.get("location_cache_minutes", 60))

--- a/src/jarvis/listening/listener.py
+++ b/src/jarvis/listening/listener.py
@@ -1733,7 +1733,7 @@ class VoiceListener(threading.Thread):
 
             # Show ready message only after stream is confirmed active
             wake_word = getattr(self.cfg, "wake_word", "jarvis").lower()
-            print(f"🎙️  Listening! Try: \"{wake_word.title()}, how's the weather?\"", flush=True)
+            print(f"🎙️  Listening! Try: \"How's the weather, {wake_word.title()}?\"", flush=True)
 
             # Set face state to IDLE (awake and ready, waiting for wake word)
             try:

--- a/src/jarvis/profile/profiles.py
+++ b/src/jarvis/profile/profiles.py
@@ -1,131 +1,20 @@
-from __future__ import annotations
-from dataclasses import dataclass
-from typing import Dict
-from ..llm import call_llm_direct
+"""
+Unified system prompt for the assistant persona.
 
+Profiles were removed to avoid an unnecessary LLM routing round-trip.
+All guidance is now merged into a single SYSTEM_PROMPT.
+"""
 
-@dataclass(frozen=True)
-class Profile:
-    name: str
-    system_prompt: str
-
-
-PROFILES: Dict[str, Profile] = {
-    "developer": Profile(
-        name="developer",
-        system_prompt=(
-            "Be surgical and conversational. If screen shows code or errors, propose minimal, testable fixes. "
-            "Prefer succinct diffs or commands; avoid long explanations. "
-            "Be aware of the current time, day, and location when suggesting scheduling-related actions or deadlines. "
-            "Consider work hours, weekdays vs weekends, and local context when making recommendations. "
-            "IMPORTANT: When conversation history is provided, use it to understand the context, previous work, "
-            "and established patterns to provide more targeted and relevant solutions. "
-            "Always respond in a short, conversational manner. No markdown tables or complex formatting."
-        ),
-    ),
-    "business": Profile(
-        name="business",
-        system_prompt=(
-            "Be pragmatic, concise, and conversational. Identify the decision, surface 2-3 options with tradeoffs, "
-            "and recommend a next action with a crisp rationale. Provide concrete templates when relevant. "
-            "Be mindful of the current time, day, and location when scheduling meetings, setting deadlines, or planning business activities. "
-            "Consider business hours, weekdays, time zones, and local business culture in your recommendations. "
-            "IMPORTANT: When conversation history is provided, use it strategically to inform your response. Look for relevant "
-            "context, patterns, and past discussions to make your analysis more targeted and useful. "
-            "Always respond in a short, conversational manner. No markdown tables or complex formatting."
-        ),
-    ),
-    "life": Profile(
-        name="life",
-        system_prompt=(
-            "Be calm, actionable, and conversational. Suggest small, realistic steps. Focus on routines, habits, "
-            "and gentle nudges. Avoid judging; encourage progress. "
-            "Be aware of the current time, day, and location when suggesting activities. "
-            "Tailor recommendations based on morning vs evening, weekday vs weekend patterns, and local opportunities. "
-            "Consider local weather, culture, and available resources in your suggestions.\n\n"
-            "IMPORTANT: When conversation history is provided, use it to inform your response. Look for relevant patterns, "
-            "past context, and what approaches have been effective to make your suggestions more targeted. "
-            "After logging meals: Follow up with healthy suggestions for the rest of the day (hydration, protein targets, vegetables, light activity). "
-            "After fetching meal history: Provide a brief recap with 1-2 gentle recommendations for balance or improvement. "
-            "Always respond in a short, conversational manner. No markdown tables or complex formatting."
-        ),
-    ),
-}
-
-
-
-
-def select_profile_llm(
-    base_url: str,
-    chat_model: str,
-    active_profiles: List[str],
-    text: str,
-    timeout_sec: float = 10.0,
-    previous_profile: str = None,
-    recent_context: str = None,
-    thinking: bool = False,
-) -> str:
-    """
-    Select the best profile for the user's query.
-
-    Args:
-        base_url: Ollama base URL
-        chat_model: Model to use for routing
-        active_profiles: List of available profiles
-        text: User's query text
-        timeout_sec: Timeout for LLM call
-        previous_profile: Profile used in recent conversation (for follow-up continuity)
-        recent_context: Brief summary of recent conversation for context
-    """
-    candidates = [p for p in active_profiles if p in PROFILES]
-    if not candidates:
-        return "developer"
-    # Build an instruction that forces a single-token answer from the allowed list
-    descriptions = {
-        "developer": "Software/code-focused assistant."
-        , "business": "Business/product/ops-focused assistant."
-        , "life": "Lifestyle/habits/wellbeing-focused assistant."
-    }
-    allowed = ", ".join(candidates)
-
-    # Build system prompt with follow-up awareness
-    sys_prompt = (
-        "You are a strict router. Read the user's text and choose the best profile.\n"
-        "Return EXACTLY one profile name from this allowed list, with no extra words: "
-        f"{allowed}.\n"
-    )
-
-    # Add follow-up guidance if there's recent conversation context
-    if previous_profile and previous_profile in candidates:
-        sys_prompt += (
-            f"\nIMPORTANT: The user was just talking to the '{previous_profile}' profile. "
-            "If this looks like a follow-up, correction, or continuation (e.g., 'no', 'yes', "
-            "'actually', 'what about', referring to previous answer), keep the SAME profile.\n"
-        )
-
-    sys_prompt += (
-        "If uncertain, pick the most reasonable.\n"
-        "Profiles: " + "; ".join([f"{k}: {descriptions.get(k, k)}" for k in candidates])
-    )
-
-    # Build user content with optional context
-    user_content = ""
-    if recent_context:
-        user_content += f"Recent conversation context:\n{recent_context}\n\n"
-    user_content += (
-        "User text (may be partial transcript):\n" + text[:2000] + "\n\n"
-        "Answer with only one of: " + allowed
-    )
-
-    resp = call_llm_direct(base_url, chat_model, sys_prompt, user_content, timeout_sec=timeout_sec, thinking=thinking)
-    if isinstance(resp, str) and resp.strip():
-        ans = resp.strip().lower()
-        # Try exact match first
-        if ans in candidates:
-            return ans
-        # Try to find any allowed token inside the response
-        for c in candidates:
-            if c in ans:
-                return c
-    # No fallback - if LLM fails, use first available profile or default to developer
-    return candidates[0] if candidates else "developer"
+SYSTEM_PROMPT: str = (
+    "Be concise, conversational, and actionable. "
+    "Adapt your tone to the topic: surgical for code/errors (propose minimal testable fixes), "
+    "pragmatic for business decisions (surface options with tradeoffs), "
+    "calm and encouraging for lifestyle/wellbeing topics (suggest small realistic steps). "
+    "Be aware of the current time, day, and location when making scheduling or activity suggestions. "
+    "Consider work hours, weekdays vs weekends, time zones, and local context. "
+    "When conversation history is provided, use it to understand context, previous work, "
+    "and established patterns to provide more targeted and relevant responses. "
+    "After logging meals: follow up with healthy suggestions (hydration, protein targets, vegetables, light activity). "
+    "After fetching meal history: provide a brief recap with 1-2 gentle recommendations for balance or improvement. "
+    "Always respond in a short, conversational manner. No markdown tables or complex formatting."
+)

--- a/src/jarvis/profile/profiles.py
+++ b/src/jarvis/profile/profiles.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
-from typing import Dict, List
+from typing import Dict
 from ..llm import call_llm_direct
 
 
@@ -52,40 +52,6 @@ PROFILES: Dict[str, Profile] = {
     ),
 }
 
-
-# Per-profile tool allowlist to limit cognitive load for the LLM
-PROFILE_ALLOWED_TOOLS: Dict[str, List[str]] = {
-    "developer": [
-        "screenshot",
-        "recallConversation",
-        "localFiles",
-        "webSearch",
-        "fetchWebPage",
-        "getWeather",
-        "stop",
-    ],
-    "business": [
-        "screenshot",
-        "recallConversation",
-        "localFiles",
-        "webSearch",
-        "fetchWebPage",
-        "getWeather",
-        "stop",
-    ],
-    "life": [
-        "screenshot",
-        "recallConversation",
-        "logMeal",
-        "fetchMeals",
-        "deleteMeal",
-        "localFiles",
-        "webSearch",
-        "fetchWebPage",
-        "getWeather",
-        "stop",
-    ],
-}
 
 
 

--- a/src/jarvis/reply/engine.py
+++ b/src/jarvis/reply/engine.py
@@ -116,9 +116,9 @@ def run_reply_engine(db: "Database", cfg, tts: Optional[Any],
     # Select tools relevant to this query (strategy controlled by config)
     from ..tools.selection import select_tools, ToolSelectionStrategy
     try:
-        strategy = ToolSelectionStrategy(getattr(cfg, "tool_selection_strategy", "all"))
+        strategy = ToolSelectionStrategy(getattr(cfg, "tool_selection_strategy", "embedding"))
     except ValueError:
-        strategy = ToolSelectionStrategy.ALL
+        strategy = ToolSelectionStrategy.EMBEDDING
     allowed_tools = select_tools(
         query=redacted,
         builtin_tools=BUILTIN_TOOLS,

--- a/src/jarvis/reply/engine.py
+++ b/src/jarvis/reply/engine.py
@@ -130,6 +130,7 @@ def run_reply_engine(db: "Database", cfg, tts: Optional[Any],
         embed_model=getattr(cfg, "ollama_embed_model", "nomic-embed-text"),
         embed_timeout_sec=float(getattr(cfg, "llm_embed_timeout_sec", 10.0)),
     )
+    debug_log(f"  🔧 Tool selection ({strategy.value}): {len(allowed_tools)} tools selected", "planning")
 
     tools_desc = generate_tools_description(allowed_tools, mcp_tools)
     tools_json_schema = generate_tools_json_schema(allowed_tools, mcp_tools)

--- a/src/jarvis/reply/engine.py
+++ b/src/jarvis/reply/engine.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from typing import Optional, TYPE_CHECKING
 
 from ..utils.redact import redact
-from ..profile.profiles import PROFILES, select_profile_llm, PROFILE_ALLOWED_TOOLS
+from ..profile.profiles import PROFILES, select_profile_llm
 from ..tools.registry import run_tool_with_retries, generate_tools_description, generate_tools_json_schema, BUILTIN_TOOLS
 from ..tools.builtin.stop import STOP_SIGNAL
 from ..debug import debug_log
@@ -133,8 +133,8 @@ def run_reply_engine(db: "Database", cfg, tts: Optional[Any],
     if conversation_context:
         context.append(f"Relevant conversation history:\n{conversation_context}")
 
-    # Step 6: Tool allowlist and description
-    allowed_tools = PROFILE_ALLOWED_TOOLS.get(profile_name) or list(BUILTIN_TOOLS.keys())
+    # Step 6: Tool list and description
+    allowed_tools = list(BUILTIN_TOOLS.keys())
 
     # Use cached MCP tools (discovered at startup, refreshed on memory expiry or manual request)
     mcp_tools = {}
@@ -516,35 +516,20 @@ def run_reply_engine(db: "Database", cfg, tts: Optional[Any],
 
         messages.append(assistant_msg)
 
-        # Check if we're stuck
+        # Check if we're stuck (no content, no tool call)
         if not content and not t_name:
-            # Empty response with no tool calls - this is problematic
-            debug_log("  ⚠️ Empty assistant response with no tool calls", "planning")
+            # Thinking-only turn: let the model continue reasoning
+            if thinking:
+                debug_log("  🧠 Thinking step (no action needed)", "planning")
+                continue
 
-            # With native tool calling, if we get empty response with no tool calls, the model is stuck
-            # Note: We don't add system messages here because they break native tool calling
+            debug_log("  ⚠️ Empty assistant response with no tool calls", "planning")
             if turn > 3:
                 debug_log("  🚨 Force exit - too many empty responses", "planning")
             break
 
-        # Parse for tool calls using OpenAI standard format
-        tool_name = None
-        tool_args = None
-        tool_call_id = None
-
-        # Check for structured tool calls in the response
         if t_name:
             tool_name, tool_args, tool_call_id = t_name, t_args, t_call_id
-
-        # If we have thinking but no content and no tool calls, treat as planning step
-        if not content and not tool_name and thinking:
-            debug_log(f"  🧠 Thinking step (no action needed)", "planning")
-
-            # With native tool calling, the model should naturally proceed to respond or call tools
-            # Note: We don't add system messages here because they break native tool calling
-            # If stuck thinking for too many turns, the loop will naturally exit at max_turns
-            continue
-        if tool_name:
             debug_log(f"🛠️ tool requested: {tool_name}", "planning")
 
             # Check if tool is not allowed - respond with tool error

--- a/src/jarvis/reply/engine.py
+++ b/src/jarvis/reply/engine.py
@@ -114,8 +114,11 @@ def run_reply_engine(db: "Database", cfg, tts: Optional[Any],
             mcp_tools = {}
 
     # Select tools relevant to this query (strategy controlled by config)
-    from ..tools.selection import select_tools
-    strategy = getattr(cfg, "tool_selection_strategy", "all")
+    from ..tools.selection import select_tools, ToolSelectionStrategy
+    try:
+        strategy = ToolSelectionStrategy(getattr(cfg, "tool_selection_strategy", "all"))
+    except ValueError:
+        strategy = ToolSelectionStrategy.ALL
     allowed_tools = select_tools(
         query=redacted,
         builtin_tools=BUILTIN_TOOLS,
@@ -124,6 +127,8 @@ def run_reply_engine(db: "Database", cfg, tts: Optional[Any],
         llm_base_url=cfg.ollama_base_url,
         llm_model=cfg.ollama_chat_model,
         llm_timeout_sec=float(getattr(cfg, "llm_tools_timeout_sec", 8.0)),
+        embed_model=getattr(cfg, "ollama_embed_model", "nomic-embed-text"),
+        embed_timeout_sec=float(getattr(cfg, "llm_embed_timeout_sec", 10.0)),
     )
 
     tools_desc = generate_tools_description(allowed_tools, mcp_tools)

--- a/src/jarvis/reply/engine.py
+++ b/src/jarvis/reply/engine.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from typing import Optional, TYPE_CHECKING
 
 from ..utils.redact import redact
-from ..profile.profiles import SYSTEM_PROMPT
+from ..system_prompt import SYSTEM_PROMPT
 from ..tools.registry import run_tool_with_retries, generate_tools_description, generate_tools_json_schema, BUILTIN_TOOLS
 from ..tools.builtin.stop import STOP_SIGNAL
 from ..debug import debug_log

--- a/src/jarvis/reply/engine.py
+++ b/src/jarvis/reply/engine.py
@@ -1,14 +1,14 @@
 """
 Reply Engine - Main orchestrator for response generation.
 
-Handles profile selection, memory enrichment, tool planning and execution.
+Handles memory enrichment, tool planning and execution.
 """
 
 from __future__ import annotations
 from typing import Optional, TYPE_CHECKING
 
 from ..utils.redact import redact
-from ..profile.profiles import PROFILES, select_profile_llm
+from ..profile.profiles import SYSTEM_PROMPT
 from ..tools.registry import run_tool_with_retries, generate_tools_description, generate_tools_json_schema, BUILTIN_TOOLS
 from ..tools.builtin.stop import STOP_SIGNAL
 from ..debug import debug_log
@@ -44,44 +44,13 @@ def run_reply_engine(db: "Database", cfg, tts: Optional[Any],
     # Step 1: Redact sensitive information
     redacted = redact(text)
 
-    # Step 2: Check for recent dialogue context first (needed for profile selection)
+    # Step 2: Check for recent dialogue context
     recent_messages = []
     is_new_conversation = True
-    previous_profile = None
-    recent_context_summary = None
 
     if dialogue_memory and dialogue_memory.has_recent_messages():
         recent_messages = dialogue_memory.get_recent_messages()
         is_new_conversation = False
-
-        # Get the previous profile used (tracked by DialogueMemory)
-        previous_profile = dialogue_memory.get_last_profile()
-
-        # Build a brief context summary (last user message + assistant response)
-        if len(recent_messages) >= 2:
-            context_parts = []
-            for msg in recent_messages[-4:]:  # Last 2 exchanges max
-                role = msg.get("role", "")
-                content = msg.get("content", "")[:150]
-                if role in ("user", "assistant") and content:
-                    context_parts.append(f"{role}: {content}")
-            if context_parts:
-                recent_context_summary = " | ".join(context_parts)
-
-    # Step 3: Profile selection (with follow-up awareness)
-    profile_name = select_profile_llm(
-        cfg.ollama_base_url,
-        cfg.ollama_chat_model,
-        cfg.active_profiles,
-        redacted,
-        timeout_sec=float(getattr(cfg, 'llm_profile_select_timeout_sec', 30.0)),
-        previous_profile=previous_profile,
-        recent_context=recent_context_summary,
-        thinking=getattr(cfg, 'llm_thinking_enabled', False),
-    )
-    print(f"  🎭 Profile selected: {profile_name}", flush=True)
-
-    system_prompt = PROFILES.get(profile_name, PROFILES["developer"]).system_prompt
 
     # Refresh MCP tools on new conversation (memory expired)
     if is_new_conversation and getattr(cfg, "mcps", {}):
@@ -176,8 +145,7 @@ def run_reply_engine(db: "Database", cfg, tts: Optional[Any],
     debug_log(f"Model size detected: {model_size.value} for {cfg.ollama_chat_model}", "planning")
 
     def _build_initial_system_message() -> str:
-        # Start with profile-specific system prompt
-        guidance = [system_prompt.strip()]
+        guidance = [SYSTEM_PROMPT.strip()]
 
         # Add model-size-appropriate prompt components
         guidance.extend(prompts.to_list())
@@ -577,7 +545,7 @@ def run_reply_engine(db: "Database", cfg, tts: Optional[Any],
                 cfg=cfg,
                 tool_name=tool_name,
                 tool_args=tool_args,
-                system_prompt=system_prompt,
+                system_prompt=SYSTEM_PROMPT,
                 original_prompt="",
                 redacted_text=redacted,
                 max_retries=1,
@@ -701,11 +669,11 @@ def run_reply_engine(db: "Database", cfg, tts: Optional[Any],
         # Print reply with appropriate header
         try:
             if not getattr(cfg, "voice_debug", False):
-                print(f"\n🤖 Jarvis ({profile_name})\n" + safe_reply + "\n", flush=True)
+                print(f"\n🤖 Jarvis\n" + safe_reply + "\n", flush=True)
             else:
-                print(f"\n[jarvis coach:{profile_name}]\n" + safe_reply + "\n", flush=True)
+                print(f"\n[jarvis]\n" + safe_reply + "\n", flush=True)
         except Exception:
-            print(f"\n[jarvis coach:{profile_name}]\n" + safe_reply + "\n", flush=True)
+            print(f"\n[jarvis]\n" + safe_reply + "\n", flush=True)
 
         # TTS output - callbacks handled by calling code
         if tts is not None and tts.enabled:
@@ -720,9 +688,6 @@ def run_reply_engine(db: "Database", cfg, tts: Optional[Any],
             # Add assistant reply if we have one
             if reply and reply.strip():
                 dialogue_memory.add_message("assistant", reply.strip())
-
-            # Track the profile used for follow-up detection
-            dialogue_memory.set_last_profile(profile_name)
 
             debug_log("interaction added to dialogue memory", "memory")
         except Exception as e:

--- a/src/jarvis/reply/engine.py
+++ b/src/jarvis/reply/engine.py
@@ -102,23 +102,29 @@ def run_reply_engine(db: "Database", cfg, tts: Optional[Any],
     if conversation_context:
         context.append(f"Relevant conversation history:\n{conversation_context}")
 
-    # Step 6: Tool list and description
-    allowed_tools = list(BUILTIN_TOOLS.keys())
-
+    # Step 6: Tool selection and description
     # Use cached MCP tools (discovered at startup, refreshed on memory expiry or manual request)
     mcp_tools = {}
     if getattr(cfg, "mcps", {}):
         try:
             from ..tools.registry import get_cached_mcp_tools
             mcp_tools = get_cached_mcp_tools()
-
-            # Add all discovered MCP tools to allowed tools
-            for mcp_tool_name in mcp_tools.keys():
-                if mcp_tool_name not in allowed_tools:
-                    allowed_tools.append(mcp_tool_name)
         except Exception as e:
             debug_log(f"⚠️ Failed to get cached MCP tools: {e}", "mcp")
             mcp_tools = {}
+
+    # Select tools relevant to this query (strategy controlled by config)
+    from ..tools.selection import select_tools
+    strategy = getattr(cfg, "tool_selection_strategy", "all")
+    allowed_tools = select_tools(
+        query=redacted,
+        builtin_tools=BUILTIN_TOOLS,
+        mcp_tools=mcp_tools,
+        strategy=strategy,
+        llm_base_url=cfg.ollama_base_url,
+        llm_model=cfg.ollama_chat_model,
+        llm_timeout_sec=float(getattr(cfg, "llm_tools_timeout_sec", 8.0)),
+    )
 
     tools_desc = generate_tools_description(allowed_tools, mcp_tools)
     tools_json_schema = generate_tools_json_schema(allowed_tools, mcp_tools)

--- a/src/jarvis/reply/reply.spec.md
+++ b/src/jarvis/reply/reply.spec.md
@@ -5,7 +5,7 @@ This specification documents only the reply flow that begins when a valid user q
 ### Architecture Overview
 - Components:
   - Reply Engine (`src/jarvis/reply/engine.py`): Orchestrates profile selection, conversation-memory enrichment, tool-use protocol, messages loop, output, and memory update.
-  - Profiles (`src/jarvis/profile/profiles.py`): Provide persona-specific `system_prompt` and a per-profile tool allowlist via `PROFILE_ALLOWED_TOOLS`.
+  - Profiles (`src/jarvis/profile/profiles.py`): Provide persona-specific `system_prompt` for each profile.
   - LLM Gateway (`src/jarvis/llm.py`): `chat_with_messages` sends the messages array and returns raw JSON; `extract_text_from_response` normalizes content across providers.
   - Conversation Memory (`src/jarvis/memory/conversation.py`): Supplies recent dialogue messages and keyword/time-bounded recall.
   - Enrichment LLM (`src/jarvis/reply/enrichment.py`): Extracts search params (keywords and optional time bounds) from the current query to drive conversation recall.
@@ -86,7 +86,7 @@ Design principles enforced by the engine:
    - Text-based fallback (automatic): If the model returns HTTP 400, the engine switches to injecting tool descriptions as plain text in the system message and parsing `` ```tool_call ``` `` markdown fences from the model's content field
    - Fallback is detected once per session (first HTTP 400 response) and persists for the rest of the conversation
    - Internal reasoning uses the `thinking` field (not shown to user)
-   - Allowed tools: profile allowlist plus MCP (if configured)
+   - Allowed tools: all builtin tools plus MCP (if configured)
    - Duplicate suppression: the engine returns a tool error response for repeated calls with identical args, guiding the model to use prior results
    - Tool results: native path appends `{role: "tool", tool_call_id: "<id>", content: "<text>"}` messages; text-based fallback appends `{role: "user", content: "[Tool result: name]\n<text>"}` messages
    - No system message injection: The engine does NOT add system messages during the loop as this breaks native tool calling; instead, guidance is provided via tool error responses when needed
@@ -238,7 +238,7 @@ Turn 4: LLM → {content: "Here's a comprehensive comparison of the iPhone 15 mo
 - Memory enrichment:
   - `memory_enrichment_max_results` limits recalled snippets.
 - Tools and MCP:
-  - `PROFILE_ALLOWED_TOOLS` governs default allowlist per profile; MCP servers added from `cfg.mcps`.
+  - All builtin tools are available regardless of profile; MCP servers added from `cfg.mcps`.
 - Agentic loop:
   - `agentic_max_turns` maximum turns in the agentic loop (default 8)
 - Context injection:

--- a/src/jarvis/reply/reply.spec.md
+++ b/src/jarvis/reply/reply.spec.md
@@ -4,14 +4,14 @@ This specification documents only the reply flow that begins when a valid user q
 
 ### Architecture Overview
 - Components:
-  - Reply Engine (`src/jarvis/reply/engine.py`): Orchestrates profile selection, conversation-memory enrichment, tool-use protocol, messages loop, output, and memory update.
-  - Profiles (`src/jarvis/profile/profiles.py`): Provide persona-specific `system_prompt` for each profile.
+  - Reply Engine (`src/jarvis/reply/engine.py`): Orchestrates conversation-memory enrichment, tool-use protocol, messages loop, output, and memory update.
+  - System Prompt (`src/jarvis/profile/profiles.py`): Provides a unified `SYSTEM_PROMPT` with adaptive guidance for all topics.
   - LLM Gateway (`src/jarvis/llm.py`): `chat_with_messages` sends the messages array and returns raw JSON; `extract_text_from_response` normalizes content across providers.
   - Conversation Memory (`src/jarvis/memory/conversation.py`): Supplies recent dialogue messages and keyword/time-bounded recall.
   - Enrichment LLM (`src/jarvis/reply/enrichment.py`): Extracts search params (keywords and optional time bounds) from the current query to drive conversation recall.
 
 Design principles enforced by the engine:
-- Tool-Profile Separation: Tools define data retrieval; profiles define style/instructions.
+- Unified System Prompt: A single prompt with adaptive guidance handles all topics; no per-profile routing.
 - Tool Response Flow: Tools return raw data; formatting/personality is handled by the LLM through the engine's loop. The system prompt explicitly instructs the model to use tool results to fulfill the user's original request, not to describe the structure or format of the tool response.
 - Language-Agnostic Design: Prompts and ASR guidance avoid language-specific phrasing.
 - Data Privacy: Inputs are redacted and logging is concise and purposeful via `debug_log`.
@@ -28,10 +28,7 @@ Design principles enforced by the engine:
 1. Redact
    - Redact input to remove sensitive data.
 
-2. Profile Selection
-   - Use a lightweight LLM-based router to select the profile; load its system guidance.
-
-3. Recent Dialogue Context
+2. Recent Dialogue Context
    - Include short-term dialogue memory (last 5 minutes) as prior messages.
 
 4. Conversation Memory Enrichment (optional)
@@ -42,13 +39,13 @@ Design principles enforced by the engine:
 
 5. Build Initial Messages
    - messages = [
-     {role: system, content: general instructions + profile-specific instructions + ASR note + tool protocol + enrichment },
+     {role: system, content: unified system prompt + ASR note + tool protocol + enrichment },
      ...recent dialogue messages...,
      {role: user, content: redacted user text}
    ]
 
    System message composition:
-   - Start with the profile `system_prompt`.
+   - Start with the unified `SYSTEM_PROMPT`.
    - Append ASR note: inputs come from speech transcription and may include errors; prefer user intent and ask brief clarifying questions when uncertain.
    - Append the tool-use protocol (allowed response formats and MCP invocation format if configured).
    - Append `Relevant conversation history:` when enrichment produced context.
@@ -101,8 +98,8 @@ Design principles enforced by the engine:
 - Redaction/DB
   - VSS enabled vs disabled
   - Embedding success vs failure (ignored)
-- Profile
-  - Valid LLM selection vs fallback
+- System Prompt
+  - Unified prompt loaded
 - Conversation Memory
   - Params extracted vs empty
   - Tool allowed vs not
@@ -128,7 +125,6 @@ sequenceDiagram
   participant Engine as Reply Engine
   participant Store as Persistent Store
   participant Emb as Embedding Service
-  participant Router as Profile Router
   participant ShortMem as Short-term Memory
   participant Recall as Conversation Recall
   participant Tools as Tool Orchestrator
@@ -137,8 +133,6 @@ sequenceDiagram
 
   Caller->>Engine: text
   Engine->>Engine: Redact
-  Engine->>Router: route(profile candidates, text)
-  Router-->>Engine: profile
   Engine->>ShortMem: recent_messages()
   Engine->>Recall: extract recall params (LLM)
   alt keywords present AND RECALL_CONVERSATION allowed
@@ -231,14 +225,14 @@ Turn 4: LLM → {content: "Here's a comprehensive comparison of the iPhone 15 mo
 
 ### Configuration and Defaults
 - Timeouts (seconds):
-  - `llm_profile_select_timeout_sec` (profile routing)
+
   - `llm_tools_timeout_sec` (enrichment extraction)
   - `llm_embed_timeout_sec` (vector search)
   - `llm_chat_timeout_sec` (messages loop turn)
 - Memory enrichment:
   - `memory_enrichment_max_results` limits recalled snippets.
 - Tools and MCP:
-  - All builtin tools are available regardless of profile; MCP servers added from `cfg.mcps`.
+  - All builtin tools are always available; MCP servers added from `cfg.mcps`.
 - Agentic loop:
   - `agentic_max_turns` maximum turns in the agentic loop (default 8)
 - Context injection:
@@ -280,7 +274,7 @@ This prevents issues like calling `webSearch` for "ni hao" (Chinese greeting).
 See `src/jarvis/reply/prompts/prompts.spec.md` for full prompt architecture documentation.
 
 ### Logging and Privacy
-- Use `debug_log` for key steps: `profile`, `memory`, `planning`, and `voice` categories.
+- Use `debug_log` for key steps: `memory`, `planning`, and `voice` categories.
 - Avoid excessive logging; logs must remain readable and privacy-preserving.
 
 

--- a/src/jarvis/reply/reply.spec.md
+++ b/src/jarvis/reply/reply.spec.md
@@ -5,7 +5,7 @@ This specification documents only the reply flow that begins when a valid user q
 ### Architecture Overview
 - Components:
   - Reply Engine (`src/jarvis/reply/engine.py`): Orchestrates conversation-memory enrichment, tool-use protocol, messages loop, output, and memory update.
-  - System Prompt (`src/jarvis/profile/profiles.py`): Provides a unified `SYSTEM_PROMPT` with adaptive guidance for all topics.
+  - System Prompt (`src/jarvis/system_prompt.py`): Provides a unified `SYSTEM_PROMPT` with adaptive guidance for all topics.
   - LLM Gateway (`src/jarvis/llm.py`): `chat_with_messages` sends the messages array and returns raw JSON; `extract_text_from_response` normalizes content across providers.
   - Conversation Memory (`src/jarvis/memory/conversation.py`): Supplies recent dialogue messages and keyword/time-bounded recall.
   - Enrichment LLM (`src/jarvis/reply/enrichment.py`): Extracts search params (keywords and optional time bounds) from the current query to drive conversation recall.

--- a/src/jarvis/system_prompt.py
+++ b/src/jarvis/system_prompt.py
@@ -1,8 +1,5 @@
 """
 Unified system prompt for the assistant persona.
-
-Profiles were removed to avoid an unnecessary LLM routing round-trip.
-All guidance is now merged into a single SYSTEM_PROMPT.
 """
 
 SYSTEM_PROMPT: str = (
@@ -14,7 +11,5 @@ SYSTEM_PROMPT: str = (
     "Consider work hours, weekdays vs weekends, time zones, and local context. "
     "When conversation history is provided, use it to understand context, previous work, "
     "and established patterns to provide more targeted and relevant responses. "
-    "After logging meals: follow up with healthy suggestions (hydration, protein targets, vegetables, light activity). "
-    "After fetching meal history: provide a brief recap with 1-2 gentle recommendations for balance or improvement. "
     "Always respond in a short, conversational manner. No markdown tables or complex formatting."
 )

--- a/src/jarvis/tools/selection.py
+++ b/src/jarvis/tools/selection.py
@@ -1,0 +1,222 @@
+"""
+Tool selection — pick relevant tools for a user query.
+
+Strategies:
+  - "all":     return every tool (no filtering)
+  - "keyword": score tools by keyword overlap with the query
+  - "llm":     ask a lightweight LLM call to choose tools
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Dict, List, Optional, TYPE_CHECKING
+
+from ..debug import debug_log
+
+if TYPE_CHECKING:
+    from .base import Tool
+    from .registry import ToolSpec
+
+# Tools that must always be available regardless of selection strategy.
+_ALWAYS_INCLUDED = {"stop"}
+
+# Common English stop-words excluded from keyword matching.
+_STOP_WORDS = frozenset({
+    "a", "an", "the", "is", "are", "was", "were", "be", "been", "being",
+    "have", "has", "had", "do", "does", "did", "will", "would", "shall",
+    "should", "may", "might", "must", "can", "could", "i", "me", "my",
+    "you", "your", "he", "she", "it", "we", "they", "them", "this",
+    "that", "what", "which", "who", "when", "where", "how", "not", "no",
+    "so", "if", "or", "and", "but", "in", "on", "at", "to", "for",
+    "of", "with", "by", "from", "as", "into", "about", "up", "out",
+    "off", "over", "just", "also", "very", "too", "some", "any", "all",
+})
+
+_TOKEN_RE = re.compile(r"[a-z0-9]+")
+_CAMEL_RE = re.compile(r"(?<=[a-z])(?=[A-Z])")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _tokenise(text: str) -> List[str]:
+    """Lowercase and split on non-alphanumeric boundaries, removing stop-words."""
+    return [t for t in _TOKEN_RE.findall(text.lower()) if t not in _STOP_WORDS]
+
+
+def _build_tool_keywords(name: str, description: str) -> set:
+    """Build a keyword set from tool name (camelCase-split) and description."""
+    # Split camelCase name: "fetchWebPage" -> ["fetch", "web", "page"]
+    name_tokens = _TOKEN_RE.findall(_CAMEL_RE.sub(" ", name).lower())
+    desc_tokens = _tokenise(description)
+    return set(name_tokens) | set(desc_tokens)
+
+
+# ---------------------------------------------------------------------------
+# Keyword strategy
+# ---------------------------------------------------------------------------
+
+def _select_keyword(
+    query: str,
+    builtin_tools: Dict[str, "Tool"],
+    mcp_tools: Dict[str, "ToolSpec"],
+) -> List[str]:
+    """Score tools by keyword overlap; return those with score > 0."""
+    query_tokens = set(_tokenise(query))
+    if not query_tokens:
+        # Nothing to match against — return all tools.
+        return _all_tool_names(builtin_tools, mcp_tools)
+
+    scored: List[tuple] = []
+
+    for name, tool in builtin_tools.items():
+        kw = _build_tool_keywords(name, tool.description)
+        score = len(query_tokens & kw)
+        scored.append((name, score))
+
+    for name, spec in mcp_tools.items():
+        kw = _build_tool_keywords(name, spec.description)
+        score = len(query_tokens & kw)
+        scored.append((name, score))
+
+    matched = [name for name, score in scored if score > 0]
+
+    # Always include mandatory tools.
+    for t in _ALWAYS_INCLUDED:
+        if t not in matched and (t in builtin_tools or t in mcp_tools):
+            matched.append(t)
+
+    if not matched or len(matched) <= len(_ALWAYS_INCLUDED):
+        # No real matches — fall back to all tools so the model isn't hamstrung.
+        debug_log("Keyword tool selection found no matches, falling back to all tools", "planning")
+        return _all_tool_names(builtin_tools, mcp_tools)
+
+    debug_log(f"Keyword tool selection: {len(matched)}/{len(builtin_tools) + len(mcp_tools)} tools selected", "planning")
+    return matched
+
+
+# ---------------------------------------------------------------------------
+# LLM strategy
+# ---------------------------------------------------------------------------
+
+def _select_llm(
+    query: str,
+    builtin_tools: Dict[str, "Tool"],
+    mcp_tools: Dict[str, "ToolSpec"],
+    llm_base_url: str,
+    llm_model: str,
+    llm_timeout_sec: float,
+) -> List[str]:
+    """Ask a lightweight LLM call which tools are relevant."""
+    from ..llm import call_llm_direct
+
+    # Build tool catalogue.
+    catalogue_lines: List[str] = []
+    all_names: List[str] = []
+    for name, tool in builtin_tools.items():
+        if name in _ALWAYS_INCLUDED:
+            continue
+        catalogue_lines.append(f"- {name}: {tool.description[:120]}")
+        all_names.append(name)
+    for name, spec in mcp_tools.items():
+        catalogue_lines.append(f"- {name}: {spec.description[:120]}")
+        all_names.append(name)
+    catalogue = "\n".join(catalogue_lines)
+
+    sys_prompt = (
+        "You are a tool router. Given a user query and a list of available tools, "
+        "return ONLY a comma-separated list of tool names that might be useful. "
+        "Return 'none' if no tools are needed. No explanations."
+    )
+    user_prompt = (
+        f"Available tools:\n{catalogue}\n\n"
+        f"User query: {query}\n\n"
+        "Which tools (comma-separated)?"
+    )
+
+    try:
+        resp = call_llm_direct(
+            llm_base_url, llm_model, sys_prompt, user_prompt,
+            timeout_sec=llm_timeout_sec,
+        )
+    except Exception as e:
+        debug_log(f"LLM tool selection failed: {e}, falling back to all tools", "planning")
+        return _all_tool_names(builtin_tools, mcp_tools)
+
+    if not resp or not isinstance(resp, str):
+        debug_log("LLM tool selection returned empty, falling back to all tools", "planning")
+        return _all_tool_names(builtin_tools, mcp_tools)
+
+    resp_lower = resp.strip().lower()
+    if resp_lower == "none":
+        debug_log("LLM tool selection returned 'none' — including only mandatory tools", "planning")
+        return [t for t in _ALWAYS_INCLUDED if t in builtin_tools or t in mcp_tools]
+
+    # Parse comma-separated names, matching against known tools.
+    known = set(builtin_tools.keys()) | set(mcp_tools.keys())
+    selected: List[str] = []
+    for token in re.split(r"[,\s]+", resp):
+        clean = token.strip().strip("'\"")
+        if clean in known and clean not in selected:
+            selected.append(clean)
+
+    # Always include mandatory tools.
+    for t in _ALWAYS_INCLUDED:
+        if t not in selected and (t in builtin_tools or t in mcp_tools):
+            selected.append(t)
+
+    if not selected or len(selected) <= len(_ALWAYS_INCLUDED):
+        debug_log("LLM tool selection matched nothing, falling back to all tools", "planning")
+        return _all_tool_names(builtin_tools, mcp_tools)
+
+    debug_log(f"LLM tool selection: {len(selected)}/{len(known)} tools selected", "planning")
+    return selected
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def _all_tool_names(
+    builtin_tools: Dict[str, "Tool"],
+    mcp_tools: Dict[str, "ToolSpec"],
+) -> List[str]:
+    return list(builtin_tools.keys()) + list(mcp_tools.keys())
+
+
+def select_tools(
+    query: str,
+    builtin_tools: Dict[str, "Tool"],
+    mcp_tools: Dict[str, "ToolSpec"],
+    strategy: str = "all",
+    llm_base_url: str = "",
+    llm_model: str = "",
+    llm_timeout_sec: float = 8.0,
+) -> List[str]:
+    """
+    Return a list of tool names relevant to *query*.
+
+    Args:
+        query:          User's text query.
+        builtin_tools:  Registry of builtin Tool instances.
+        mcp_tools:      Registry of discovered MCP ToolSpec entries.
+        strategy:       "all", "keyword", or "llm".
+        llm_base_url:   Ollama base URL (needed for "llm" strategy).
+        llm_model:      Chat model name (needed for "llm" strategy).
+        llm_timeout_sec: Timeout for the LLM call.
+
+    Returns:
+        List of tool name strings.
+    """
+    if strategy == "keyword":
+        return _select_keyword(query, builtin_tools, mcp_tools)
+    elif strategy == "llm":
+        return _select_llm(
+            query, builtin_tools, mcp_tools,
+            llm_base_url, llm_model, llm_timeout_sec,
+        )
+    else:
+        # "all" or unknown strategy — return everything.
+        return _all_tool_names(builtin_tools, mcp_tools)

--- a/src/jarvis/tools/selection.py
+++ b/src/jarvis/tools/selection.py
@@ -35,6 +35,12 @@ _ALWAYS_INCLUDED = {"stop"}
 # Prevents overly aggressive filtering that would leave the model with nothing useful.
 _MIN_SELECTED = 3
 
+# Relative similarity threshold for embedding strategy.
+# A tool is kept when its cosine similarity >= top_score * _RELATIVE_THRESHOLD.
+# This adapts to the actual score distribution rather than using a fixed cutoff
+# that either passes everything (too low) or nothing (too high).
+_RELATIVE_THRESHOLD = 0.85
+
 # Common English stop-words excluded from keyword matching.
 _STOP_WORDS = frozenset({
     "a", "an", "the", "is", "are", "was", "were", "be", "been", "being",
@@ -185,9 +191,13 @@ def _select_embedding(
     # Sort by similarity descending.
     similarities.sort(key=lambda x: x[1], reverse=True)
 
-    # Select tools above a similarity threshold, with a minimum count.
-    threshold = 0.3
-    selected = [name for name, sim in similarities if sim >= threshold]
+    # Select tools using a relative threshold: keep tools whose similarity is
+    # within _RELATIVE_THRESHOLD of the best match.  This adapts to the actual
+    # score distribution — a flat 0.3 cutoff lets everything through because
+    # nomic-embed-text gives high baseline similarity across all tools.
+    top_sim = similarities[0][1]
+    cutoff = top_sim * _RELATIVE_THRESHOLD
+    selected = [name for name, sim in similarities if sim >= cutoff]
 
     # Always return at least _MIN_SELECTED tools (the top-N by similarity).
     if len(selected) < _MIN_SELECTED:
@@ -197,7 +207,7 @@ def _select_embedding(
 
     debug_log(
         f"Embedding tool selection: {len(selected)}/{len(builtin_tools) + len(mcp_tools)} tools "
-        f"(top sim={similarities[0][1]:.3f})",
+        f"(top sim={top_sim:.3f}, cutoff={cutoff:.3f})",
         "planning",
     )
     return selected

--- a/src/jarvis/tools/selection.py
+++ b/src/jarvis/tools/selection.py
@@ -1,16 +1,18 @@
 """
 Tool selection — pick relevant tools for a user query.
 
-Strategies:
-  - "all":     return every tool (no filtering)
-  - "keyword": score tools by keyword overlap with the query
-  - "llm":     ask a lightweight LLM call to choose tools
+Strategies (ToolSelectionStrategy enum):
+  - ALL:       return every tool (no filtering)
+  - KEYWORD:   score tools by keyword overlap with the query
+  - EMBEDDING: rank tools by cosine similarity of embeddings
+  - LLM:       ask a lightweight LLM call to choose tools
 """
 
 from __future__ import annotations
 
 import re
-from typing import Dict, List, Optional, TYPE_CHECKING
+from enum import Enum
+from typing import Dict, List, TYPE_CHECKING
 
 from ..debug import debug_log
 
@@ -18,8 +20,20 @@ if TYPE_CHECKING:
     from .base import Tool
     from .registry import ToolSpec
 
+
+class ToolSelectionStrategy(Enum):
+    ALL = "all"
+    KEYWORD = "keyword"
+    EMBEDDING = "embedding"
+    LLM = "llm"
+
+
 # Tools that must always be available regardless of selection strategy.
 _ALWAYS_INCLUDED = {"stop"}
+
+# Minimum number of tools to return from similarity-based strategies.
+# Prevents overly aggressive filtering that would leave the model with nothing useful.
+_MIN_SELECTED = 3
 
 # Common English stop-words excluded from keyword matching.
 _STOP_WORDS = frozenset({
@@ -48,14 +62,38 @@ def _tokenise(text: str) -> List[str]:
 
 def _build_tool_keywords(name: str, description: str) -> set:
     """Build a keyword set from tool name (camelCase-split) and description."""
-    # Split camelCase name: "fetchWebPage" -> ["fetch", "web", "page"]
     name_tokens = _TOKEN_RE.findall(_CAMEL_RE.sub(" ", name).lower())
     desc_tokens = _tokenise(description)
     return set(name_tokens) | set(desc_tokens)
 
 
+def _tool_summary(name: str, description: str) -> str:
+    """One-line summary used as embedding input for a tool."""
+    readable_name = _CAMEL_RE.sub(" ", name).lower()
+    return f"{readable_name}: {description}"
+
+
+def _ensure_always_included(
+    selected: List[str],
+    builtin_tools: Dict[str, "Tool"],
+    mcp_tools: Dict[str, "ToolSpec"],
+) -> List[str]:
+    """Append always-included tools if missing."""
+    for t in _ALWAYS_INCLUDED:
+        if t not in selected and (t in builtin_tools or t in mcp_tools):
+            selected.append(t)
+    return selected
+
+
+def _all_tool_names(
+    builtin_tools: Dict[str, "Tool"],
+    mcp_tools: Dict[str, "ToolSpec"],
+) -> List[str]:
+    return list(builtin_tools.keys()) + list(mcp_tools.keys())
+
+
 # ---------------------------------------------------------------------------
-# Keyword strategy
+# Strategy: keyword
 # ---------------------------------------------------------------------------
 
 def _select_keyword(
@@ -66,7 +104,6 @@ def _select_keyword(
     """Score tools by keyword overlap; return those with score > 0."""
     query_tokens = set(_tokenise(query))
     if not query_tokens:
-        # Nothing to match against — return all tools.
         return _all_tool_names(builtin_tools, mcp_tools)
 
     scored: List[tuple] = []
@@ -82,14 +119,9 @@ def _select_keyword(
         scored.append((name, score))
 
     matched = [name for name, score in scored if score > 0]
+    matched = _ensure_always_included(matched, builtin_tools, mcp_tools)
 
-    # Always include mandatory tools.
-    for t in _ALWAYS_INCLUDED:
-        if t not in matched and (t in builtin_tools or t in mcp_tools):
-            matched.append(t)
-
-    if not matched or len(matched) <= len(_ALWAYS_INCLUDED):
-        # No real matches — fall back to all tools so the model isn't hamstrung.
+    if len(matched) <= len(_ALWAYS_INCLUDED):
         debug_log("Keyword tool selection found no matches, falling back to all tools", "planning")
         return _all_tool_names(builtin_tools, mcp_tools)
 
@@ -98,7 +130,81 @@ def _select_keyword(
 
 
 # ---------------------------------------------------------------------------
-# LLM strategy
+# Strategy: embedding
+# ---------------------------------------------------------------------------
+
+def _select_embedding(
+    query: str,
+    builtin_tools: Dict[str, "Tool"],
+    mcp_tools: Dict[str, "ToolSpec"],
+    embed_base_url: str,
+    embed_model: str,
+    embed_timeout_sec: float,
+) -> List[str]:
+    """Rank tools by cosine similarity between query and tool description embeddings."""
+    import numpy as np
+    from ..memory.embeddings import get_embedding
+
+    # Embed the query.
+    query_vec = get_embedding(query, embed_base_url, embed_model, timeout_sec=embed_timeout_sec)
+    if query_vec is None:
+        debug_log("Embedding tool selection: failed to embed query, falling back to all tools", "planning")
+        return _all_tool_names(builtin_tools, mcp_tools)
+
+    query_arr = np.array(query_vec, dtype=np.float32)
+    q_norm = np.linalg.norm(query_arr)
+    if q_norm > 0:
+        query_arr = query_arr / q_norm
+
+    # Embed each tool description and compute cosine similarity.
+    similarities: List[tuple] = []
+
+    all_tools: Dict[str, str] = {}
+    for name, tool in builtin_tools.items():
+        if name in _ALWAYS_INCLUDED:
+            continue
+        all_tools[name] = _tool_summary(name, tool.description)
+    for name, spec in mcp_tools.items():
+        all_tools[name] = _tool_summary(name, spec.description)
+
+    for name, summary in all_tools.items():
+        tool_vec = get_embedding(summary, embed_base_url, embed_model, timeout_sec=embed_timeout_sec)
+        if tool_vec is None:
+            continue
+        tool_arr = np.array(tool_vec, dtype=np.float32)
+        t_norm = np.linalg.norm(tool_arr)
+        if t_norm > 0:
+            tool_arr = tool_arr / t_norm
+        sim = float(np.dot(query_arr, tool_arr))
+        similarities.append((name, sim))
+
+    if not similarities:
+        debug_log("Embedding tool selection: no tool embeddings produced, falling back to all tools", "planning")
+        return _all_tool_names(builtin_tools, mcp_tools)
+
+    # Sort by similarity descending.
+    similarities.sort(key=lambda x: x[1], reverse=True)
+
+    # Select tools above a similarity threshold, with a minimum count.
+    threshold = 0.3
+    selected = [name for name, sim in similarities if sim >= threshold]
+
+    # Always return at least _MIN_SELECTED tools (the top-N by similarity).
+    if len(selected) < _MIN_SELECTED:
+        selected = [name for name, _ in similarities[:_MIN_SELECTED]]
+
+    selected = _ensure_always_included(selected, builtin_tools, mcp_tools)
+
+    debug_log(
+        f"Embedding tool selection: {len(selected)}/{len(builtin_tools) + len(mcp_tools)} tools "
+        f"(top sim={similarities[0][1]:.3f})",
+        "planning",
+    )
+    return selected
+
+
+# ---------------------------------------------------------------------------
+# Strategy: llm
 # ---------------------------------------------------------------------------
 
 def _select_llm(
@@ -112,17 +218,13 @@ def _select_llm(
     """Ask a lightweight LLM call which tools are relevant."""
     from ..llm import call_llm_direct
 
-    # Build tool catalogue.
     catalogue_lines: List[str] = []
-    all_names: List[str] = []
     for name, tool in builtin_tools.items():
         if name in _ALWAYS_INCLUDED:
             continue
         catalogue_lines.append(f"- {name}: {tool.description[:120]}")
-        all_names.append(name)
     for name, spec in mcp_tools.items():
         catalogue_lines.append(f"- {name}: {spec.description[:120]}")
-        all_names.append(name)
     catalogue = "\n".join(catalogue_lines)
 
     sys_prompt = (
@@ -154,7 +256,6 @@ def _select_llm(
         debug_log("LLM tool selection returned 'none' — including only mandatory tools", "planning")
         return [t for t in _ALWAYS_INCLUDED if t in builtin_tools or t in mcp_tools]
 
-    # Parse comma-separated names, matching against known tools.
     known = set(builtin_tools.keys()) | set(mcp_tools.keys())
     selected: List[str] = []
     for token in re.split(r"[,\s]+", resp):
@@ -162,12 +263,9 @@ def _select_llm(
         if clean in known and clean not in selected:
             selected.append(clean)
 
-    # Always include mandatory tools.
-    for t in _ALWAYS_INCLUDED:
-        if t not in selected and (t in builtin_tools or t in mcp_tools):
-            selected.append(t)
+    selected = _ensure_always_included(selected, builtin_tools, mcp_tools)
 
-    if not selected or len(selected) <= len(_ALWAYS_INCLUDED):
+    if len(selected) <= len(_ALWAYS_INCLUDED):
         debug_log("LLM tool selection matched nothing, falling back to all tools", "planning")
         return _all_tool_names(builtin_tools, mcp_tools)
 
@@ -179,44 +277,45 @@ def _select_llm(
 # Public API
 # ---------------------------------------------------------------------------
 
-def _all_tool_names(
-    builtin_tools: Dict[str, "Tool"],
-    mcp_tools: Dict[str, "ToolSpec"],
-) -> List[str]:
-    return list(builtin_tools.keys()) + list(mcp_tools.keys())
-
-
 def select_tools(
     query: str,
     builtin_tools: Dict[str, "Tool"],
     mcp_tools: Dict[str, "ToolSpec"],
-    strategy: str = "all",
+    strategy: ToolSelectionStrategy = ToolSelectionStrategy.ALL,
     llm_base_url: str = "",
     llm_model: str = "",
     llm_timeout_sec: float = 8.0,
+    embed_model: str = "",
+    embed_timeout_sec: float = 10.0,
 ) -> List[str]:
     """
     Return a list of tool names relevant to *query*.
 
     Args:
-        query:          User's text query.
-        builtin_tools:  Registry of builtin Tool instances.
-        mcp_tools:      Registry of discovered MCP ToolSpec entries.
-        strategy:       "all", "keyword", or "llm".
-        llm_base_url:   Ollama base URL (needed for "llm" strategy).
-        llm_model:      Chat model name (needed for "llm" strategy).
-        llm_timeout_sec: Timeout for the LLM call.
+        query:            User's text query.
+        builtin_tools:    Registry of builtin Tool instances.
+        mcp_tools:        Registry of discovered MCP ToolSpec entries.
+        strategy:         ToolSelectionStrategy enum value.
+        llm_base_url:     Ollama base URL (needed for llm/embedding strategies).
+        llm_model:        Chat model name (needed for "llm" strategy).
+        llm_timeout_sec:  Timeout for the LLM call.
+        embed_model:      Embedding model name (needed for "embedding" strategy).
+        embed_timeout_sec: Timeout for embedding calls.
 
     Returns:
         List of tool name strings.
     """
-    if strategy == "keyword":
+    if strategy == ToolSelectionStrategy.KEYWORD:
         return _select_keyword(query, builtin_tools, mcp_tools)
-    elif strategy == "llm":
+    elif strategy == ToolSelectionStrategy.EMBEDDING:
+        return _select_embedding(
+            query, builtin_tools, mcp_tools,
+            llm_base_url, embed_model, embed_timeout_sec,
+        )
+    elif strategy == ToolSelectionStrategy.LLM:
         return _select_llm(
             query, builtin_tools, mcp_tools,
             llm_base_url, llm_model, llm_timeout_sec,
         )
     else:
-        # "all" or unknown strategy — return everything.
         return _all_tool_names(builtin_tools, mcp_tools)

--- a/src/jarvis/tools/selection.spec.md
+++ b/src/jarvis/tools/selection.spec.md
@@ -2,15 +2,26 @@
 
 Selects a subset of available tools relevant to a given user query, so the LLM receives only tools it is likely to need. Reduces noise for smaller models and lowers token cost.
 
+### ToolSelectionStrategy Enum
+
+```python
+class ToolSelectionStrategy(Enum):
+    ALL = "all"
+    KEYWORD = "keyword"
+    EMBEDDING = "embedding"
+    LLM = "llm"
+```
+
 ### Strategies
 
 Controlled by `tool_selection_strategy` in config:
 
-| Value       | Behaviour                                                         | LLM call? |
-|-------------|-------------------------------------------------------------------|-----------|
-| `"all"`     | Pass every registered tool (current default).                     | No        |
-| `"keyword"` | Score tools by keyword overlap with the query; return top matches.| No        |
-| `"llm"`     | Ask a lightweight LLM call to pick relevant tool names.           | Yes       |
+| Value         | Behaviour                                                           | LLM call? | Extra dependency |
+|---------------|---------------------------------------------------------------------|-----------|------------------|
+| `"all"`       | Pass every registered tool (current default).                       | No        | None             |
+| `"keyword"`   | Score tools by keyword overlap with the query; return top matches.  | No        | None             |
+| `"embedding"` | Rank tools by cosine similarity of embeddings via nomic-embed-text. | No        | numpy            |
+| `"llm"`       | Ask a lightweight LLM call to pick relevant tool names.             | Yes       | None             |
 
 ### Always-included Tools
 
@@ -24,6 +35,16 @@ Regardless of strategy, these tools are **always** included:
 3. Score each tool: count of query tokens that appear in the tool's keyword set.
 4. Return tools with score > 0, plus always-included tools.
 5. If no tools score > 0, fall back to returning all tools (query is too vague to filter).
+
+### Embedding Strategy
+
+1. Embed the user query using `get_embedding()` (calls Ollama `/api/embeddings` with the configured embed model).
+2. For each tool (excluding always-included), build a summary string from the tool name (camelCase split) and description, then embed it.
+3. Compute cosine similarity between the query embedding and each tool embedding.
+4. Select tools with similarity >= 0.3 threshold.
+5. If fewer than `_MIN_SELECTED` (3) tools pass the threshold, return the top 3 by similarity.
+6. Append always-included tools.
+7. If the query embedding fails, fall back to returning all tools.
 
 ### LLM Strategy
 
@@ -40,10 +61,12 @@ def select_tools(
     query: str,
     builtin_tools: Dict[str, Tool],
     mcp_tools: Dict[str, ToolSpec],
-    strategy: str,               # "all", "keyword", or "llm"
-    llm_base_url: str = "",      # needed only for "llm" strategy
-    llm_model: str = "",         # needed only for "llm" strategy
+    strategy: ToolSelectionStrategy = ToolSelectionStrategy.ALL,
+    llm_base_url: str = "",
+    llm_model: str = "",
     llm_timeout_sec: float = 8.0,
+    embed_model: str = "",
+    embed_timeout_sec: float = 10.0,
 ) -> List[str]:
     """Return list of tool names relevant to the query."""
 ```
@@ -55,6 +78,6 @@ Called from the reply engine (Step 6) before `generate_tools_json_schema()` and 
 ### Configuration
 
 - Key: `tool_selection_strategy`
-- Type: `str`
+- Type: `str` (validated against `ToolSelectionStrategy` enum values)
 - Default: `"all"` (backwards-compatible)
-- Valid values: `"all"`, `"keyword"`, `"llm"`
+- Valid values: `"all"`, `"keyword"`, `"embedding"`, `"llm"`

--- a/src/jarvis/tools/selection.spec.md
+++ b/src/jarvis/tools/selection.spec.md
@@ -18,9 +18,9 @@ Controlled by `tool_selection_strategy` in config:
 
 | Value         | Behaviour                                                           | LLM call? | Extra dependency |
 |---------------|---------------------------------------------------------------------|-----------|------------------|
-| `"all"`       | Pass every registered tool (current default).                       | No        | None             |
+| `"all"`       | Pass every registered tool.                                         | No        | None             |
 | `"keyword"`   | Score tools by keyword overlap with the query; return top matches.  | No        | None             |
-| `"embedding"` | Rank tools by cosine similarity of embeddings via nomic-embed-text. | No        | numpy            |
+| `"embedding"` | Rank tools by cosine similarity of embeddings via nomic-embed-text (default). | No | numpy      |
 | `"llm"`       | Ask a lightweight LLM call to pick relevant tool names.             | Yes       | None             |
 
 ### Always-included Tools
@@ -79,5 +79,5 @@ Called from the reply engine (Step 6) before `generate_tools_json_schema()` and 
 
 - Key: `tool_selection_strategy`
 - Type: `str` (validated against `ToolSelectionStrategy` enum values)
-- Default: `"all"` (backwards-compatible)
+- Default: `"embedding"`
 - Valid values: `"all"`, `"keyword"`, `"embedding"`, `"llm"`

--- a/src/jarvis/tools/selection.spec.md
+++ b/src/jarvis/tools/selection.spec.md
@@ -41,7 +41,7 @@ Regardless of strategy, these tools are **always** included:
 1. Embed the user query using `get_embedding()` (calls Ollama `/api/embeddings` with the configured embed model).
 2. For each tool (excluding always-included), build a summary string from the tool name (camelCase split) and description, then embed it.
 3. Compute cosine similarity between the query embedding and each tool embedding.
-4. Select tools with similarity >= 0.3 threshold.
+4. Select tools using a **relative threshold**: keep tools whose similarity >= `top_score * _RELATIVE_THRESHOLD` (0.85). This adapts to the actual score distribution rather than a fixed cutoff that either passes everything or nothing.
 5. If fewer than `_MIN_SELECTED` (3) tools pass the threshold, return the top 3 by similarity.
 6. Append always-included tools.
 7. If the query embedding fails, fall back to returning all tools.

--- a/src/jarvis/tools/selection.spec.md
+++ b/src/jarvis/tools/selection.spec.md
@@ -1,0 +1,60 @@
+## Tool Selection Spec
+
+Selects a subset of available tools relevant to a given user query, so the LLM receives only tools it is likely to need. Reduces noise for smaller models and lowers token cost.
+
+### Strategies
+
+Controlled by `tool_selection_strategy` in config:
+
+| Value       | Behaviour                                                         | LLM call? |
+|-------------|-------------------------------------------------------------------|-----------|
+| `"all"`     | Pass every registered tool (current default).                     | No        |
+| `"keyword"` | Score tools by keyword overlap with the query; return top matches.| No        |
+| `"llm"`     | Ask a lightweight LLM call to pick relevant tool names.           | Yes       |
+
+### Always-included Tools
+
+Regardless of strategy, these tools are **always** included:
+- `stop` — needed so the user can dismiss the assistant at any time.
+
+### Keyword Strategy
+
+1. Build a keyword index per tool from its `name` (camelCase split) and `description` (lowercased, stop-words removed).
+2. Tokenise the user query (lowercase, split on whitespace/punctuation).
+3. Score each tool: count of query tokens that appear in the tool's keyword set.
+4. Return tools with score > 0, plus always-included tools.
+5. If no tools score > 0, fall back to returning all tools (query is too vague to filter).
+
+### LLM Strategy
+
+1. Build a numbered list of tool names + one-line descriptions.
+2. Send to `call_llm_direct` with a system prompt asking for a comma-separated list of relevant tool names.
+3. Parse the response, matching against known tool names.
+4. Return matched tools plus always-included tools.
+5. On timeout or parse failure, fall back to returning all tools.
+
+### Interface
+
+```python
+def select_tools(
+    query: str,
+    builtin_tools: Dict[str, Tool],
+    mcp_tools: Dict[str, ToolSpec],
+    strategy: str,               # "all", "keyword", or "llm"
+    llm_base_url: str = "",      # needed only for "llm" strategy
+    llm_model: str = "",         # needed only for "llm" strategy
+    llm_timeout_sec: float = 8.0,
+) -> List[str]:
+    """Return list of tool names relevant to the query."""
+```
+
+### Integration
+
+Called from the reply engine (Step 6) before `generate_tools_json_schema()` and `generate_tools_description()`. The returned list replaces the current `allowed_tools = list(BUILTIN_TOOLS.keys())`.
+
+### Configuration
+
+- Key: `tool_selection_strategy`
+- Type: `str`
+- Default: `"all"` (backwards-compatible)
+- Valid values: `"all"`, `"keyword"`, `"llm"`

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,7 +53,7 @@ class MockConfig:
     llm_embed_timeout_sec: float = 10.0
     llm_chat_timeout_sec: float = 45.0
     agentic_max_turns: int = 8
-    tool_selection_strategy: str = "all"
+    tool_selection_strategy: str = "embedding"
     memory_enrichment_max_results: int = 5
     location_enabled: bool = True
     location_ip_address: Optional[str] = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,13 +49,11 @@ class MockConfig:
     tts_chatterbox_exaggeration: float = 0.5
     tts_chatterbox_cfg_weight: float = 0.5
     web_search_enabled: bool = True
-    llm_profile_select_timeout_sec: float = 10.0
     llm_tools_timeout_sec: float = 8.0
     llm_embed_timeout_sec: float = 10.0
     llm_chat_timeout_sec: float = 45.0
     agentic_max_turns: int = 8
     memory_enrichment_max_results: int = 5
-    active_profiles: List[str] = field(default_factory=lambda: ["developer", "business", "life"])
     location_enabled: bool = True
     location_ip_address: Optional[str] = None
     location_auto_detect: bool = False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,6 +53,7 @@ class MockConfig:
     llm_embed_timeout_sec: float = 10.0
     llm_chat_timeout_sec: float = 45.0
     agentic_max_turns: int = 8
+    tool_selection_strategy: str = "all"
     memory_enrichment_max_results: int = 5
     location_enabled: bool = True
     location_ip_address: Optional[str] = None

--- a/tests/test_dialogue_memory.py
+++ b/tests/test_dialogue_memory.py
@@ -86,22 +86,18 @@ class TestReplyEngineDialogueMemory:
     
     @patch('src.jarvis.reply.engine.chat_with_messages')
     @patch('src.jarvis.reply.engine.extract_text_from_response')
-    @patch('src.jarvis.profile.profiles.select_profile_llm')
-    def test_dialogue_memory_preserves_message_order(self, mock_profile, mock_extract, mock_chat):
+    def test_dialogue_memory_preserves_message_order(self, mock_extract, mock_chat):
         """Test that reply engine stores conversation in correct order."""
         # Mock dependencies
-        mock_profile.return_value = "developer"
         mock_extract.return_value = "Final response"
         mock_chat.return_value = {"message": {"content": "Final response"}}
-        
+
         # Mock database and config
         mock_db = Mock()
         mock_cfg = Mock()
         mock_cfg.ollama_base_url = "http://localhost:11434"
         mock_cfg.ollama_chat_model = "test"
-        mock_cfg.active_profiles = ["developer"]
         mock_cfg.voice_debug = False
-        mock_cfg.llm_profile_select_timeout_sec = 30.0
         mock_cfg.llm_tools_timeout_sec = 8.0
         mock_cfg.llm_embed_timeout_sec = 10.0
         mock_cfg.llm_chat_timeout_sec = 45.0
@@ -132,12 +128,10 @@ class TestReplyEngineDialogueMemory:
     
     @patch('src.jarvis.reply.engine.chat_with_messages')
     @patch('src.jarvis.reply.engine.extract_text_from_response')
-    @patch('src.jarvis.profile.profiles.select_profile_llm')
     @patch('src.jarvis.reply.engine.run_tool_with_retries')
-    def test_dialogue_memory_filters_tool_calls(self, mock_tool, mock_profile, mock_extract, mock_chat):
+    def test_dialogue_memory_filters_tool_calls(self, mock_tool, mock_extract, mock_chat):
         """Test that JSON tool calls are filtered from dialogue memory."""
         # Mock dependencies
-        mock_profile.return_value = "developer"
         mock_tool.return_value = Mock(reply_text="Weather data", error_message=None)
         
         # Mock multi-turn conversation: structured tool call then final response
@@ -166,9 +160,7 @@ class TestReplyEngineDialogueMemory:
         mock_cfg = Mock()
         mock_cfg.ollama_base_url = "http://localhost:11434"
         mock_cfg.ollama_chat_model = "test"
-        mock_cfg.active_profiles = ["developer"]
         mock_cfg.voice_debug = False
-        mock_cfg.llm_profile_select_timeout_sec = 30.0
         mock_cfg.llm_tools_timeout_sec = 8.0
         mock_cfg.llm_embed_timeout_sec = 10.0
         mock_cfg.llm_chat_timeout_sec = 45.0
@@ -176,10 +168,10 @@ class TestReplyEngineDialogueMemory:
         mock_cfg.location_ip_address = None
         mock_cfg.location_auto_detect = False
         mock_cfg.agentic_max_turns = 8
-        
+
         # Create dialogue memory
         dialogue_memory = DialogueMemory()
-        
+
         # Run reply engine
         result = run_reply_engine(
             db=mock_db,
@@ -188,11 +180,11 @@ class TestReplyEngineDialogueMemory:
             text="What's the weather in London?",
             dialogue_memory=dialogue_memory
         )
-        
+
         # Check that dialogue memory was updated
         chunks = dialogue_memory.get_pending_chunks()
         assert len(chunks) == 2  # User message and assistant response stored separately
-        
+
         # Should include user input and final response
         assert "User: What's the weather in London?" in chunks
         assert "Assistant: It's sunny in London today!" in chunks
@@ -589,52 +581,3 @@ class TestDialogueMemoryUnifiedDurations:
         assert dm.MAX_UNSAVED_AGE_SEC == 120.0
 
 
-@pytest.mark.unit
-class TestDialogueMemoryProfileTracking:
-    """Test profile tracking for follow-up detection."""
-
-    def test_set_and_get_last_profile(self):
-        """Test setting and getting last profile."""
-        dm = DialogueMemory()
-        dm.add_message("user", "test message")
-        dm.set_last_profile("life")
-
-        assert dm.get_last_profile() == "life"
-
-    def test_profile_requires_recent_messages(self):
-        """Profile should only return if there are recent messages."""
-        dm = DialogueMemory()
-        dm.set_last_profile("developer")
-
-        # No messages, so profile should be None
-        assert dm.get_last_profile() is None
-
-    def test_profile_cleared_after_window(self):
-        """Profile should be None if messages are too old."""
-        dm = DialogueMemory()
-        dm.add_message("user", "old message")
-        dm.set_last_profile("business")
-
-        # Manually expire the message
-        with dm._lock:
-            dm._messages = [(time.time() - 400, "user", "old message")]  # 400s ago > 300s window
-
-        assert dm.get_last_profile() is None
-
-    def test_profile_preserved_with_recent_messages(self):
-        """Profile should be preserved if messages are recent."""
-        dm = DialogueMemory()
-        dm.add_message("user", "recent message")
-        dm.set_last_profile("life")
-
-        # Still within window
-        assert dm.get_last_profile() == "life"
-
-    def test_profile_overwrite(self):
-        """Setting profile should overwrite previous value."""
-        dm = DialogueMemory()
-        dm.add_message("user", "test")
-        dm.set_last_profile("developer")
-        dm.set_last_profile("life")
-
-        assert dm.get_last_profile() == "life"

--- a/tests/test_greeting_no_tools.py
+++ b/tests/test_greeting_no_tools.py
@@ -188,3 +188,81 @@ class TestGreetingNoTools:
 
         assert capture.has_any_tool(), \
             f"Query '{query}' SHOULD trigger tools but didn't. Response: {response}"
+
+    @pytest.mark.unit
+    def test_thinking_only_response_continues_loop(
+        self,
+        mock_config,
+        db,
+        dialogue_memory,
+    ):
+        """A thinking-only response (no content, no tool call) should continue the loop, not break it."""
+        from jarvis.reply.engine import run_reply_engine
+
+        mock_config.ollama_chat_model = "gemma4:12b"
+        call_count = 0
+
+        def mock_chat(base_url, chat_model, messages, timeout_sec, extra_options=None, tools=None):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                # First turn: thinking only, no content, no tool call
+                return {"message": {"content": "", "role": "assistant", "thinking": "Let me think about this..."}}
+            # Second turn: actual response
+            return _mock_llm_response("The answer is 42.")
+
+        with patch('jarvis.reply.engine.chat_with_messages', side_effect=mock_chat), \
+             patch('jarvis.reply.engine.extract_search_params_for_memory', return_value={"keywords": []}), \
+             patch('jarvis.reply.engine.select_profile_llm', return_value="developer"):
+
+            response = run_reply_engine(
+                db=db, cfg=mock_config, tts=None,
+                text="what is the meaning of life",
+                dialogue_memory=dialogue_memory,
+            )
+
+        assert call_count == 2, f"Expected 2 LLM calls (thinking + response), got {call_count}"
+        assert response is not None
+        assert "42" in response
+
+    @pytest.mark.unit
+    def test_all_tools_available_regardless_of_profile(
+        self,
+        mock_config,
+        db,
+        dialogue_memory,
+    ):
+        """All builtin tools should be available regardless of which profile is selected."""
+        from jarvis.reply.engine import run_reply_engine
+
+        mock_config.ollama_chat_model = "gemma4:e2b"
+        capture = ToolCallCapture()
+
+        def mock_tool_run(db, cfg, tool_name, tool_args, **kwargs):
+            from jarvis.tools.types import ToolExecutionResult
+            capture.record(tool_name, tool_args or {})
+            return ToolExecutionResult(success=True, reply_text="Logged: pizza")
+
+        call_count = 0
+
+        def mock_chat(base_url, chat_model, messages, timeout_sec, extra_options=None, tools=None):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return _mock_llm_response("", [_tool_call("logMeal", {"description": "pizza"})])
+            return _mock_llm_response("Logged your meal!")
+
+        # Use developer profile — logMeal was previously restricted to "life" only
+        with patch('jarvis.reply.engine.run_tool_with_retries', side_effect=mock_tool_run), \
+             patch('jarvis.reply.engine.chat_with_messages', side_effect=mock_chat), \
+             patch('jarvis.reply.engine.extract_search_params_for_memory', return_value={"keywords": []}), \
+             patch('jarvis.reply.engine.select_profile_llm', return_value="developer"):
+
+            run_reply_engine(
+                db=db, cfg=mock_config, tts=None,
+                text="log that I had pizza for lunch",
+                dialogue_memory=dialogue_memory,
+            )
+
+        assert capture.has_any_tool(), "logMeal should be callable from developer profile"
+        assert "logMeal" in capture.tool_names()

--- a/tests/test_greeting_no_tools.py
+++ b/tests/test_greeting_no_tools.py
@@ -260,5 +260,5 @@ class TestGreetingNoTools:
                 dialogue_memory=dialogue_memory,
             )
 
-        assert capture.has_any_tool(), "logMeal should be callable from developer profile"
+        assert capture.has_any_tool(), "logMeal should always be callable"
         assert "logMeal" in capture.tool_names()

--- a/tests/test_greeting_no_tools.py
+++ b/tests/test_greeting_no_tools.py
@@ -200,7 +200,7 @@ class TestGreetingNoTools:
         mock_config.ollama_chat_model = "gemma4:12b"
         call_count = 0
 
-        def mock_chat(base_url, chat_model, messages, timeout_sec, extra_options=None, tools=None):
+        def mock_chat(base_url, chat_model, messages, timeout_sec, extra_options=None, tools=None, thinking=False):
             nonlocal call_count
             call_count += 1
             if call_count == 1:
@@ -242,7 +242,7 @@ class TestGreetingNoTools:
 
         call_count = 0
 
-        def mock_chat(base_url, chat_model, messages, timeout_sec, extra_options=None, tools=None):
+        def mock_chat(base_url, chat_model, messages, timeout_sec, extra_options=None, tools=None, thinking=False):
             nonlocal call_count
             call_count += 1
             if call_count == 1:

--- a/tests/test_greeting_no_tools.py
+++ b/tests/test_greeting_no_tools.py
@@ -130,8 +130,7 @@ class TestGreetingNoTools:
 
         with patch('jarvis.reply.engine.run_tool_with_retries', side_effect=mock_tool_run), \
              patch('jarvis.reply.engine.chat_with_messages', side_effect=mock_chat), \
-             patch('jarvis.reply.engine.extract_search_params_for_memory', return_value={"keywords": []}), \
-             patch('jarvis.reply.engine.select_profile_llm', return_value="life"):
+             patch('jarvis.reply.engine.extract_search_params_for_memory', return_value={"keywords": []}):
 
             run_reply_engine(
                 db=db, cfg=mock_config, tts=None,
@@ -178,8 +177,7 @@ class TestGreetingNoTools:
 
         with patch('jarvis.reply.engine.run_tool_with_retries', side_effect=mock_tool_run), \
              patch('jarvis.reply.engine.chat_with_messages', side_effect=mock_chat), \
-             patch('jarvis.reply.engine.extract_search_params_for_memory', return_value={"keywords": []}), \
-             patch('jarvis.reply.engine.select_profile_llm', return_value="life"):
+             patch('jarvis.reply.engine.extract_search_params_for_memory', return_value={"keywords": []}):
 
             response = run_reply_engine(
                 db=db, cfg=mock_config, tts=None,
@@ -212,8 +210,7 @@ class TestGreetingNoTools:
             return _mock_llm_response("The answer is 42.")
 
         with patch('jarvis.reply.engine.chat_with_messages', side_effect=mock_chat), \
-             patch('jarvis.reply.engine.extract_search_params_for_memory', return_value={"keywords": []}), \
-             patch('jarvis.reply.engine.select_profile_llm', return_value="developer"):
+             patch('jarvis.reply.engine.extract_search_params_for_memory', return_value={"keywords": []}):
 
             response = run_reply_engine(
                 db=db, cfg=mock_config, tts=None,
@@ -252,11 +249,10 @@ class TestGreetingNoTools:
                 return _mock_llm_response("", [_tool_call("logMeal", {"description": "pizza"})])
             return _mock_llm_response("Logged your meal!")
 
-        # Use developer profile — logMeal was previously restricted to "life" only
+        # logMeal was previously restricted to "life" profile only — now all tools are always available
         with patch('jarvis.reply.engine.run_tool_with_retries', side_effect=mock_tool_run), \
              patch('jarvis.reply.engine.chat_with_messages', side_effect=mock_chat), \
-             patch('jarvis.reply.engine.extract_search_params_for_memory', return_value={"keywords": []}), \
-             patch('jarvis.reply.engine.select_profile_llm', return_value="developer"):
+             patch('jarvis.reply.engine.extract_search_params_for_memory', return_value={"keywords": []}):
 
             run_reply_engine(
                 db=db, cfg=mock_config, tts=None,

--- a/tests/test_mcp_integration.py
+++ b/tests/test_mcp_integration.py
@@ -12,14 +12,13 @@ from unittest.mock import Mock, patch
 @pytest.mark.integration
 def test_mcp_tools_integrated_with_reply_engine():
     """Test that MCP tools are properly integrated with the reply engine's tool discovery."""
-    from jarvis.tools.registry import discover_mcp_tools, generate_tools_description
-    from jarvis.profile.profiles import PROFILE_ALLOWED_TOOLS
-    
+    from jarvis.tools.registry import discover_mcp_tools, generate_tools_description, BUILTIN_TOOLS
+
     # Mock MCP client
     class FakeMCPClient:
         def __init__(self, config):
             pass
-            
+
         def list_tools(self, server_name):
             if server_name == "test-server":
                 return [
@@ -27,18 +26,18 @@ def test_mcp_tools_integrated_with_reply_engine():
                     {"name": "tool2", "description": "Test tool 2"}
                 ]
             return []
-    
+
     with patch('jarvis.tools.registry.MCPClient', FakeMCPClient):
         # Test discovery
         mcps_config = {"test-server": {"command": "fake"}}
         mcp_tools, _errors = discover_mcp_tools(mcps_config)
-        
+
         # Test tool registration (simulate what reply engine does)
-        allowed_tools = PROFILE_ALLOWED_TOOLS.get("developer", []).copy()
+        allowed_tools = list(BUILTIN_TOOLS.keys())
         for mcp_tool_name in mcp_tools.keys():
             if mcp_tool_name not in allowed_tools:
                 allowed_tools.append(mcp_tool_name)
-        
+
         # Test tool descriptions include MCP tools
         description = generate_tools_description(allowed_tools, mcp_tools)
         

--- a/tests/test_tool_selection.py
+++ b/tests/test_tool_selection.py
@@ -1,0 +1,245 @@
+"""Tests for tool selection strategies."""
+
+import pytest
+from unittest.mock import patch, Mock
+
+from jarvis.tools.selection import (
+    select_tools,
+    _tokenise,
+    _build_tool_keywords,
+    _ALWAYS_INCLUDED,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+class FakeTool:
+    """Minimal tool stand-in for testing."""
+    def __init__(self, name: str, description: str):
+        self._name = name
+        self._description = description
+
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def description(self):
+        return self._description
+
+
+class FakeToolSpec:
+    """Minimal ToolSpec stand-in for testing."""
+    def __init__(self, name: str, description: str):
+        self.name = name
+        self.description = description
+
+
+def _builtin():
+    """Return a small set of fake builtin tools."""
+    return {
+        "webSearch": FakeTool("webSearch", "Search the web using DuckDuckGo for current information, news, or general queries."),
+        "getWeather": FakeTool("getWeather", "Get current weather conditions."),
+        "logMeal": FakeTool("logMeal", "Log a single meal when the user mentions eating or drinking something."),
+        "fetchMeals": FakeTool("fetchMeals", "Retrieve meals from the database for a given time range."),
+        "screenshot": FakeTool("screenshot", "Capture a selected screen region and OCR the text."),
+        "localFiles": FakeTool("localFiles", "Safely read, write, list, append, or delete files within your home directory."),
+        "stop": FakeTool("stop", "End the current conversation."),
+    }
+
+
+def _mcp():
+    """Return a small set of fake MCP tools."""
+    return {
+        "homeassistant__turn_on": FakeToolSpec("homeassistant__turn_on", "Turn on a smart home device."),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tokenisation
+# ---------------------------------------------------------------------------
+
+class TestTokenise:
+
+    @pytest.mark.unit
+    def test_basic_tokenise(self):
+        tokens = _tokenise("What's the weather in London?")
+        assert "weather" in tokens
+        assert "london" in tokens
+        # Stop-words removed
+        assert "the" not in tokens
+        assert "in" not in tokens
+
+    @pytest.mark.unit
+    def test_empty_string(self):
+        assert _tokenise("") == []
+
+
+class TestBuildToolKeywords:
+
+    @pytest.mark.unit
+    def test_camel_case_split(self):
+        kw = _build_tool_keywords("fetchWebPage", "Fetch content from a URL.")
+        assert "fetch" in kw
+        assert "web" in kw
+        assert "page" in kw
+
+    @pytest.mark.unit
+    def test_description_tokens(self):
+        kw = _build_tool_keywords("getWeather", "Get current weather conditions.")
+        assert "weather" in kw
+        assert "conditions" in kw
+
+
+# ---------------------------------------------------------------------------
+# Strategy: all
+# ---------------------------------------------------------------------------
+
+class TestAllStrategy:
+
+    @pytest.mark.unit
+    def test_returns_everything(self):
+        result = select_tools("hello", _builtin(), _mcp(), strategy="all")
+        assert len(result) == len(_builtin()) + len(_mcp())
+
+    @pytest.mark.unit
+    def test_unknown_strategy_falls_back_to_all(self):
+        result = select_tools("hello", _builtin(), _mcp(), strategy="banana")
+        assert len(result) == len(_builtin()) + len(_mcp())
+
+
+# ---------------------------------------------------------------------------
+# Strategy: keyword
+# ---------------------------------------------------------------------------
+
+class TestKeywordStrategy:
+
+    @pytest.mark.unit
+    def test_weather_query_selects_weather_tool(self):
+        result = select_tools("what's the weather in London", _builtin(), {}, strategy="keyword")
+        assert "getWeather" in result
+
+    @pytest.mark.unit
+    def test_weather_query_excludes_irrelevant(self):
+        result = select_tools("what's the weather in London", _builtin(), {}, strategy="keyword")
+        assert "logMeal" not in result
+        assert "screenshot" not in result
+
+    @pytest.mark.unit
+    def test_meal_query_selects_meal_tools(self):
+        result = select_tools("what did I eat yesterday", _builtin(), {}, strategy="keyword")
+        assert "fetchMeals" in result or "logMeal" in result
+
+    @pytest.mark.unit
+    def test_search_query_selects_web_search(self):
+        result = select_tools("search for python tutorials", _builtin(), {}, strategy="keyword")
+        assert "webSearch" in result
+
+    @pytest.mark.unit
+    def test_stop_always_included(self):
+        result = select_tools("what's the weather", _builtin(), {}, strategy="keyword")
+        assert "stop" in result
+
+    @pytest.mark.unit
+    def test_vague_query_falls_back_to_all(self):
+        """A query with no keyword matches should return all tools."""
+        result = select_tools("hmm", _builtin(), {}, strategy="keyword")
+        assert len(result) == len(_builtin())
+
+    @pytest.mark.unit
+    def test_mcp_tools_included(self):
+        result = select_tools("turn on the lights", _builtin(), _mcp(), strategy="keyword")
+        assert "homeassistant__turn_on" in result
+
+    @pytest.mark.unit
+    def test_file_query_selects_local_files(self):
+        result = select_tools("read the config file", _builtin(), {}, strategy="keyword")
+        assert "localFiles" in result
+
+
+# ---------------------------------------------------------------------------
+# Strategy: llm
+# ---------------------------------------------------------------------------
+
+class TestLLMStrategy:
+
+    @pytest.mark.unit
+    def test_parses_comma_separated_response(self):
+        def mock_llm(base_url, model, sys, user, timeout_sec=8.0):
+            return "webSearch, getWeather"
+
+        with patch("jarvis.llm.call_llm_direct", side_effect=mock_llm):
+            result = select_tools(
+                "what's the weather",
+                _builtin(), {},
+                strategy="llm",
+                llm_base_url="http://localhost",
+                llm_model="test",
+            )
+        assert "webSearch" in result
+        assert "getWeather" in result
+        assert "stop" in result  # always included
+
+    @pytest.mark.unit
+    def test_none_response_returns_only_mandatory(self):
+        def mock_llm(base_url, model, sys, user, timeout_sec=8.0):
+            return "none"
+
+        with patch("jarvis.llm.call_llm_direct", side_effect=mock_llm):
+            result = select_tools(
+                "hello",
+                _builtin(), {},
+                strategy="llm",
+                llm_base_url="http://localhost",
+                llm_model="test",
+            )
+        assert result == ["stop"]
+
+    @pytest.mark.unit
+    def test_llm_failure_falls_back_to_all(self):
+        def mock_llm(base_url, model, sys, user, timeout_sec=8.0):
+            raise TimeoutError("LLM timed out")
+
+        with patch("jarvis.llm.call_llm_direct", side_effect=mock_llm):
+            result = select_tools(
+                "anything",
+                _builtin(), _mcp(),
+                strategy="llm",
+                llm_base_url="http://localhost",
+                llm_model="test",
+            )
+        assert len(result) == len(_builtin()) + len(_mcp())
+
+    @pytest.mark.unit
+    def test_empty_response_falls_back_to_all(self):
+        def mock_llm(base_url, model, sys, user, timeout_sec=8.0):
+            return ""
+
+        with patch("jarvis.llm.call_llm_direct", side_effect=mock_llm):
+            result = select_tools(
+                "anything",
+                _builtin(), {},
+                strategy="llm",
+                llm_base_url="http://localhost",
+                llm_model="test",
+            )
+        assert len(result) == len(_builtin())
+
+    @pytest.mark.unit
+    def test_ignores_hallucinated_tool_names(self):
+        def mock_llm(base_url, model, sys, user, timeout_sec=8.0):
+            return "webSearch, nonExistentTool, getWeather"
+
+        with patch("jarvis.llm.call_llm_direct", side_effect=mock_llm):
+            result = select_tools(
+                "search and weather",
+                _builtin(), {},
+                strategy="llm",
+                llm_base_url="http://localhost",
+                llm_model="test",
+            )
+        assert "webSearch" in result
+        assert "getWeather" in result
+        assert "nonExistentTool" not in result

--- a/tests/test_tool_selection.py
+++ b/tests/test_tool_selection.py
@@ -1,10 +1,11 @@
 """Tests for tool selection strategies."""
 
 import pytest
-from unittest.mock import patch, Mock
+from unittest.mock import patch
 
 from jarvis.tools.selection import (
     select_tools,
+    ToolSelectionStrategy,
     _tokenise,
     _build_tool_keywords,
     _ALWAYS_INCLUDED,
@@ -58,6 +59,32 @@ def _mcp():
 
 
 # ---------------------------------------------------------------------------
+# Enum
+# ---------------------------------------------------------------------------
+
+class TestToolSelectionStrategy:
+
+    @pytest.mark.unit
+    def test_enum_values(self):
+        assert ToolSelectionStrategy.ALL.value == "all"
+        assert ToolSelectionStrategy.KEYWORD.value == "keyword"
+        assert ToolSelectionStrategy.EMBEDDING.value == "embedding"
+        assert ToolSelectionStrategy.LLM.value == "llm"
+
+    @pytest.mark.unit
+    def test_enum_from_string(self):
+        assert ToolSelectionStrategy("all") == ToolSelectionStrategy.ALL
+        assert ToolSelectionStrategy("keyword") == ToolSelectionStrategy.KEYWORD
+        assert ToolSelectionStrategy("embedding") == ToolSelectionStrategy.EMBEDDING
+        assert ToolSelectionStrategy("llm") == ToolSelectionStrategy.LLM
+
+    @pytest.mark.unit
+    def test_invalid_value_raises(self):
+        with pytest.raises(ValueError):
+            ToolSelectionStrategy("banana")
+
+
+# ---------------------------------------------------------------------------
 # Tokenisation
 # ---------------------------------------------------------------------------
 
@@ -68,7 +95,6 @@ class TestTokenise:
         tokens = _tokenise("What's the weather in London?")
         assert "weather" in tokens
         assert "london" in tokens
-        # Stop-words removed
         assert "the" not in tokens
         assert "in" not in tokens
 
@@ -101,12 +127,12 @@ class TestAllStrategy:
 
     @pytest.mark.unit
     def test_returns_everything(self):
-        result = select_tools("hello", _builtin(), _mcp(), strategy="all")
+        result = select_tools("hello", _builtin(), _mcp(), strategy=ToolSelectionStrategy.ALL)
         assert len(result) == len(_builtin()) + len(_mcp())
 
     @pytest.mark.unit
-    def test_unknown_strategy_falls_back_to_all(self):
-        result = select_tools("hello", _builtin(), _mcp(), strategy="banana")
+    def test_default_strategy_is_all(self):
+        result = select_tools("hello", _builtin(), _mcp())
         assert len(result) == len(_builtin()) + len(_mcp())
 
 
@@ -118,45 +144,136 @@ class TestKeywordStrategy:
 
     @pytest.mark.unit
     def test_weather_query_selects_weather_tool(self):
-        result = select_tools("what's the weather in London", _builtin(), {}, strategy="keyword")
+        result = select_tools("what's the weather in London", _builtin(), {}, strategy=ToolSelectionStrategy.KEYWORD)
         assert "getWeather" in result
 
     @pytest.mark.unit
     def test_weather_query_excludes_irrelevant(self):
-        result = select_tools("what's the weather in London", _builtin(), {}, strategy="keyword")
+        result = select_tools("what's the weather in London", _builtin(), {}, strategy=ToolSelectionStrategy.KEYWORD)
         assert "logMeal" not in result
         assert "screenshot" not in result
 
     @pytest.mark.unit
     def test_meal_query_selects_meal_tools(self):
-        result = select_tools("what did I eat yesterday", _builtin(), {}, strategy="keyword")
+        result = select_tools("what did I eat yesterday", _builtin(), {}, strategy=ToolSelectionStrategy.KEYWORD)
         assert "fetchMeals" in result or "logMeal" in result
 
     @pytest.mark.unit
     def test_search_query_selects_web_search(self):
-        result = select_tools("search for python tutorials", _builtin(), {}, strategy="keyword")
+        result = select_tools("search for python tutorials", _builtin(), {}, strategy=ToolSelectionStrategy.KEYWORD)
         assert "webSearch" in result
 
     @pytest.mark.unit
     def test_stop_always_included(self):
-        result = select_tools("what's the weather", _builtin(), {}, strategy="keyword")
+        result = select_tools("what's the weather", _builtin(), {}, strategy=ToolSelectionStrategy.KEYWORD)
         assert "stop" in result
 
     @pytest.mark.unit
     def test_vague_query_falls_back_to_all(self):
-        """A query with no keyword matches should return all tools."""
-        result = select_tools("hmm", _builtin(), {}, strategy="keyword")
+        result = select_tools("hmm", _builtin(), {}, strategy=ToolSelectionStrategy.KEYWORD)
         assert len(result) == len(_builtin())
 
     @pytest.mark.unit
     def test_mcp_tools_included(self):
-        result = select_tools("turn on the lights", _builtin(), _mcp(), strategy="keyword")
+        result = select_tools("turn on the lights", _builtin(), _mcp(), strategy=ToolSelectionStrategy.KEYWORD)
         assert "homeassistant__turn_on" in result
 
     @pytest.mark.unit
     def test_file_query_selects_local_files(self):
-        result = select_tools("read the config file", _builtin(), {}, strategy="keyword")
+        result = select_tools("read the config file", _builtin(), {}, strategy=ToolSelectionStrategy.KEYWORD)
         assert "localFiles" in result
+
+
+# ---------------------------------------------------------------------------
+# Strategy: embedding
+# ---------------------------------------------------------------------------
+
+class TestEmbeddingStrategy:
+
+    def _mock_embedding(self, text_to_vec):
+        """Return a mock get_embedding that maps text substrings to vectors."""
+        def mock_get_embedding(text, base_url, model, timeout_sec=10.0):
+            for key, vec in text_to_vec.items():
+                if key in text.lower():
+                    return vec
+            # Default: zero vector
+            return [0.0] * 4
+        return mock_get_embedding
+
+    @pytest.mark.unit
+    def test_selects_similar_tools(self):
+        """Weather query should rank getWeather highest."""
+        mock_embed = self._mock_embedding({
+            "weather": [1.0, 0.0, 0.0, 0.0],      # query + weather tool
+            "search": [0.0, 1.0, 0.0, 0.0],
+            "meal": [0.0, 0.0, 1.0, 0.0],
+            "screen": [0.0, 0.0, 0.0, 1.0],
+            "file": [0.1, 0.1, 0.1, 0.1],
+            "conversation": [0.1, 0.1, 0.1, 0.1],
+        })
+        with patch("jarvis.memory.embeddings.get_embedding", side_effect=mock_embed):
+            result = select_tools(
+                "what's the weather",
+                _builtin(), {},
+                strategy=ToolSelectionStrategy.EMBEDDING,
+                llm_base_url="http://localhost",
+                embed_model="nomic-embed-text",
+            )
+        assert "getWeather" in result
+
+    @pytest.mark.unit
+    def test_stop_always_included(self):
+        """Stop tool must be present even if not semantically matched."""
+        mock_embed = self._mock_embedding({
+            "weather": [1.0, 0.0, 0.0, 0.0],
+        })
+        with patch("jarvis.memory.embeddings.get_embedding", side_effect=mock_embed):
+            result = select_tools(
+                "what's the weather",
+                _builtin(), {},
+                strategy=ToolSelectionStrategy.EMBEDDING,
+                llm_base_url="http://localhost",
+                embed_model="nomic-embed-text",
+            )
+        assert "stop" in result
+
+    @pytest.mark.unit
+    def test_failed_query_embedding_falls_back(self):
+        """If query embedding fails, fall back to all tools."""
+        def mock_fail(text, base_url, model, timeout_sec=10.0):
+            return None
+
+        with patch("jarvis.memory.embeddings.get_embedding", side_effect=mock_fail):
+            result = select_tools(
+                "anything",
+                _builtin(), _mcp(),
+                strategy=ToolSelectionStrategy.EMBEDDING,
+                llm_base_url="http://localhost",
+                embed_model="nomic-embed-text",
+            )
+        assert len(result) == len(_builtin()) + len(_mcp())
+
+    @pytest.mark.unit
+    def test_returns_minimum_tools(self):
+        """Should return at least _MIN_SELECTED tools even if similarity is low."""
+        # All tools get zero similarity (orthogonal to query)
+        call_count = [0]
+        def mock_embed(text, base_url, model, timeout_sec=10.0):
+            call_count[0] += 1
+            if call_count[0] == 1:  # query
+                return [1.0, 0.0, 0.0, 0.0]
+            return [0.0, 0.0, 0.0, 1.0]  # all tools orthogonal
+
+        with patch("jarvis.memory.embeddings.get_embedding", side_effect=mock_embed):
+            result = select_tools(
+                "something obscure",
+                _builtin(), {},
+                strategy=ToolSelectionStrategy.EMBEDDING,
+                llm_base_url="http://localhost",
+                embed_model="nomic-embed-text",
+            )
+        # Should still have at least _MIN_SELECTED + stop
+        assert len(result) >= 3
 
 
 # ---------------------------------------------------------------------------
@@ -174,13 +291,13 @@ class TestLLMStrategy:
             result = select_tools(
                 "what's the weather",
                 _builtin(), {},
-                strategy="llm",
+                strategy=ToolSelectionStrategy.LLM,
                 llm_base_url="http://localhost",
                 llm_model="test",
             )
         assert "webSearch" in result
         assert "getWeather" in result
-        assert "stop" in result  # always included
+        assert "stop" in result
 
     @pytest.mark.unit
     def test_none_response_returns_only_mandatory(self):
@@ -191,7 +308,7 @@ class TestLLMStrategy:
             result = select_tools(
                 "hello",
                 _builtin(), {},
-                strategy="llm",
+                strategy=ToolSelectionStrategy.LLM,
                 llm_base_url="http://localhost",
                 llm_model="test",
             )
@@ -206,7 +323,7 @@ class TestLLMStrategy:
             result = select_tools(
                 "anything",
                 _builtin(), _mcp(),
-                strategy="llm",
+                strategy=ToolSelectionStrategy.LLM,
                 llm_base_url="http://localhost",
                 llm_model="test",
             )
@@ -221,7 +338,7 @@ class TestLLMStrategy:
             result = select_tools(
                 "anything",
                 _builtin(), {},
-                strategy="llm",
+                strategy=ToolSelectionStrategy.LLM,
                 llm_base_url="http://localhost",
                 llm_model="test",
             )
@@ -236,7 +353,7 @@ class TestLLMStrategy:
             result = select_tools(
                 "search and weather",
                 _builtin(), {},
-                strategy="llm",
+                strategy=ToolSelectionStrategy.LLM,
                 llm_base_url="http://localhost",
                 llm_model="test",
             )

--- a/tests/test_tool_selection.py
+++ b/tests/test_tool_selection.py
@@ -9,6 +9,7 @@ from jarvis.tools.selection import (
     _tokenise,
     _build_tool_keywords,
     _ALWAYS_INCLUDED,
+    _RELATIVE_THRESHOLD,
 )
 
 
@@ -274,6 +275,73 @@ class TestEmbeddingStrategy:
             )
         # Should still have at least _MIN_SELECTED + stop
         assert len(result) >= 3
+
+    @pytest.mark.unit
+    def test_relative_threshold_filters_low_similarity(self):
+        """Relative threshold keeps only tools near the top score, not everything."""
+        import math
+
+        # Simulate realistic scores with a clear top cluster and a weak tail.
+        # query = [1, 0, 0, 0]
+        # strong  → cos_sim ≈ 0.90   (getWeather)
+        # good    → cos_sim ≈ 0.88   (webSearch — within 85% of top)
+        # weak    → cos_sim ≈ 0.40   (everything else — well below cutoff)
+        #
+        # cutoff = 0.90 * 0.85 = 0.765
+        # strong (0.90) and good (0.88) pass; weak (0.40) do not.
+        # With _MIN_SELECTED=3, top-3 would apply if <3 passed, but 2 pass + stop = 3 total.
+
+        strong = [0.9, 0.436, 0, 0]
+        s_norm = math.sqrt(sum(x*x for x in strong))
+        strong = [x / s_norm for x in strong]
+
+        good = [0.88, 0.475, 0, 0]
+        g_norm = math.sqrt(sum(x*x for x in good))
+        good = [x / g_norm for x in good]
+
+        weak = [0.4, 0.917, 0, 0]
+        w_norm = math.sqrt(sum(x*x for x in weak))
+        weak = [x / w_norm for x in weak]
+
+        mock_map = {
+            "weather": [1.0, 0.0, 0.0, 0.0],     # query
+            "get weather": strong,                  # getWeather → high sim
+            "web search": good,                     # webSearch → just above cutoff
+            "log meal": weak,                       # logMeal → low sim
+            "fetch meals": weak,                    # fetchMeals → low sim
+            "screen": weak,                         # screenshot → low sim
+            "file": weak,                           # localFiles → low sim
+        }
+
+        def mock_embed(text, base_url, model, timeout_sec=10.0):
+            text_lower = text.lower()
+            for key, vec in mock_map.items():
+                if key in text_lower:
+                    return vec
+            return [0.0] * 4
+
+        with patch("jarvis.memory.embeddings.get_embedding", side_effect=mock_embed):
+            result = select_tools(
+                "what's the weather",
+                _builtin(), {},
+                strategy=ToolSelectionStrategy.EMBEDDING,
+                llm_base_url="http://localhost",
+                embed_model="nomic-embed-text",
+            )
+
+        # Strong and good matches must be included
+        assert "getWeather" in result
+        assert "webSearch" in result
+
+        # stop is always included
+        assert "stop" in result
+
+        # Fewer tools than total — the relative threshold actually filtered
+        total_non_stop = len([t for t in _builtin() if t != "stop"])
+        selected_non_stop = len([t for t in result if t != "stop"])
+        assert selected_non_stop < total_non_stop, (
+            f"Expected fewer than {total_non_stop} tools but got {selected_non_stop}: {result}"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/builtin/test_stop.py
+++ b/tests/tools/builtin/test_stop.py
@@ -61,9 +61,8 @@ class TestStopSignalIntegration:
         assert "stop" in BUILTIN_TOOLS
         assert isinstance(BUILTIN_TOOLS["stop"], StopTool)
 
-    def test_stop_tool_in_all_profiles(self):
-        """Test that stop tool is available in all profiles."""
-        from src.jarvis.profile.profiles import PROFILE_ALLOWED_TOOLS
+    def test_stop_tool_always_available(self):
+        """Test that stop tool is available to all profiles via BUILTIN_TOOLS."""
+        from src.jarvis.tools.registry import BUILTIN_TOOLS
 
-        for profile_name, allowed_tools in PROFILE_ALLOWED_TOOLS.items():
-            assert "stop" in allowed_tools, f"stop tool missing from {profile_name} profile"
+        assert "stop" in BUILTIN_TOOLS, "stop tool must be in BUILTIN_TOOLS"


### PR DESCRIPTION
## Summary

- **Remove the profile system entirely** — eliminates the LLM round-trip for profile routing and per-profile tool allowlists that were artificially gating tools
- **Fix thinking-only response bug** — thinking steps no longer break the agentic loop (was dead code due to placement after unconditional `break`)
- **Add smart tool selection** with 4 strategies controlled by `tool_selection_strategy` config (`ToolSelectionStrategy` enum):
  - `all` — pass every tool, backwards-compatible
  - `keyword` — fast token-overlap scoring, no LLM call needed
  - `embedding` (default) — cosine similarity via nomic-embed-text using a **relative threshold** (85% of the top score) that adapts to actual score distribution. Selects ~4 tools per query instead of all 11.
  - `llm` — lightweight LLM call to pick relevant tools
- Every strategy gracefully falls back to all tools on failure (including when the embedding model is unavailable)
- `stop` tool is always included regardless of strategy
- Unified system prompt moved to `src/jarvis/system_prompt.py`; profile directory removed

## Test plan

- [x] 27 unit tests for tool selection (enum, tokenisation, all 4 strategies, relative threshold filtering)
- [x] Embedding unit tests use mocked embeddings with controlled cosine similarity
- [x] LLM tests verify parsing, hallucinated names, empty/none responses, timeouts
- [x] **5 live evals** using real nomic-embed-text (weather, meal log, meal recall, web search, location weather) — verify actual filtering works
- [x] Existing greeting, dialogue memory, MCP integration, and stop tool tests updated and passing
- [x] Thinking-only response continuation test added
- [x] All 90 unit tests pass, all 5 live evals pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)