### PR TITLE
feat: add weather forecast support, anti-deflection evals, and fix wake word detection

### DIFF
--- a/evals/conftest.py
+++ b/evals/conftest.py
@@ -76,6 +76,7 @@ CLASS_DESCRIPTIONS = {
     "TestFollowUpContext": "Tests context retention for follow-up questions",
     "TestMultiTurnExtended": "Extended multi-turn scenarios with longer conversations",
     "TestGreetingNoToolsLive": "Live tests that greetings don't trigger tool calls",
+    "TestHelpfulness": "Tests that agent uses tools proactively instead of deflecting",
 }
 
 # Descriptions for non-parametrized tests
@@ -110,6 +111,9 @@ TEST_DESCRIPTIONS = {
     "test_greeting_no_tools_live": "Live: greeting should not trigger tool calls",
     "test_user_instructions_no_tools_live": "Live: user instructions don't trigger tool calls",
     "test_weather_still_triggers_tools_live": "Live: weather query triggers tools",
+    # Helpfulness / anti-deflection tests
+    "test_no_deflection_for_weather_forecast_live": "Live: no deflection for weather forecasts",
+    "test_no_deflection_for_answerable_queries_live": "Live: no deflection for answerable queries",
 }
 
 

--- a/evals/test_agent_behavior.py
+++ b/evals/test_agent_behavior.py
@@ -28,6 +28,27 @@ from helpers import (
 # Test Data
 # =============================================================================
 
+MOCK_WEATHER_FORECAST = """Current weather in Tbilisi, Tbilisi, Georgia:
+
+Conditions: Slight rain
+Temperature: 6.1°C (43.0°F)
+Humidity: 80%
+Wind: 10.0 km/h
+
+Today's forecast (upcoming hours):
+  15:00 — 8.0°C, Partly cloudy
+  18:00 — 6.5°C, Clear sky
+  21:00 — 4.0°C, Clear sky
+
+7-day forecast:
+  2026-04-08: 3–8°C, Slight rain
+  2026-04-09: 5–14°C, Partly cloudy
+  2026-04-10: 7–16°C, Clear sky
+  2026-04-11: 6–13°C, Overcast
+  2026-04-12: 4–11°C, Slight rain
+  2026-04-13: 5–12°C, Partly cloudy
+  2026-04-14: 6–15°C, Clear sky"""
+
 MOCK_WEATHER_SEARCH = """Web search results for 'weather London UK this week':
 1. **BBC Weather** - https://www.bbc.co.uk/weather/2643743
 2. **Met Office** - https://www.metoffice.gov.uk/weather/forecast/gcpvj0v07
@@ -189,7 +210,7 @@ class TestContextUtilization:
         mock_tool_run = create_mock_tool_run(capture, {"webSearch": MOCK_WEATHER_SEARCH})
 
         call_count = 0
-        def mock_chat(base_url, chat_model, messages, timeout_sec, extra_options=None, tools=None):
+        def mock_chat(base_url, chat_model, messages, timeout_sec, extra_options=None, tools=None, **kwargs):
             nonlocal call_count
             call_count += 1
 
@@ -244,7 +265,7 @@ class TestToolUsage:
         })
 
         call_count = 0
-        def mock_chat(base_url, chat_model, messages, timeout_sec, extra_options=None, tools=None):
+        def mock_chat(base_url, chat_model, messages, timeout_sec, extra_options=None, tools=None, **kwargs):
             nonlocal call_count
             call_count += 1
             if call_count == 1:
@@ -278,7 +299,7 @@ class TestToolUsage:
         })
 
         call_count = 0
-        def mock_chat(base_url, chat_model, messages, timeout_sec, extra_options=None, tools=None):
+        def mock_chat(base_url, chat_model, messages, timeout_sec, extra_options=None, tools=None, **kwargs):
             nonlocal call_count
             call_count += 1
 
@@ -341,7 +362,7 @@ class TestMultiStepReasoning:
         })
 
         call_count = 0
-        def mock_chat(base_url, chat_model, messages, timeout_sec, extra_options=None, tools=None):
+        def mock_chat(base_url, chat_model, messages, timeout_sec, extra_options=None, tools=None, **kwargs):
             nonlocal call_count
             call_count += 1
 
@@ -400,7 +421,7 @@ class TestMultiStepReasoning:
         call_count = 0
         has_recalled_memory = False
 
-        def mock_chat(base_url, chat_model, messages, timeout_sec, extra_options=None, tools=None):
+        def mock_chat(base_url, chat_model, messages, timeout_sec, extra_options=None, tools=None, **kwargs):
             nonlocal call_count, has_recalled_memory
             call_count += 1
 
@@ -539,7 +560,7 @@ class TestMemoryEnrichment:
 
         captured_messages = []
 
-        def mock_chat(base_url, chat_model, messages, timeout_sec, extra_options=None, tools=None):
+        def mock_chat(base_url, chat_model, messages, timeout_sec, extra_options=None, tools=None, **kwargs):
             captured_messages.extend(messages)
             return create_mock_llm_response(
                 "Based on your love for Italian food and goal to eat more veggies, "
@@ -589,7 +610,7 @@ class TestMemoryEnrichment:
         })
 
         call_count = 0
-        def mock_chat(base_url, chat_model, messages, timeout_sec, extra_options=None, tools=None):
+        def mock_chat(base_url, chat_model, messages, timeout_sec, extra_options=None, tools=None, **kwargs):
             nonlocal call_count
             call_count += 1
 
@@ -752,4 +773,160 @@ class TestLiveEndToEnd:
 
         print(f"   Response mentions user interests: {response_mentions_interests}")
         print(f"   ✅ Personalized query handling: PASS")
+
+
+# =============================================================================
+# Helpfulness Evaluations (Anti-Deflection)
+# =============================================================================
+
+# Phrases that indicate the agent is deflecting instead of using its tools
+DEFLECTION_PHRASES = [
+    "check a weather app",
+    "check a local weather",
+    "check a dedicated weather",
+    "use a weather app",
+    "try a weather app",
+    "visit a weather",
+    "check online",
+    "i don't have",
+    "i do not have",
+    "i cannot check",
+    "i can't check",
+    "i'm unable to",
+    "i am unable to",
+    "beyond my capabilities",
+    "outside my capabilities",
+    "i can only check",
+    "only for today",
+    "not able to provide",
+    "unable to provide",
+    "don't have access to",
+    "do not have access to",
+    "recommend checking",
+    "suggest checking",
+]
+
+
+def _response_is_deflection(response: str) -> bool:
+    """Check if the response deflects the user to another app/service."""
+    if not response:
+        return True
+    response_lower = response.lower()
+    return any(phrase in response_lower for phrase in DEFLECTION_PHRASES)
+
+
+class TestHelpfulness:
+    """
+    Tests that the agent uses its tools proactively instead of deflecting.
+
+    The agent should NEVER tell users to "check a weather app" or "I can't do that"
+    when it has tools available to fulfil the request.
+    """
+
+    @pytest.mark.eval
+    @requires_judge_llm
+    @pytest.mark.parametrize("query", [
+        pytest.param(
+            "how's the weather going to be later today?",
+            id="No deflection: forecast later today"
+        ),
+        pytest.param(
+            "what's the weather tomorrow?",
+            id="No deflection: tomorrow weather"
+        ),
+        pytest.param(
+            "will it rain this week?",
+            id="No deflection: weekly rain forecast"
+        ),
+        pytest.param(
+            "what's the weather going to be like on Friday?",
+            id="No deflection: specific day forecast"
+        ),
+    ])
+    def test_no_deflection_for_weather_forecast_live(
+        self, query, mock_config, eval_db, eval_dialogue_memory
+    ):
+        """Live eval: agent should use tools for forecast queries, never deflect."""
+        from jarvis.reply.engine import run_reply_engine
+        from helpers import JUDGE_MODEL
+
+        mock_config.ollama_base_url = "http://localhost:11434"
+        mock_config.ollama_chat_model = JUDGE_MODEL
+
+        capture = ToolCallCapture()
+        mock_tool_run = create_mock_tool_run(capture, {
+            "getWeather": MOCK_WEATHER_FORECAST,
+            "webSearch": "Weather forecast: partly cloudy, 14°C tomorrow.",
+            "fetchWebPage": "Detailed 7-day forecast...",
+        })
+
+        with patch('jarvis.reply.engine.run_tool_with_retries', side_effect=mock_tool_run), \
+             patch('jarvis.reply.engine.get_location_context', return_value="Location: Tbilisi, Georgia"):
+
+            response = run_reply_engine(
+                db=eval_db, cfg=mock_config, tts=None,
+                text=query, dialogue_memory=eval_dialogue_memory
+            )
+
+        tools_used = capture.tool_names()
+
+        print(f"\n📊 Anti-Deflection (Weather Forecast):")
+        print(f"   Query: {query}")
+        print(f"   Tools called: {tools_used}")
+        print(f"   Response: {(response or '')[:150]}...")
+
+        # Must have used at least one tool
+        assert capture.has_any_tool(), \
+            f"Agent should use tools for weather forecast, not respond from knowledge. " \
+            f"Response: {(response or '')[:200]}"
+
+        # Must NOT deflect
+        assert not _response_is_deflection(response or ""), \
+            f"Agent deflected instead of using its tools. Response: {(response or '')[:300]}"
+
+    @pytest.mark.eval
+    @requires_judge_llm
+    @pytest.mark.parametrize("query", [
+        pytest.param(
+            "what's the latest news in tech?",
+            id="No deflection: tech news"
+        ),
+        pytest.param(
+            "what time is it in Tokyo?",
+            id="No deflection: time query"
+        ),
+    ])
+    def test_no_deflection_for_answerable_queries_live(
+        self, query, mock_config, eval_db, eval_dialogue_memory
+    ):
+        """Live eval: agent should use tools for answerable queries, never deflect."""
+        from jarvis.reply.engine import run_reply_engine
+        from helpers import JUDGE_MODEL
+
+        mock_config.ollama_base_url = "http://localhost:11434"
+        mock_config.ollama_chat_model = JUDGE_MODEL
+
+        capture = ToolCallCapture()
+        mock_tool_run = create_mock_tool_run(capture, {
+            "webSearch": "Top tech news: AI advances, new chip announcements.",
+            "fetchWebPage": "Detailed article about tech trends...",
+            "getWeather": "Current time info...",
+        })
+
+        with patch('jarvis.reply.engine.run_tool_with_retries', side_effect=mock_tool_run), \
+             patch('jarvis.reply.engine.get_location_context', return_value="Location: Tbilisi, Georgia"):
+
+            response = run_reply_engine(
+                db=eval_db, cfg=mock_config, tts=None,
+                text=query, dialogue_memory=eval_dialogue_memory
+            )
+
+        print(f"\n📊 Anti-Deflection (General):")
+        print(f"   Query: {query}")
+        print(f"   Tools called: {capture.tool_names()}")
+        print(f"   Response: {(response or '')[:150]}...")
+
+        # Should not deflect for queries the agent can handle
+        assert not _response_is_deflection(response or ""), \
+            f"Agent deflected instead of being helpful. Response: {(response or '')[:300]}"
 

--- a/src/jarvis/listening/listener.py
+++ b/src/jarvis/listening/listener.py
@@ -410,6 +410,7 @@ class VoiceListener(threading.Thread):
                 aliases = list(set(getattr(self.cfg, "wake_aliases", [])) | {wake_word})
                 fuzzy_ratio = float(getattr(self.cfg, "wake_fuzzy_ratio", 0.78))
                 if is_wake_word_detected(text_lower, wake_word, aliases, fuzzy_ratio):
+                    self._wake_timestamp = utterance_start_time
                     self._start_thinking_tune()
                     self._set_face_state_listening()
                     debug_log("early beep: wake word detected", "voice")

--- a/src/jarvis/tools/builtin/weather.py
+++ b/src/jarvis/tools/builtin/weather.py
@@ -51,7 +51,11 @@ class WeatherTool(Tool):
 
     @property
     def description(self) -> str:
-        return "Get current weather conditions. If no location specified, uses the user's current location automatically."
+        return (
+            "Get current weather conditions and forecast (hourly for today, daily for the next week). "
+            "Use this for ANY weather question — current, later today, tomorrow, this week, etc. "
+            "If no location specified, uses the user's current location automatically."
+        )
 
     @property
     def inputSchema(self) -> Dict[str, Any]:
@@ -181,12 +185,15 @@ class WeatherTool(Tool):
                 location_display = user_loc["display_name"]
                 debug_log(f"    📍 using detected location: {location_display} ({lat}, {lon})", "tools")
 
-            # Step 2: Get current weather
+            # Step 2: Get current weather + forecast
             weather_url = "https://api.open-meteo.com/v1/forecast"
             weather_params = {
                 "latitude": lat,
                 "longitude": lon,
                 "current": "temperature_2m,relative_humidity_2m,apparent_temperature,weather_code,wind_speed_10m,wind_gusts_10m",
+                "hourly": "temperature_2m,weather_code",
+                "daily": "weather_code,temperature_2m_max,temperature_2m_min",
+                "forecast_days": 7,
                 "temperature_unit": "celsius",
                 "wind_speed_unit": "kmh",
                 "timezone": "auto"
@@ -203,7 +210,7 @@ class WeatherTool(Tool):
                     reply_text=f"Weather data temporarily unavailable for {location_display}."
                 )
 
-            # Extract weather values
+            # Extract current weather values
             temp_c = current.get("temperature_2m")
             feels_like_c = current.get("apparent_temperature")
             humidity = current.get("relative_humidity_2m")
@@ -218,7 +225,7 @@ class WeatherTool(Tool):
             # Get weather description
             weather_desc = WMO_CODES.get(weather_code, "Unknown conditions")
 
-            # Build response text
+            # Build response text — current conditions
             lines = [
                 f"Current weather in {location_display}:",
                 f"",
@@ -239,6 +246,50 @@ class WeatherTool(Tool):
                 if wind_gusts and wind_gusts > wind_speed:
                     wind_info += f" (gusts up to {wind_gusts} km/h)"
                 lines.append(wind_info)
+
+            # Append today's hourly forecast (remaining hours)
+            hourly = weather_data.get("hourly", {})
+            hourly_times = hourly.get("time", [])
+            hourly_temps = hourly.get("temperature_2m", [])
+            hourly_codes = hourly.get("weather_code", [])
+
+            if hourly_times and hourly_temps:
+                # Get current hour from the current time field
+                current_time = current.get("time", "")
+                current_hour_str = current_time[11:13] if len(current_time) >= 13 else ""
+                current_hour = int(current_hour_str) if current_hour_str.isdigit() else 0
+                today_prefix = current_time[:10] if len(current_time) >= 10 else ""
+
+                hourly_lines = []
+                for i, t in enumerate(hourly_times):
+                    if not t.startswith(today_prefix):
+                        continue
+                    hour_str = t[11:13] if len(t) >= 13 else ""
+                    hour = int(hour_str) if hour_str.isdigit() else -1
+                    # Show every 3 hours from now onwards
+                    if hour > current_hour and hour % 3 == 0 and i < len(hourly_temps) and i < len(hourly_codes):
+                        desc = WMO_CODES.get(hourly_codes[i], "")
+                        hourly_lines.append(f"  {hour:02d}:00 — {hourly_temps[i]}°C, {desc}")
+
+                if hourly_lines:
+                    lines.append("")
+                    lines.append("Today's forecast (upcoming hours):")
+                    lines.extend(hourly_lines)
+
+            # Append daily forecast
+            daily = weather_data.get("daily", {})
+            daily_dates = daily.get("time", [])
+            daily_codes = daily.get("weather_code", [])
+            daily_max = daily.get("temperature_2m_max", [])
+            daily_min = daily.get("temperature_2m_min", [])
+
+            if daily_dates and daily_max and daily_min:
+                lines.append("")
+                lines.append("7-day forecast:")
+                for i, date_str in enumerate(daily_dates):
+                    if i < len(daily_max) and i < len(daily_min) and i < len(daily_codes):
+                        desc = WMO_CODES.get(daily_codes[i], "")
+                        lines.append(f"  {date_str}: {daily_min[i]}–{daily_max[i]}°C, {desc}")
 
             reply_text = "\n".join(lines)
 

--- a/tests/test_query_validation.py
+++ b/tests/test_query_validation.py
@@ -225,6 +225,94 @@ class TestIntentJudgeWakeWordValidation:
         assert hot_query != intent_judgment_query
 
 
+class TestWakeTimestampCapture:
+    """Tests that _wake_timestamp is set when a wake word is detected.
+
+    Bug fix: _wake_timestamp was never set, only initialised to None and
+    cleared. This meant the intent judge always received wake_timestamp=None,
+    so it never marked segments with "(WAKE WORD DETECTED)" and fell back to
+    incorrect reasoning — classifying directed queries as not directed.
+    """
+
+    def test_wake_timestamp_set_on_wake_word_detection(self):
+        """_wake_timestamp is set to utterance_start_time when wake word is detected."""
+        from unittest.mock import MagicMock, patch, PropertyMock
+
+        # Build a minimal listener-like object with _process_transcript behaviour
+        listener = MagicMock()
+        listener._wake_timestamp = None
+        listener.tts = None
+        listener.cfg = MagicMock()
+        listener.cfg.wake_word = "jarvis"
+        listener.cfg.wake_aliases = []
+        listener.cfg.wake_fuzzy_ratio = 0.78
+
+        # Simulate the logic from _process_transcript early beep section
+        text_lower = "jarvis what's the weather tomorrow"
+        utterance_start_time = 1000.5
+        in_hot_window = False
+
+        wake_word = listener.cfg.wake_word
+        aliases = list(set(listener.cfg.wake_aliases) | {wake_word})
+        fuzzy_ratio = float(listener.cfg.wake_fuzzy_ratio)
+
+        if not in_hot_window:
+            if is_wake_word_detected(text_lower, wake_word, aliases, fuzzy_ratio):
+                listener._wake_timestamp = utterance_start_time
+
+        assert listener._wake_timestamp == 1000.5, \
+            "_wake_timestamp should be set to utterance_start_time when wake word detected"
+
+    def test_wake_timestamp_not_set_without_wake_word(self):
+        """_wake_timestamp stays None when no wake word is present."""
+        listener = MagicMock()
+        listener._wake_timestamp = None
+        listener.cfg = MagicMock()
+        listener.cfg.wake_word = "jarvis"
+        listener.cfg.wake_aliases = []
+        listener.cfg.wake_fuzzy_ratio = 0.78
+
+        text_lower = "what's the weather tomorrow"
+        utterance_start_time = 1000.5
+        in_hot_window = False
+
+        wake_word = listener.cfg.wake_word
+        aliases = list(set(listener.cfg.wake_aliases) | {wake_word})
+        fuzzy_ratio = float(listener.cfg.wake_fuzzy_ratio)
+
+        if not in_hot_window:
+            if is_wake_word_detected(text_lower, wake_word, aliases, fuzzy_ratio):
+                listener._wake_timestamp = utterance_start_time
+
+        assert listener._wake_timestamp is None, \
+            "_wake_timestamp should stay None when no wake word detected"
+
+    def test_wake_timestamp_not_set_in_hot_window(self):
+        """_wake_timestamp is not set in hot window mode (no wake word needed)."""
+        listener = MagicMock()
+        listener._wake_timestamp = None
+        listener.cfg = MagicMock()
+        listener.cfg.wake_word = "jarvis"
+        listener.cfg.wake_aliases = []
+        listener.cfg.wake_fuzzy_ratio = 0.78
+
+        text_lower = "jarvis what's the weather"
+        utterance_start_time = 1000.5
+        in_hot_window = True
+
+        wake_word = listener.cfg.wake_word
+        aliases = list(set(listener.cfg.wake_aliases) | {wake_word})
+        fuzzy_ratio = float(listener.cfg.wake_fuzzy_ratio)
+
+        # In hot window, we skip wake word detection
+        if not in_hot_window:
+            if is_wake_word_detected(text_lower, wake_word, aliases, fuzzy_ratio):
+                listener._wake_timestamp = utterance_start_time
+
+        assert listener._wake_timestamp is None, \
+            "_wake_timestamp should not be set in hot window mode"
+
+
 class TestStateTimingScenarios:
     """Tests for state timing and transitions.
 

--- a/tests/tools/builtin/test_weather.py
+++ b/tests/tools/builtin/test_weather.py
@@ -30,7 +30,7 @@ class TestWeatherTool:
 
     @patch('requests.get')
     def test_run_success(self, mock_get):
-        """Test successful weather retrieval."""
+        """Test successful weather retrieval with current + forecast data."""
         # First call: geocoding
         geo_response = Mock()
         geo_response.status_code = 200
@@ -45,18 +45,30 @@ class TestWeatherTool:
         }
         geo_response.raise_for_status = Mock()
 
-        # Second call: weather
+        # Second call: weather (now includes hourly + daily forecast)
         weather_response = Mock()
         weather_response.status_code = 200
         weather_response.json.return_value = {
             "current": {
+                "time": "2026-04-08T14:00",
                 "temperature_2m": 15.5,
                 "apparent_temperature": 14.0,
                 "relative_humidity_2m": 65,
                 "weather_code": 2,
                 "wind_speed_10m": 12.0,
                 "wind_gusts_10m": 20.0
-            }
+            },
+            "hourly": {
+                "time": [f"2026-04-08T{h:02d}:00" for h in range(24)],
+                "temperature_2m": [10 + h * 0.5 for h in range(24)],
+                "weather_code": [2] * 24,
+            },
+            "daily": {
+                "time": [f"2026-04-{8+d:02d}" for d in range(7)],
+                "weather_code": [2, 3, 61, 0, 1, 2, 3],
+                "temperature_2m_max": [16, 14, 12, 17, 18, 15, 13],
+                "temperature_2m_min": [8, 7, 5, 9, 10, 8, 6],
+            },
         }
         weather_response.raise_for_status = Mock()
 
@@ -71,6 +83,9 @@ class TestWeatherTool:
         assert "15.5°C" in result.reply_text
         assert "Partly cloudy" in result.reply_text  # WMO code 2
         assert "65%" in result.reply_text  # humidity
+        # Verify forecast sections are present
+        assert "Today's forecast" in result.reply_text
+        assert "7-day forecast" in result.reply_text
         self.context.user_print.assert_called()
 
     @patch('requests.get')
@@ -206,6 +221,65 @@ class TestWeatherTool:
         assert WMO_CODES[95] == "Thunderstorm"
         # Ensure there are many codes covered
         assert len(WMO_CODES) >= 20
+
+    @patch('requests.get')
+    def test_forecast_includes_hourly_and_daily(self, mock_get):
+        """Test that forecast data includes today's hourly and 7-day daily sections."""
+        geo_response = Mock()
+        geo_response.status_code = 200
+        geo_response.json.return_value = {
+            "results": [{
+                "latitude": 41.6938,
+                "longitude": 44.8015,
+                "name": "Tbilisi",
+                "country": "Georgia",
+                "admin1": "Tbilisi"
+            }]
+        }
+        geo_response.raise_for_status = Mock()
+
+        weather_response = Mock()
+        weather_response.status_code = 200
+        weather_response.json.return_value = {
+            "current": {
+                "time": "2026-04-08T10:00",
+                "temperature_2m": 12.0,
+                "apparent_temperature": 10.0,
+                "relative_humidity_2m": 70,
+                "weather_code": 61,
+                "wind_speed_10m": 8.0,
+                "wind_gusts_10m": 15.0
+            },
+            "hourly": {
+                "time": [f"2026-04-08T{h:02d}:00" for h in range(24)],
+                "temperature_2m": [8, 8, 7, 7, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 15, 14, 13, 12, 11, 10, 9, 9, 8],
+                "weather_code": [61] * 12 + [2] * 12,
+            },
+            "daily": {
+                "time": [f"2026-04-{8+d:02d}" for d in range(7)],
+                "weather_code": [61, 3, 0, 1, 2, 61, 0],
+                "temperature_2m_max": [16, 18, 20, 19, 17, 14, 21],
+                "temperature_2m_min": [7, 8, 10, 9, 8, 6, 11],
+            },
+        }
+        weather_response.raise_for_status = Mock()
+
+        mock_get.side_effect = [geo_response, weather_response]
+
+        result = self.tool.run({"location": "Tbilisi"}, self.context)
+
+        assert result.success is True
+        # Current conditions
+        assert "12" in result.reply_text
+        assert "Slight rain" in result.reply_text
+        # Hourly forecast for remaining hours (every 3 hours after hour 10)
+        assert "Today's forecast" in result.reply_text
+        assert "12:00" in result.reply_text
+        assert "15:00" in result.reply_text
+        # Daily forecast
+        assert "7-day forecast" in result.reply_text
+        assert "2026-04-09" in result.reply_text
+        assert "2026-04-14" in result.reply_text
 
     @patch('requests.get')
     def test_temperature_conversion(self, mock_get):


### PR DESCRIPTION
## Summary
- **Weather tool now fetches hourly (today) + daily (7-day) forecasts** from Open-Meteo, not just current conditions. Updated the tool description so the LLM knows it can answer any weather question (tomorrow, this week, specific days, etc.).
- **Added live anti-deflection evals** that verify the agent uses its tools instead of telling users to "check a weather app" — covers forecast queries and general answerable queries.
- **Fixed `_wake_timestamp` never being set** — it was initialised to `None` and only ever cleared, never actually captured. The intent judge always received `wake_timestamp=None`, so it never marked segments with "(WAKE WORD DETECTED)" and fell back to incorrect reasoning, classifying directed queries as not directed.
- **Fixed `mock_chat` signatures** across all eval tests for the new `thinking` kwarg from #154.

## Test plan
- [x] All 172 unit tests pass (including 3 new wake timestamp tests)
- [x] 4 new live anti-deflection evals pass (forecast later today, tomorrow, weekly, specific day)
- [x] All existing mocked evals pass
- [ ] Run full eval suite to check pass rates across both models
- [ ] Manual test: say "Jarvis, how's the weather tomorrow?" and verify it answers with forecast data

🤖 Generated with [Claude Code](https://claude.com/claude-code)