### PR TITLE
fix: auto-recover from corrupted Whisper model cache (#155)

### DIFF
--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -1,0 +1,178 @@
+---
+name: review-pr
+description: >
+  Multi-agent adversarial PR review. Spawns parallel specialist agents
+  (correctness, security, performance, maintainability, completeness) then
+  a verifier agent that challenges every finding. Only verified issues survive.
+  Accepts an optional PR number or URL; defaults to the current branch's open PR.
+argument-hint: "[PR number or URL]"
+---
+
+# Multi-Agent Adversarial PR Review
+
+You are an orchestrator for a thorough, multi-perspective pull request review.
+Your job is to gather PR context, spawn specialist review agents in parallel,
+then run a verification pass to filter out false positives.
+
+## Step 1 — Gather PR Context
+
+Determine the PR to review:
+- If `$ARGUMENTS` is provided, use it (a PR number, URL, or branch name).
+- Otherwise, detect the current branch and find its open PR.
+
+Use the GitHub MCP tools (or `gh` CLI if MCP is unavailable) to fetch:
+1. **PR metadata**: title, body, author, base branch, labels
+2. **Full diff**: the complete code diff
+3. **Changed file list**: just the filenames for targeted exploration
+4. **PR comments/reviews**: any existing review feedback
+5. **CI status**: check if CI is passing or failing
+
+Also read the project's `CLAUDE.md` for coding conventions the review should enforce.
+
+Store all this context — you will include it in each specialist agent's prompt.
+
+## Step 2 — Spawn Specialist Agents (Parallel)
+
+Launch **all five** specialist agents simultaneously using the Agent tool.
+Each agent receives the full diff, changed file list, PR description, and
+project conventions. Each must output a structured list of findings.
+
+### Agent 1: Correctness Reviewer
+Focus: Logic bugs, edge cases, regressions.
+- Off-by-one errors, null/undefined handling, race conditions
+- Broken invariants, incorrect control flow
+- State management issues (missing assignments, leaked state)
+- Regressions: does this change break existing behaviour?
+- Read surrounding code (not just the diff) to understand context
+
+### Agent 2: Security Reviewer
+Focus: Vulnerabilities and unsafe patterns.
+- Injection (SQL, command, XSS, path traversal)
+- Authentication/authorisation bypass
+- Secrets or credentials in code
+- Unsafe deserialisation, SSRF, open redirects
+- Cryptographic misuse, insecure randomness
+- Dependency vulnerabilities (if new deps added)
+
+### Agent 3: Performance Reviewer
+Focus: Efficiency and scalability.
+- N+1 queries, unnecessary allocations, missing caching
+- O(n²) or worse algorithms where linear is possible
+- Blocking calls in async/event-loop contexts
+- Memory leaks, unbounded growth (queues, buffers, caches)
+- Unnecessary I/O, redundant network calls
+
+### Agent 4: Maintainability Reviewer
+Focus: Design quality and readability.
+- SOLID principle violations, excessive coupling
+- Code duplication (DRY violations)
+- Naming clarity (variables, functions, classes)
+- Missing or misleading comments/docstrings
+- Overly complex logic that could be simplified
+- Inconsistency with project conventions (from CLAUDE.md)
+
+### Agent 5: Completeness Reviewer
+Focus: What's missing.
+- Missing test coverage for new/changed code paths
+- Missing error handling for failure modes
+- Undocumented behaviour changes (README, specs, CHANGELOG)
+- Spec drift: do changes contradict any spec files?
+- Missing migration steps or configuration updates
+- Edge cases not addressed in the implementation
+
+### Agent Prompt Template
+
+Each agent's prompt MUST include:
+1. The full diff
+2. The changed file list
+3. The PR description
+4. Relevant project conventions from CLAUDE.md
+5. Instruction to READ the surrounding code in changed files (not just the diff lines) for full context
+6. Instruction to output findings as a structured list:
+
+```
+For each finding, output:
+- **File**: path/to/file.py:LINE
+- **Severity**: critical / high / medium / low
+- **Category**: bug / security / performance / design / missing
+- **Confidence**: high / medium / low
+- **Description**: What the issue is and why it matters
+- **Suggestion**: Concrete fix or alternative approach
+```
+
+7. Instruction: if no issues found in your area, explicitly state "No issues found" — do not invent findings to appear thorough.
+8. Instruction: only report issues with confidence >= medium. Do not report style nits unless they violate project conventions.
+
+## Step 3 — Verification Phase (Adversarial)
+
+After ALL specialist agents complete, spawn a single **Verifier Agent** that
+receives every finding from all specialists. The verifier's job is to
+**challenge and disprove** each finding:
+
+### Verifier Agent Instructions
+
+You are a devil's advocate. For EACH finding from the specialist reviewers:
+
+1. **Read the actual code** (not just the diff) — the "bug" may be handled
+   elsewhere in the codebase.
+2. **Check if the concern is mitigated** by framework defaults, type system
+   guarantees, or existing validation.
+3. **Verify the severity** — is this really critical, or is it a cosmetic issue
+   dressed up as a bug?
+4. **Check for duplicates** — multiple specialists may report the same issue
+   in different words.
+5. **Assess confidence** — is the specialist making assumptions about runtime
+   behaviour without evidence?
+
+For each finding, output one of:
+- **VERIFIED** — the issue is real and correctly categorised
+- **DOWNGRADED** — the issue exists but severity/confidence should be lower (explain why)
+- **DISMISSED** — the issue is a false positive (explain why)
+- **DUPLICATE** — already covered by another finding (reference which one)
+
+## Step 4 — Synthesise Final Report
+
+Collect all VERIFIED and DOWNGRADED findings. Produce a final review report:
+
+### Report Format
+
+```markdown
+## PR Review: <PR title>
+
+### Summary
+<2-3 sentence overview of the PR and overall assessment>
+
+### Critical / High Issues
+<Only VERIFIED findings with severity critical or high>
+
+### Medium Issues
+<VERIFIED findings with severity medium>
+
+### Suggestions
+<DOWNGRADED findings and low-severity items, briefly>
+
+### What Looks Good
+<Positive observations — good patterns, thorough tests, clean design>
+
+### Verdict
+<One of: APPROVE / REQUEST_CHANGES / COMMENT>
+<Brief justification>
+```
+
+### Rules for the Final Report
+- Lead with the most important issues
+- Be specific: include file paths, line numbers, and code snippets
+- Be constructive: every criticism must include a concrete suggestion
+- Acknowledge what's done well — reviews should be balanced
+- If no critical/high issues exist, lean towards APPROVE
+- Use the project's conventions (British English, emojis for emphasis)
+
+## Important Guidelines
+
+- **Do NOT make changes to code** — this is a read-only review
+- **Do NOT post the review to GitHub** unless explicitly asked
+- **Be thorough but not noisy** — quality over quantity
+- **Respect the author's intent** — understand why before criticising what
+- Each specialist agent should use `subagent_type: "Explore"` for efficient codebase reading
+- The verifier agent should use `subagent_type: "general-purpose"` for deeper reasoning
+- When spawning agents, always include the full diff and context in the prompt — agents have no memory of this conversation

--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,9 @@ __pycache__/
 .pytest_cache/
 .mamba_env/
 .micromamba/
-.claude/
+.claude/*
 !.claude/launch.json
+!.claude/skills/
 
 # Release artifacts
 release_output.log

--- a/src/jarvis/listening/listener.py
+++ b/src/jarvis/listening/listener.py
@@ -1491,7 +1491,19 @@ class VoiceListener(threading.Thread):
                                 ct2_model = getattr(self.model, "model", None)
                                 resolved_device = str(getattr(ct2_model, "device", try_device)).lower()
                                 debug_log(f"faster-whisper initialised after cache recovery: name={model_name}, device={resolved_device}, compute={try_compute}", "voice")
+
+                                used_device = try_device
+                                used_compute = try_compute
                                 self._whisper_device = resolved_device
+
+                                # Show warnings if we fell back to different settings
+                                if try_device != device and device in ("auto", "cuda"):
+                                    print(f"  ⚠️  CUDA not available, using CPU (this may be slower)", flush=True)
+                                    print(f"  💡 Tip: Install NVIDIA CUDA toolkit for faster speech recognition", flush=True)
+                                if try_compute != compute:
+                                    print(f"  ⚠️  Using '{try_compute}' compute type ('{compute}' not supported)", flush=True)
+                                if resolved_device == "cpu":
+                                    print(f"  ⚡ CPU mode: using {cpu_threads} threads with optimised decoding", flush=True)
                                 print(f"  ✅ Whisper model '{model_name}' loaded on {resolved_device} (recovered)", flush=True)
                                 last_error = None
                                 break

--- a/src/jarvis/listening/listener.py
+++ b/src/jarvis/listening/listener.py
@@ -190,6 +190,55 @@ def _get_mlx_model_repo(model_name: str) -> str:
     return model_map.get(model_name, f"mlx-community/whisper-{model_name}-mlx")
 
 
+def _clear_corrupted_whisper_cache(error_message: str) -> bool:
+    """Clear a corrupted Whisper model cache directory.
+
+    Parses the CTranslate2 error message to find the snapshot directory,
+    then deletes the parent ``models--`` directory so the model can be
+    re-downloaded cleanly (including blobs that may also be corrupt).
+
+    Returns ``True`` if a cache directory was found and deleted.
+    """
+    import re
+    import shutil
+
+    # CTranslate2 error format:
+    #   "Unable to open file 'model.bin' in model '/path/to/snapshots/hash'"
+    match = re.search(
+        r"unable to open file\s+'[^']+'\s+in model\s+'([^']+)'",
+        error_message,
+        re.IGNORECASE,
+    )
+    if not match:
+        debug_log("could not parse cache path from error message", "voice")
+        return False
+
+    snapshot_path = match.group(1)
+
+    # Walk up to the models-- directory
+    # snapshot_path is e.g. .../models--Org--Name/snapshots/<hash>
+    # We want to delete .../models--Org--Name entirely
+    from pathlib import Path
+    path = Path(snapshot_path)
+    model_dir = None
+    for parent in [path] + list(path.parents):
+        if parent.name.startswith("models--"):
+            model_dir = parent
+            break
+
+    if model_dir is None or not model_dir.is_dir():
+        debug_log(f"could not locate models-- cache directory from: {snapshot_path}", "voice")
+        return False
+
+    try:
+        shutil.rmtree(model_dir)
+        debug_log(f"cleared corrupted Whisper cache: {model_dir}", "voice")
+        return True
+    except OSError as e:
+        debug_log(f"failed to clear corrupted cache: {e}", "voice")
+        return False
+
+
 class VoiceListener(threading.Thread):
     """Main voice listening thread that orchestrates all voice processing."""
 
@@ -1423,6 +1472,38 @@ class VoiceListener(threading.Thread):
                     if is_cuda_error or is_compute_error:
                         debug_log(f"config ({try_device}, {try_compute}) failed, trying fallback: {e}", "voice")
                         continue
+
+                    # Check for corrupted model cache (e.g. interrupted download)
+                    is_corrupted_cache = "unable to open file" in error_str
+
+                    if is_corrupted_cache:
+                        debug_log(f"detected corrupted Whisper model cache: {e}", "voice")
+                        print("  ⚠️  Whisper model cache appears corrupted, attempting recovery...", flush=True)
+
+                        cache_cleared = _clear_corrupted_whisper_cache(str(e))
+                        if cache_cleared:
+                            try:
+                                print(f"  🔄 Re-downloading Whisper model '{model_name}'...", flush=True)
+                                self.model = WhisperModel(
+                                    model_name, device=try_device, compute_type=try_compute,
+                                    cpu_threads=cpu_threads,
+                                )
+                                ct2_model = getattr(self.model, "model", None)
+                                resolved_device = str(getattr(ct2_model, "device", try_device)).lower()
+                                debug_log(f"faster-whisper initialised after cache recovery: name={model_name}, device={resolved_device}, compute={try_compute}", "voice")
+                                self._whisper_device = resolved_device
+                                print(f"  ✅ Whisper model '{model_name}' loaded on {resolved_device} (recovered)", flush=True)
+                                last_error = None
+                                break
+                            except Exception as retry_e:
+                                debug_log(f"retry after cache clear also failed: {retry_e}", "voice")
+                                print(f"  ❌ Failed to load Whisper model after cache recovery: {retry_e}", flush=True)
+                                return
+                        else:
+                            debug_log("could not clear corrupted cache automatically", "voice")
+                            print(f"  ❌ Failed to load Whisper model: {e}", flush=True)
+                            print("  💡 Try manually deleting the Whisper model cache directory and restarting", flush=True)
+                            return
                     else:
                         # For other errors (model not found, network issues, etc.), don't try fallbacks
                         debug_log(f"failed to initialize faster-whisper: {e}", "voice")

--- a/src/jarvis/listening/listener.py
+++ b/src/jarvis/listening/listener.py
@@ -245,7 +245,7 @@ class VoiceListener(threading.Thread):
     def __init__(self, db: "Database", cfg, tts: Optional[Any],
                  dialogue_memory: "DialogueMemory"):
         """
-        Initialize voice listener.
+        Initialise voice listener.
 
         Args:
             db: Database instance for storage
@@ -283,14 +283,14 @@ class VoiceListener(threading.Thread):
         self._samplerate = int(getattr(self.cfg, "sample_rate", 16000))
         self._vad: Optional = None
 
-        # Initialize VAD if available
+        # Initialise VAD if available
         if webrtcvad is not None and bool(getattr(self.cfg, "vad_enabled", True)):
             try:
                 self._vad = webrtcvad.Vad(int(getattr(self.cfg, "vad_aggressiveness", 2)))
             except Exception:
                 self._vad = None
 
-        # Initialize modular components
+        # Initialise modular components
         self.echo_detector = EchoDetector(
             echo_tolerance=float(getattr(self.cfg, "echo_tolerance", 0.3)),
             energy_spike_threshold=float(getattr(self.cfg, "echo_energy_threshold", 2.0))
@@ -313,12 +313,12 @@ class VoiceListener(threading.Thread):
         # Used for both retention and context passed to intent judge
         self._buffer_duration = float(getattr(self.cfg, "transcript_buffer_duration_sec", 120.0))
         self._transcript_buffer = TranscriptBuffer(max_duration_sec=self._buffer_duration)
-        debug_log(f"transcript buffer initialized ({self._buffer_duration}s)", "voice")
+        debug_log(f"transcript buffer initialised ({self._buffer_duration}s)", "voice")
 
         # Intent judge (full context, larger model) - always used when available
         self._intent_judge = create_intent_judge(self.cfg)
         if self._intent_judge is not None:
-            debug_log(f"intent judge initialized (model: {self._intent_judge.config.model})", "voice")
+            debug_log(f"intent judge initialised (model: {self._intent_judge.config.model})", "voice")
         else:
             debug_log("intent judge unavailable, using simple wake word detection", "voice")
 
@@ -1240,6 +1240,37 @@ class VoiceListener(threading.Thread):
 
         return "faster-whisper"
 
+    def _apply_whisper_load_success(
+        self, model_name: str, try_device: str, try_compute: str,
+        device: str, compute: str, cpu_threads: int,
+        context: str = "",
+    ) -> str:
+        """Record state and print diagnostics after a successful Whisper model load.
+
+        Returns the resolved device string.
+        """
+        ct2_model = getattr(self.model, "model", None)
+        resolved_device = str(getattr(ct2_model, "device", try_device)).lower()
+        debug_log(
+            f"faster-whisper initialised{context}: name={model_name}, "
+            f"device={resolved_device}, compute={try_compute}, "
+            f"cpu_threads={cpu_threads}",
+            "voice",
+        )
+        self._whisper_device = resolved_device
+
+        if try_device != device and device in ("auto", "cuda"):
+            print("  ⚠️  CUDA not available, using CPU (this may be slower)", flush=True)
+            print("  💡 Tip: Install NVIDIA CUDA toolkit for faster speech recognition", flush=True)
+        if try_compute != compute:
+            print(f"  ⚠️  Using '{try_compute}' compute type ('{compute}' not supported)", flush=True)
+        if resolved_device == "cpu":
+            print(f"  ⚡ CPU mode: using {cpu_threads} threads with optimised decoding", flush=True)
+
+        suffix = f" ({context})" if context else ""
+        print(f"  ✅ Whisper model '{model_name}' loaded on {resolved_device}{suffix}", flush=True)
+        return resolved_device
+
     def run(self) -> None:
         """Main voice listening loop."""
         if sd is None:
@@ -1251,7 +1282,7 @@ class VoiceListener(threading.Thread):
         try:
             devices = sd.query_devices()
             input_devices = [d for d in devices if d.get('max_input_channels', 0) > 0]
-            debug_log(f"PortAudio initialized: {len(input_devices)} input device(s) found", "voice")
+            debug_log(f"PortAudio initialised: {len(input_devices)} input device(s) found", "voice")
             if not input_devices:
                 print("  ❌ No microphone found. Please connect a microphone.", flush=True)
                 return
@@ -1294,7 +1325,7 @@ class VoiceListener(threading.Thread):
                     print("", flush=True)
                 return
 
-        # Determine and initialize Whisper backend
+        # Determine and initialise Whisper backend
         self._whisper_backend = self._determine_whisper_backend()
         model_name = getattr(self.cfg, "whisper_model", "small")
 
@@ -1317,26 +1348,41 @@ class VoiceListener(threading.Thread):
                 print("  ❌ MLX Whisper not available. Install with: pip install mlx-whisper", flush=True)
                 return
 
-            try:
-                self._mlx_model_repo = _get_mlx_model_repo(model_name)
-                print(f"  🔄 Loading MLX Whisper model '{model_name}' (Apple Silicon GPU)...", flush=True)
+            self._mlx_model_repo = _get_mlx_model_repo(model_name)
+            print(f"  🔄 Loading MLX Whisper model '{model_name}' (Apple Silicon GPU)...", flush=True)
 
-                # Pre-load the model by doing a warmup transcription with silent audio
-                # This triggers the model download before we need it for real transcription
-                if np is not None:
-                    warmup_audio = np.zeros(self._samplerate, dtype=np.float32)  # 1 second of silence
-                    _ = mlx_whisper.transcribe(
-                        warmup_audio,
-                        path_or_hf_repo=self._mlx_model_repo,
-                        language=None,
-                    )
-                    debug_log(f"MLX Whisper model pre-loaded: repo={self._mlx_model_repo}", "voice")
+            max_retries = 4
+            for attempt in range(max_retries + 1):
+                try:
+                    # Pre-load the model by doing a warmup transcription with silent audio
+                    # This triggers the model download before we need it for real transcription
+                    if np is not None:
+                        warmup_audio = np.zeros(self._samplerate, dtype=np.float32)  # 1 second of silence
+                        _ = mlx_whisper.transcribe(
+                            warmup_audio,
+                            path_or_hf_repo=self._mlx_model_repo,
+                            language=None,
+                        )
+                        debug_log(f"MLX Whisper model pre-loaded: repo={self._mlx_model_repo}", "voice")
 
-                print(f"  ✅ MLX Whisper '{model_name}' ready (Apple Silicon GPU acceleration)", flush=True)
-            except Exception as e:
-                debug_log(f"failed to initialize MLX Whisper: {e}", "voice")
-                print(f"  ❌ Failed to initialize MLX Whisper: {e}", flush=True)
-                return
+                    print(f"  ✅ MLX Whisper '{model_name}' ready (Apple Silicon GPU acceleration)", flush=True)
+                    break
+                except Exception as e:
+                    error_str = str(e).lower()
+                    is_rate_limited = any(x in error_str for x in [
+                        "429", "too many requests", "rate limit",
+                    ])
+                    if is_rate_limited and attempt < max_retries:
+                        wait = 2 ** (attempt + 1)
+                        debug_log(f"rate limited loading MLX Whisper (attempt {attempt + 1}): {e}", "voice")
+                        print(f"  ⏳ Rate limited by HuggingFace, retrying in {wait}s ({attempt + 1}/{max_retries})...", flush=True)
+                        time.sleep(wait)
+                        continue
+                    debug_log(f"failed to initialise MLX Whisper: {e}", "voice")
+                    print(f"  ❌ Failed to initialise MLX Whisper: {e}", flush=True)
+                    if is_rate_limited:
+                        print("  💡 HuggingFace is rate limiting downloads. Please wait a few minutes and restart.", flush=True)
+                    return
         else:
             # faster-whisper backend
             if not FASTER_WHISPER_AVAILABLE:
@@ -1434,26 +1480,12 @@ class VoiceListener(threading.Thread):
                         model_name, device=try_device, compute_type=try_compute,
                         cpu_threads=cpu_threads,
                     )
-
-                    # Resolve actual device (CTranslate2 resolves "auto" internally)
-                    # Cast to str — CTranslate2 may return an enum (e.g. Device.CPU)
-                    ct2_model = getattr(self.model, "model", None)
-                    resolved_device = str(getattr(ct2_model, "device", try_device)).lower()
-                    debug_log(f"faster-whisper initialised: name={model_name}, device={resolved_device}, compute={try_compute}, cpu_threads={cpu_threads}", "voice")
-
+                    self._apply_whisper_load_success(
+                        model_name, try_device, try_compute,
+                        device, compute, cpu_threads,
+                    )
                     used_device = try_device
                     used_compute = try_compute
-                    self._whisper_device = resolved_device
-
-                    # Show warnings if we fell back to different settings
-                    if try_device != device and device in ("auto", "cuda"):
-                        print(f"  ⚠️  CUDA not available, using CPU (this may be slower)", flush=True)
-                        print(f"  💡 Tip: Install NVIDIA CUDA toolkit for faster speech recognition", flush=True)
-                    if try_compute != compute:
-                        print(f"  ⚠️  Using '{try_compute}' compute type ('{compute}' not supported)", flush=True)
-                    if resolved_device == "cpu":
-                        print(f"  ⚡ CPU mode: using {cpu_threads} threads with optimised decoding", flush=True)
-                    print(f"  ✅ Whisper model '{model_name}' loaded on {resolved_device}", flush=True)
                     last_error = None
                     break
                 except Exception as e:
@@ -1488,23 +1520,13 @@ class VoiceListener(threading.Thread):
                                     model_name, device=try_device, compute_type=try_compute,
                                     cpu_threads=cpu_threads,
                                 )
-                                ct2_model = getattr(self.model, "model", None)
-                                resolved_device = str(getattr(ct2_model, "device", try_device)).lower()
-                                debug_log(f"faster-whisper initialised after cache recovery: name={model_name}, device={resolved_device}, compute={try_compute}", "voice")
-
+                                self._apply_whisper_load_success(
+                                    model_name, try_device, try_compute,
+                                    device, compute, cpu_threads,
+                                    context="recovered",
+                                )
                                 used_device = try_device
                                 used_compute = try_compute
-                                self._whisper_device = resolved_device
-
-                                # Show warnings if we fell back to different settings
-                                if try_device != device and device in ("auto", "cuda"):
-                                    print(f"  ⚠️  CUDA not available, using CPU (this may be slower)", flush=True)
-                                    print(f"  💡 Tip: Install NVIDIA CUDA toolkit for faster speech recognition", flush=True)
-                                if try_compute != compute:
-                                    print(f"  ⚠️  Using '{try_compute}' compute type ('{compute}' not supported)", flush=True)
-                                if resolved_device == "cpu":
-                                    print(f"  ⚡ CPU mode: using {cpu_threads} threads with optimised decoding", flush=True)
-                                print(f"  ✅ Whisper model '{model_name}' loaded on {resolved_device} (recovered)", flush=True)
                                 last_error = None
                                 break
                             except Exception as retry_e:
@@ -1535,22 +1557,13 @@ class VoiceListener(threading.Thread):
                                     model_name, device=try_device, compute_type=try_compute,
                                     cpu_threads=cpu_threads,
                                 )
-                                ct2_model = getattr(self.model, "model", None)
-                                resolved_device = str(getattr(ct2_model, "device", try_device)).lower()
-                                debug_log(f"faster-whisper initialised after rate-limit retry: name={model_name}, device={resolved_device}, compute={try_compute}", "voice")
-
+                                self._apply_whisper_load_success(
+                                    model_name, try_device, try_compute,
+                                    device, compute, cpu_threads,
+                                    context="rate-limit retry",
+                                )
                                 used_device = try_device
                                 used_compute = try_compute
-                                self._whisper_device = resolved_device
-
-                                if try_device != device and device in ("auto", "cuda"):
-                                    print("  ⚠️  CUDA not available, using CPU (this may be slower)", flush=True)
-                                    print("  💡 Tip: Install NVIDIA CUDA toolkit for faster speech recognition", flush=True)
-                                if try_compute != compute:
-                                    print(f"  ⚠️  Using '{try_compute}' compute type ('{compute}' not supported)", flush=True)
-                                if resolved_device == "cpu":
-                                    print(f"  ⚡ CPU mode: using {cpu_threads} threads with optimised decoding", flush=True)
-                                print(f"  ✅ Whisper model '{model_name}' loaded on {resolved_device}", flush=True)
                                 last_error = None
                                 retry_succeeded = True
                                 break
@@ -1565,12 +1578,12 @@ class VoiceListener(threading.Thread):
                         return
                     else:
                         # For other errors (model not found, etc.), don't try fallbacks
-                        debug_log(f"failed to initialize faster-whisper: {e}", "voice")
+                        debug_log(f"failed to initialise faster-whisper: {e}", "voice")
                         print(f"  ❌ Failed to load Whisper model: {e}", flush=True)
                         return
 
             if last_error is not None:
-                debug_log(f"failed to initialize faster-whisper with any config: {last_error}", "voice")
+                debug_log(f"failed to initialise faster-whisper with any config: {last_error}", "voice")
                 print(f"  ❌ Failed to load Whisper model: {last_error}", flush=True)
                 return
 

--- a/src/jarvis/listening/listener.py
+++ b/src/jarvis/listening/listener.py
@@ -1516,8 +1516,55 @@ class VoiceListener(threading.Thread):
                             print(f"  ❌ Failed to load Whisper model: {e}", flush=True)
                             print("  💡 Try manually deleting the Whisper model cache directory and restarting", flush=True)
                             return
+                    # Check for rate limiting (HTTP 429)
+                    is_rate_limited = any(x in error_str for x in [
+                        "429", "too many requests", "rate limit",
+                    ])
+
+                    if is_rate_limited:
+                        _max_retries = 4
+                        _backoff = 2
+                        debug_log(f"rate limited loading Whisper model: {e}", "voice")
+                        retry_succeeded = False
+                        for retry_num in range(1, _max_retries + 1):
+                            wait = _backoff ** retry_num
+                            print(f"  ⏳ Rate limited by HuggingFace, retrying in {wait}s ({retry_num}/{_max_retries})...", flush=True)
+                            time.sleep(wait)
+                            try:
+                                self.model = WhisperModel(
+                                    model_name, device=try_device, compute_type=try_compute,
+                                    cpu_threads=cpu_threads,
+                                )
+                                ct2_model = getattr(self.model, "model", None)
+                                resolved_device = str(getattr(ct2_model, "device", try_device)).lower()
+                                debug_log(f"faster-whisper initialised after rate-limit retry: name={model_name}, device={resolved_device}, compute={try_compute}", "voice")
+
+                                used_device = try_device
+                                used_compute = try_compute
+                                self._whisper_device = resolved_device
+
+                                if try_device != device and device in ("auto", "cuda"):
+                                    print("  ⚠️  CUDA not available, using CPU (this may be slower)", flush=True)
+                                    print("  💡 Tip: Install NVIDIA CUDA toolkit for faster speech recognition", flush=True)
+                                if try_compute != compute:
+                                    print(f"  ⚠️  Using '{try_compute}' compute type ('{compute}' not supported)", flush=True)
+                                if resolved_device == "cpu":
+                                    print(f"  ⚡ CPU mode: using {cpu_threads} threads with optimised decoding", flush=True)
+                                print(f"  ✅ Whisper model '{model_name}' loaded on {resolved_device}", flush=True)
+                                last_error = None
+                                retry_succeeded = True
+                                break
+                            except Exception as retry_e:
+                                debug_log(f"rate-limit retry {retry_num} failed: {retry_e}", "voice")
+                                last_error = retry_e
+                        if retry_succeeded:
+                            break
+                        debug_log(f"gave up after {_max_retries} rate-limit retries", "voice")
+                        print(f"  ❌ Failed to load Whisper model after {_max_retries} retries: {last_error}", flush=True)
+                        print("  💡 HuggingFace is rate limiting downloads. Please wait a few minutes and restart.", flush=True)
+                        return
                     else:
-                        # For other errors (model not found, network issues, etc.), don't try fallbacks
+                        # For other errors (model not found, etc.), don't try fallbacks
                         debug_log(f"failed to initialize faster-whisper: {e}", "voice")
                         print(f"  ❌ Failed to load Whisper model: {e}", flush=True)
                         return

--- a/src/jarvis/listening/listening.spec.md
+++ b/src/jarvis/listening/listening.spec.md
@@ -316,6 +316,18 @@ When components are unavailable, the system degrades gracefully:
 | 16 kHz sample rate | Stream at device native rate, resample to 16 kHz for Whisper |
 | Transcript Buffer | Process each utterance independently |
 
+## Download Recovery
+
+Whisper model loading handles transient download failures automatically:
+
+### Corrupted Cache Recovery
+
+If the HuggingFace model cache is corrupted (e.g. from an interrupted download), the system detects the CTranslate2 "unable to open file" error, deletes the parent `models--` cache directory, and retries the download once. If the retry also fails, a message guides the user to manually delete the cache.
+
+### Rate Limit Retry (HTTP 429)
+
+When HuggingFace returns HTTP 429 (Too Many Requests), both faster-whisper and MLX Whisper backends retry up to 4 times with exponential backoff (2s, 4s, 8s, 16s). Progress messages inform the user of each retry attempt. If all retries are exhausted, the user is advised to wait and restart.
+
 ## Future: Acoustic Echo Cancellation
 
 Currently, echo is handled at the transcript level via fuzzy text matching and the intent judge. True acoustic echo cancellation (AEC) would:

--- a/src/jarvis/output/tts.py
+++ b/src/jarvis/output/tts.py
@@ -102,6 +102,7 @@ def _download_piper_voice(voice_name: str, progress_callback: Optional[Callable[
                     response.raise_for_status()
                     break  # Success
                 except requests.exceptions.HTTPError as http_err:
+                    response.close()
                     status = getattr(http_err.response, "status_code", None)
                     if status == 429 and attempt < max_retries:
                         wait = 2 ** (attempt + 1)

--- a/src/jarvis/output/tts.py
+++ b/src/jarvis/output/tts.py
@@ -93,9 +93,22 @@ def _download_piper_voice(voice_name: str, progress_callback: Optional[Callable[
 
             log(f"  Downloading {desc}...")
 
-            # Stream download for large files
-            response = requests.get(url, stream=True, timeout=60)
-            response.raise_for_status()
+            # Stream download with retry on rate limiting (HTTP 429)
+            max_retries = 4
+            response = None
+            for attempt in range(max_retries + 1):
+                response = requests.get(url, stream=True, timeout=60)
+                try:
+                    response.raise_for_status()
+                    break  # Success
+                except requests.exceptions.HTTPError as http_err:
+                    status = getattr(http_err.response, "status_code", None)
+                    if status == 429 and attempt < max_retries:
+                        wait = 2 ** (attempt + 1)
+                        log(f"  ⏳ Rate limited by HuggingFace, retrying in {wait}s ({attempt + 1}/{max_retries})...")
+                        time.sleep(wait)
+                        continue
+                    raise  # Non-429 or retries exhausted
 
             total_size = int(response.headers.get("content-length", 0))
             downloaded = 0

--- a/tests/test_piper_tts.py
+++ b/tests/test_piper_tts.py
@@ -574,11 +574,14 @@ class TestPiperVoiceDownloadRetry:
 
         with patch("requests.get", side_effect=mock_get):
             with patch("src.jarvis.output.tts._get_piper_models_dir", return_value=tmp_path):
-                with patch("src.jarvis.output.tts.time.sleep"):  # Skip actual sleep
+                with patch("src.jarvis.output.tts.time.sleep") as mock_sleep:
                     result = _download_piper_voice("en_GB-alan-medium")
 
         assert result is not None
         assert (tmp_path / "en_GB-alan-medium.onnx").exists()
+        # Verify exponential backoff: 2^1=2s for the onnx 429, 2^1=2s for the json 429
+        sleep_values = [c.args[0] for c in mock_sleep.call_args_list]
+        assert all(v == 2 for v in sleep_values)
 
     def test_429_gives_up_after_max_retries(self, tmp_path):
         """Download gives up after exhausting retries on persistent 429."""
@@ -596,10 +599,13 @@ class TestPiperVoiceDownloadRetry:
 
         with patch("requests.get", side_effect=mock_get):
             with patch("src.jarvis.output.tts._get_piper_models_dir", return_value=tmp_path):
-                with patch("src.jarvis.output.tts.time.sleep"):
+                with patch("src.jarvis.output.tts.time.sleep") as mock_sleep:
                     result = _download_piper_voice("en_GB-alan-medium")
 
         assert result is None
+        # Verify exponential backoff sequence: 2, 4, 8, 16
+        sleep_values = [c.args[0] for c in mock_sleep.call_args_list]
+        assert sleep_values == [2, 4, 8, 16]
 
     def test_non_429_error_not_retried(self, tmp_path):
         """Download does not retry on non-429 HTTP errors (e.g. 404)."""

--- a/tests/test_piper_tts.py
+++ b/tests/test_piper_tts.py
@@ -539,3 +539,90 @@ class TestPiperTTSThreadSafety:
 
         # Should not crash, queue should have items
         # (actual number depends on timing)
+
+
+class TestPiperVoiceDownloadRetry:
+    """Tests for retry logic when HuggingFace returns 429 Too Many Requests."""
+
+    def test_429_retried_then_succeeds(self, tmp_path):
+        """Download retries on 429 and succeeds on subsequent attempt."""
+        import requests
+        from src.jarvis.output.tts import _download_piper_voice
+
+        call_count = {"onnx": 0, "json": 0}
+
+        def mock_get(url, **kwargs):
+            resp = MagicMock()
+            is_json = url.endswith(".json")
+            key = "json" if is_json else "onnx"
+            call_count[key] += 1
+
+            if call_count[key] == 1:
+                # First call: 429
+                http_err = requests.exceptions.HTTPError(
+                    response=MagicMock(status_code=429)
+                )
+                http_err.response = MagicMock(status_code=429)
+                resp.raise_for_status.side_effect = http_err
+                return resp
+
+            # Subsequent calls: success
+            resp.raise_for_status.return_value = None
+            resp.headers = {"content-length": "4"}
+            resp.iter_content.return_value = [b"data"]
+            return resp
+
+        with patch("requests.get", side_effect=mock_get):
+            with patch("src.jarvis.output.tts._get_piper_models_dir", return_value=tmp_path):
+                with patch("src.jarvis.output.tts.time.sleep"):  # Skip actual sleep
+                    result = _download_piper_voice("en_GB-alan-medium")
+
+        assert result is not None
+        assert (tmp_path / "en_GB-alan-medium.onnx").exists()
+
+    def test_429_gives_up_after_max_retries(self, tmp_path):
+        """Download gives up after exhausting retries on persistent 429."""
+        import requests
+        from src.jarvis.output.tts import _download_piper_voice
+
+        def mock_get(url, **kwargs):
+            resp = MagicMock()
+            http_err = requests.exceptions.HTTPError(
+                response=MagicMock(status_code=429)
+            )
+            http_err.response = MagicMock(status_code=429)
+            resp.raise_for_status.side_effect = http_err
+            return resp
+
+        with patch("requests.get", side_effect=mock_get):
+            with patch("src.jarvis.output.tts._get_piper_models_dir", return_value=tmp_path):
+                with patch("src.jarvis.output.tts.time.sleep"):
+                    result = _download_piper_voice("en_GB-alan-medium")
+
+        assert result is None
+
+    def test_non_429_error_not_retried(self, tmp_path):
+        """Download does not retry on non-429 HTTP errors (e.g. 404)."""
+        import requests
+        from src.jarvis.output.tts import _download_piper_voice
+
+        get_call_count = 0
+
+        def mock_get(url, **kwargs):
+            nonlocal get_call_count
+            get_call_count += 1
+            resp = MagicMock()
+            http_err = requests.exceptions.HTTPError(
+                response=MagicMock(status_code=404)
+            )
+            http_err.response = MagicMock(status_code=404)
+            resp.raise_for_status.side_effect = http_err
+            return resp
+
+        with patch("requests.get", side_effect=mock_get):
+            with patch("src.jarvis.output.tts._get_piper_models_dir", return_value=tmp_path):
+                result = _download_piper_voice("en_GB-alan-medium")
+
+        assert result is None
+        # Should only call once for the onnx file (no retry)
+        assert get_call_count == 1

--- a/tests/test_voice_listener.py
+++ b/tests/test_voice_listener.py
@@ -1416,4 +1416,71 @@ class TestCorruptedWhisperCacheRecovery:
 
                             # Should show manual cleanup hint
                             captured = capsys.readouterr()
-                            assert "manually delet" in captured.out.lower()
+                            assert "whisper model cache" in captured.out.lower()
+
+    def test_rmtree_oserror_prevents_retry(self, tmp_path):
+        """When shutil.rmtree raises OSError, model stays None and no retry occurs."""
+        snapshot_dir = tmp_path / "models--Systran--faster-whisper-medium" / "snapshots" / "abc123"
+        snapshot_dir.mkdir(parents=True)
+        (snapshot_dir / "model.bin").write_bytes(b"corrupted")
+
+        error_msg = f"Unable to open file 'model.bin' in model '{snapshot_dir}'"
+
+        with patch("jarvis.listening.listener.sys") as mock_sys:
+            mock_sys.platform = "linux"
+            with patch("jarvis.listening.listener.FASTER_WHISPER_AVAILABLE", True):
+                with patch("jarvis.listening.listener.MLX_WHISPER_AVAILABLE", False):
+                    with patch("jarvis.listening.listener.WhisperModel") as mock_class:
+                        mock_class.side_effect = RuntimeError(error_msg)
+
+                        with patch("jarvis.listening.listener.sd") as mock_sd:
+                            mock_sd.query_devices.return_value = [{"name": "Test Mic", "max_input_channels": 1}]
+
+                            # Make shutil.rmtree raise OSError
+                            with patch("shutil.rmtree", side_effect=OSError("Permission denied")):
+                                from jarvis.listening.listener import VoiceListener
+
+                                mock_db = MagicMock()
+                                mock_cfg = self._create_mock_config()
+                                mock_tts = MagicMock()
+                                mock_dialogue_memory = MagicMock()
+
+                                listener = VoiceListener(mock_db, mock_cfg, mock_tts, mock_dialogue_memory)
+                                listener.run()
+
+                                # Only the initial attempt — no retry since cache could not be cleared
+                                mock_class.assert_called_once()
+                                assert listener.model is None
+
+    def test_no_models_ancestor_prevents_cache_clear(self, tmp_path):
+        """When error path has no models-- ancestor, cache is not cleared and model stays None."""
+        # Create a path without a models-- segment
+        plain_dir = tmp_path / "some" / "random" / "path"
+        plain_dir.mkdir(parents=True)
+        (plain_dir / "model.bin").write_bytes(b"corrupted")
+
+        error_msg = f"Unable to open file 'model.bin' in model '{plain_dir}'"
+
+        with patch("jarvis.listening.listener.sys") as mock_sys:
+            mock_sys.platform = "linux"
+            with patch("jarvis.listening.listener.FASTER_WHISPER_AVAILABLE", True):
+                with patch("jarvis.listening.listener.MLX_WHISPER_AVAILABLE", False):
+                    with patch("jarvis.listening.listener.WhisperModel") as mock_class:
+                        mock_class.side_effect = RuntimeError(error_msg)
+
+                        with patch("jarvis.listening.listener.sd") as mock_sd:
+                            mock_sd.query_devices.return_value = [{"name": "Test Mic", "max_input_channels": 1}]
+
+                            from jarvis.listening.listener import VoiceListener
+
+                            mock_db = MagicMock()
+                            mock_cfg = self._create_mock_config()
+                            mock_tts = MagicMock()
+                            mock_dialogue_memory = MagicMock()
+
+                            listener = VoiceListener(mock_db, mock_cfg, mock_tts, mock_dialogue_memory)
+                            listener.run()
+
+                            # No retry — _clear_corrupted_whisper_cache returns False
+                            mock_class.assert_called_once()
+                            assert listener.model is None

--- a/tests/test_voice_listener.py
+++ b/tests/test_voice_listener.py
@@ -9,28 +9,29 @@ import time
 import pytest
 
 
+def _create_mock_config(**kwargs):
+    """Create a mock config object with default values for voice listener tests."""
+    mock_cfg = MagicMock()
+    mock_cfg.whisper_model = kwargs.get("whisper_model", "small")
+    mock_cfg.whisper_device = kwargs.get("whisper_device", "auto")
+    mock_cfg.whisper_compute_type = kwargs.get("whisper_compute_type", "int8")
+    mock_cfg.whisper_backend = kwargs.get("whisper_backend", "faster-whisper")
+    mock_cfg.sample_rate = kwargs.get("sample_rate", 16000)
+    mock_cfg.vad_enabled = kwargs.get("vad_enabled", True)
+    mock_cfg.vad_aggressiveness = kwargs.get("vad_aggressiveness", 2)
+    mock_cfg.echo_tolerance = kwargs.get("echo_tolerance", 0.3)
+    mock_cfg.echo_energy_threshold = kwargs.get("echo_energy_threshold", 2.0)
+    mock_cfg.hot_window_seconds = kwargs.get("hot_window_seconds", 3.0)
+    mock_cfg.voice_collect_seconds = kwargs.get("voice_collect_seconds", 2.0)
+    mock_cfg.voice_max_collect_seconds = kwargs.get("voice_max_collect_seconds", 60.0)
+    mock_cfg.voice_device = kwargs.get("voice_device", None)
+    mock_cfg.voice_debug = kwargs.get("voice_debug", False)
+    mock_cfg.tune_enabled = kwargs.get("tune_enabled", False)
+    return mock_cfg
+
+
 class TestWhisperComputeTypeFallback:
     """Tests for Whisper compute type fallback mechanism."""
-
-    def _create_mock_config(self, **kwargs):
-        """Create a mock config object with default values."""
-        mock_cfg = MagicMock()
-        mock_cfg.whisper_model = kwargs.get("whisper_model", "small")
-        mock_cfg.whisper_device = kwargs.get("whisper_device", "auto")
-        mock_cfg.whisper_compute_type = kwargs.get("whisper_compute_type", "int8")
-        mock_cfg.whisper_backend = kwargs.get("whisper_backend", "faster-whisper")
-        mock_cfg.sample_rate = kwargs.get("sample_rate", 16000)
-        mock_cfg.vad_enabled = kwargs.get("vad_enabled", True)
-        mock_cfg.vad_aggressiveness = kwargs.get("vad_aggressiveness", 2)
-        mock_cfg.echo_tolerance = kwargs.get("echo_tolerance", 0.3)
-        mock_cfg.echo_energy_threshold = kwargs.get("echo_energy_threshold", 2.0)
-        mock_cfg.hot_window_seconds = kwargs.get("hot_window_seconds", 3.0)
-        mock_cfg.voice_collect_seconds = kwargs.get("voice_collect_seconds", 2.0)
-        mock_cfg.voice_max_collect_seconds = kwargs.get("voice_max_collect_seconds", 60.0)
-        mock_cfg.voice_device = kwargs.get("voice_device", None)
-        mock_cfg.voice_debug = kwargs.get("voice_debug", False)
-        mock_cfg.tune_enabled = kwargs.get("tune_enabled", False)
-        return mock_cfg
 
     def test_successful_load_with_int8(self):
         """When int8 is supported, loads successfully without fallback."""
@@ -50,7 +51,7 @@ class TestWhisperComputeTypeFallback:
                             from jarvis.listening.listener import VoiceListener
 
                             mock_db = MagicMock()
-                            mock_cfg = self._create_mock_config(whisper_compute_type="int8")
+                            mock_cfg = _create_mock_config(whisper_compute_type="int8")
                             mock_tts = MagicMock()
                             mock_dialogue_memory = MagicMock()
 
@@ -87,7 +88,7 @@ class TestWhisperComputeTypeFallback:
                             from jarvis.listening.listener import VoiceListener
 
                             mock_db = MagicMock()
-                            mock_cfg = self._create_mock_config(whisper_compute_type="int8")
+                            mock_cfg = _create_mock_config(whisper_compute_type="int8")
                             mock_tts = MagicMock()
                             mock_dialogue_memory = MagicMock()
 
@@ -125,7 +126,7 @@ class TestWhisperComputeTypeFallback:
                             from jarvis.listening.listener import VoiceListener
 
                             mock_db = MagicMock()
-                            mock_cfg = self._create_mock_config(whisper_compute_type="int8")
+                            mock_cfg = _create_mock_config(whisper_compute_type="int8")
                             mock_tts = MagicMock()
                             mock_dialogue_memory = MagicMock()
 
@@ -158,7 +159,7 @@ class TestWhisperComputeTypeFallback:
                             from jarvis.listening.listener import VoiceListener
 
                             mock_db = MagicMock()
-                            mock_cfg = self._create_mock_config(whisper_compute_type="int8")
+                            mock_cfg = _create_mock_config(whisper_compute_type="int8")
                             mock_tts = MagicMock()
                             mock_dialogue_memory = MagicMock()
 
@@ -187,7 +188,7 @@ class TestWhisperComputeTypeFallback:
                             from jarvis.listening.listener import VoiceListener
 
                             mock_db = MagicMock()
-                            mock_cfg = self._create_mock_config(whisper_compute_type="int8")
+                            mock_cfg = _create_mock_config(whisper_compute_type="int8")
                             mock_tts = MagicMock()
                             mock_dialogue_memory = MagicMock()
 
@@ -221,7 +222,7 @@ class TestWhisperComputeTypeFallback:
 
                             mock_db = MagicMock()
                             # Config specifies float16 instead of int8
-                            mock_cfg = self._create_mock_config(whisper_compute_type="float16")
+                            mock_cfg = _create_mock_config(whisper_compute_type="float16")
                             mock_tts = MagicMock()
                             mock_dialogue_memory = MagicMock()
 
@@ -253,7 +254,7 @@ class TestWhisperComputeTypeFallback:
 
                             mock_db = MagicMock()
                             # Config specifies float32
-                            mock_cfg = self._create_mock_config(whisper_compute_type="float32")
+                            mock_cfg = _create_mock_config(whisper_compute_type="float32")
                             mock_tts = MagicMock()
                             mock_dialogue_memory = MagicMock()
 
@@ -272,26 +273,6 @@ class TestWhisperComputeTypeFallback:
 
 class TestWindowsCudaDetection:
     """Tests for Windows CUDA detection logic."""
-
-    def _create_mock_config(self, **kwargs):
-        """Create a mock config object with default values."""
-        mock_cfg = MagicMock()
-        mock_cfg.whisper_model = kwargs.get("whisper_model", "small")
-        mock_cfg.whisper_device = kwargs.get("whisper_device", "auto")
-        mock_cfg.whisper_compute_type = kwargs.get("whisper_compute_type", "int8")
-        mock_cfg.whisper_backend = kwargs.get("whisper_backend", "faster-whisper")
-        mock_cfg.sample_rate = kwargs.get("sample_rate", 16000)
-        mock_cfg.vad_enabled = kwargs.get("vad_enabled", True)
-        mock_cfg.vad_aggressiveness = kwargs.get("vad_aggressiveness", 2)
-        mock_cfg.echo_tolerance = kwargs.get("echo_tolerance", 0.3)
-        mock_cfg.echo_energy_threshold = kwargs.get("echo_energy_threshold", 2.0)
-        mock_cfg.hot_window_seconds = kwargs.get("hot_window_seconds", 3.0)
-        mock_cfg.voice_collect_seconds = kwargs.get("voice_collect_seconds", 2.0)
-        mock_cfg.voice_max_collect_seconds = kwargs.get("voice_max_collect_seconds", 60.0)
-        mock_cfg.voice_device = kwargs.get("voice_device", None)
-        mock_cfg.voice_debug = kwargs.get("voice_debug", False)
-        mock_cfg.tune_enabled = kwargs.get("tune_enabled", False)
-        return mock_cfg
 
     def test_cuda_detected_when_all_dlls_present(self):
         """When cuBLAS and cuDNN DLLs are found, GPU mode is used."""
@@ -313,7 +294,7 @@ class TestWindowsCudaDetection:
                                 with patch.dict("sys.modules", {"ctypes": mock_ctypes}):
                                     from jarvis.listening.listener import VoiceListener
 
-                                    mock_cfg = self._create_mock_config()
+                                    mock_cfg = _create_mock_config()
                                     listener = VoiceListener(MagicMock(), mock_cfg, MagicMock(), MagicMock())
                                     listener.run()
 
@@ -340,7 +321,7 @@ class TestWindowsCudaDetection:
                                 with patch.dict("sys.modules", {"ctypes": mock_ctypes}):
                                     from jarvis.listening.listener import VoiceListener
 
-                                    mock_cfg = self._create_mock_config()
+                                    mock_cfg = _create_mock_config()
                                     listener = VoiceListener(MagicMock(), mock_cfg, MagicMock(), MagicMock())
                                     listener.run()
 
@@ -389,26 +370,6 @@ class TestWindowsCudaDetection:
 class TestLargeV3TurboFallback:
     """Tests for large-v3-turbo runtime fallback when faster-whisper is too old."""
 
-    def _create_mock_config(self, **kwargs):
-        """Create a mock config object with default values."""
-        mock_cfg = MagicMock()
-        mock_cfg.whisper_model = kwargs.get("whisper_model", "small")
-        mock_cfg.whisper_device = kwargs.get("whisper_device", "auto")
-        mock_cfg.whisper_compute_type = kwargs.get("whisper_compute_type", "int8")
-        mock_cfg.whisper_backend = kwargs.get("whisper_backend", "faster-whisper")
-        mock_cfg.sample_rate = kwargs.get("sample_rate", 16000)
-        mock_cfg.vad_enabled = kwargs.get("vad_enabled", True)
-        mock_cfg.vad_aggressiveness = kwargs.get("vad_aggressiveness", 2)
-        mock_cfg.echo_tolerance = kwargs.get("echo_tolerance", 0.3)
-        mock_cfg.echo_energy_threshold = kwargs.get("echo_energy_threshold", 2.0)
-        mock_cfg.hot_window_seconds = kwargs.get("hot_window_seconds", 3.0)
-        mock_cfg.voice_collect_seconds = kwargs.get("voice_collect_seconds", 2.0)
-        mock_cfg.voice_max_collect_seconds = kwargs.get("voice_max_collect_seconds", 60.0)
-        mock_cfg.voice_device = kwargs.get("voice_device", None)
-        mock_cfg.voice_debug = kwargs.get("voice_debug", False)
-        mock_cfg.tune_enabled = kwargs.get("tune_enabled", False)
-        return mock_cfg
-
     def test_turbo_falls_back_to_large_v3_when_unsupported(self, capsys):
         """large-v3-turbo config falls back to large-v3 when faster-whisper < 1.1.0."""
         mock_whisper_model = MagicMock()
@@ -425,7 +386,7 @@ class TestLargeV3TurboFallback:
 
                                 from jarvis.listening.listener import VoiceListener
 
-                                mock_cfg = self._create_mock_config(whisper_model="large-v3-turbo")
+                                mock_cfg = _create_mock_config(whisper_model="large-v3-turbo")
                                 listener = VoiceListener(MagicMock(), mock_cfg, MagicMock(), MagicMock())
                                 listener.run()
 
@@ -452,7 +413,7 @@ class TestLargeV3TurboFallback:
 
                                 from jarvis.listening.listener import VoiceListener
 
-                                mock_cfg = self._create_mock_config(whisper_model="large-v3-turbo")
+                                mock_cfg = _create_mock_config(whisper_model="large-v3-turbo")
                                 listener = VoiceListener(MagicMock(), mock_cfg, MagicMock(), MagicMock())
                                 listener.run()
 
@@ -583,26 +544,6 @@ class TestRepetitiveHallucinationDetection:
 class TestCpuOptimisations:
     """Tests for faster-whisper CPU mode optimisations."""
 
-    def _create_mock_config(self, **kwargs):
-        """Create a mock config object with default values."""
-        mock_cfg = MagicMock()
-        mock_cfg.whisper_model = kwargs.get("whisper_model", "small")
-        mock_cfg.whisper_device = kwargs.get("whisper_device", "auto")
-        mock_cfg.whisper_compute_type = kwargs.get("whisper_compute_type", "int8")
-        mock_cfg.whisper_backend = kwargs.get("whisper_backend", "faster-whisper")
-        mock_cfg.sample_rate = kwargs.get("sample_rate", 16000)
-        mock_cfg.vad_enabled = kwargs.get("vad_enabled", True)
-        mock_cfg.vad_aggressiveness = kwargs.get("vad_aggressiveness", 2)
-        mock_cfg.echo_tolerance = kwargs.get("echo_tolerance", 0.3)
-        mock_cfg.echo_energy_threshold = kwargs.get("echo_energy_threshold", 2.0)
-        mock_cfg.hot_window_seconds = kwargs.get("hot_window_seconds", 3.0)
-        mock_cfg.voice_collect_seconds = kwargs.get("voice_collect_seconds", 2.0)
-        mock_cfg.voice_max_collect_seconds = kwargs.get("voice_max_collect_seconds", 60.0)
-        mock_cfg.voice_device = kwargs.get("voice_device", None)
-        mock_cfg.voice_debug = kwargs.get("voice_debug", False)
-        mock_cfg.tune_enabled = kwargs.get("tune_enabled", False)
-        return mock_cfg
-
     def test_cpu_threads_set_when_device_is_cpu(self):
         """CPU cores are passed to WhisperModel when device resolves to cpu."""
         mock_whisper_model = MagicMock()
@@ -620,7 +561,7 @@ class TestCpuOptimisations:
                             with patch("jarvis.listening.listener.os.cpu_count", return_value=8):
                                 from jarvis.listening.listener import VoiceListener
 
-                                mock_cfg = self._create_mock_config(whisper_device="cpu")
+                                mock_cfg = _create_mock_config(whisper_device="cpu")
                                 listener = VoiceListener(MagicMock(), mock_cfg, MagicMock(), MagicMock())
                                 listener.run()
 
@@ -642,7 +583,7 @@ class TestCpuOptimisations:
                             with patch("jarvis.listening.listener.os.cpu_count", return_value=12):
                                 from jarvis.listening.listener import VoiceListener
 
-                                mock_cfg = self._create_mock_config(whisper_device="auto")
+                                mock_cfg = _create_mock_config(whisper_device="auto")
                                 listener = VoiceListener(MagicMock(), mock_cfg, MagicMock(), MagicMock())
                                 listener.run()
 
@@ -664,7 +605,7 @@ class TestCpuOptimisations:
 
                             from jarvis.listening.listener import VoiceListener
 
-                            mock_cfg = self._create_mock_config()
+                            mock_cfg = _create_mock_config()
                             listener = VoiceListener(MagicMock(), mock_cfg, MagicMock(), MagicMock())
                             listener.run()
 
@@ -689,7 +630,7 @@ class TestCpuOptimisations:
 
                             from jarvis.listening.listener import VoiceListener
 
-                            mock_cfg = self._create_mock_config()
+                            mock_cfg = _create_mock_config()
                             listener = VoiceListener(MagicMock(), mock_cfg, MagicMock(), MagicMock())
                             listener.run()
 
@@ -862,26 +803,6 @@ class TestMicPermissionHint:
 class TestCrossPlatformDeviceLogging:
     """Tests for cross-platform audio device name logging."""
 
-    def _create_mock_config(self, **kwargs):
-        """Create a mock config object with default values."""
-        mock_cfg = MagicMock()
-        mock_cfg.whisper_model = kwargs.get("whisper_model", "small")
-        mock_cfg.whisper_device = kwargs.get("whisper_device", "auto")
-        mock_cfg.whisper_compute_type = kwargs.get("whisper_compute_type", "int8")
-        mock_cfg.whisper_backend = kwargs.get("whisper_backend", "faster-whisper")
-        mock_cfg.sample_rate = kwargs.get("sample_rate", 16000)
-        mock_cfg.vad_enabled = kwargs.get("vad_enabled", True)
-        mock_cfg.vad_aggressiveness = kwargs.get("vad_aggressiveness", 2)
-        mock_cfg.echo_tolerance = kwargs.get("echo_tolerance", 0.3)
-        mock_cfg.echo_energy_threshold = kwargs.get("echo_energy_threshold", 2.0)
-        mock_cfg.hot_window_seconds = kwargs.get("hot_window_seconds", 3.0)
-        mock_cfg.voice_collect_seconds = kwargs.get("voice_collect_seconds", 2.0)
-        mock_cfg.voice_max_collect_seconds = kwargs.get("voice_max_collect_seconds", 60.0)
-        mock_cfg.voice_device = kwargs.get("voice_device", None)
-        mock_cfg.voice_debug = kwargs.get("voice_debug", False)
-        mock_cfg.tune_enabled = kwargs.get("tune_enabled", False)
-        return mock_cfg
-
     def test_device_name_printed_on_linux(self, capsys):
         """Device name is printed on Linux, not just Windows."""
         mock_whisper_model = MagicMock()
@@ -908,7 +829,7 @@ class TestCrossPlatformDeviceLogging:
                             from jarvis.listening.listener import VoiceListener
 
                             mock_db = MagicMock()
-                            mock_cfg = self._create_mock_config()
+                            mock_cfg = _create_mock_config()
                             mock_tts = MagicMock()
                             mock_dialogue_memory = MagicMock()
 
@@ -944,7 +865,7 @@ class TestCrossPlatformDeviceLogging:
                             from jarvis.listening.listener import VoiceListener
 
                             mock_db = MagicMock()
-                            mock_cfg = self._create_mock_config()
+                            mock_cfg = _create_mock_config()
                             mock_tts = MagicMock()
                             mock_dialogue_memory = MagicMock()
 
@@ -958,26 +879,6 @@ class TestCrossPlatformDeviceLogging:
 
 class TestCrossPlatformAudioHealthWarning:
     """Tests for cross-platform audio health monitoring."""
-
-    def _create_mock_config(self, **kwargs):
-        """Create a mock config object with default values."""
-        mock_cfg = MagicMock()
-        mock_cfg.whisper_model = kwargs.get("whisper_model", "small")
-        mock_cfg.whisper_device = kwargs.get("whisper_device", "auto")
-        mock_cfg.whisper_compute_type = kwargs.get("whisper_compute_type", "int8")
-        mock_cfg.whisper_backend = kwargs.get("whisper_backend", "faster-whisper")
-        mock_cfg.sample_rate = kwargs.get("sample_rate", 16000)
-        mock_cfg.vad_enabled = kwargs.get("vad_enabled", True)
-        mock_cfg.vad_aggressiveness = kwargs.get("vad_aggressiveness", 2)
-        mock_cfg.echo_tolerance = kwargs.get("echo_tolerance", 0.3)
-        mock_cfg.echo_energy_threshold = kwargs.get("echo_energy_threshold", 2.0)
-        mock_cfg.hot_window_seconds = kwargs.get("hot_window_seconds", 3.0)
-        mock_cfg.voice_collect_seconds = kwargs.get("voice_collect_seconds", 2.0)
-        mock_cfg.voice_max_collect_seconds = kwargs.get("voice_max_collect_seconds", 60.0)
-        mock_cfg.voice_device = kwargs.get("voice_device", None)
-        mock_cfg.voice_debug = kwargs.get("voice_debug", False)
-        mock_cfg.tune_enabled = kwargs.get("tune_enabled", False)
-        return mock_cfg
 
     def test_health_warning_fires_on_linux(self, capsys):
         """Audio health warning fires on Linux when no audio received after 5s."""
@@ -1011,7 +912,7 @@ class TestCrossPlatformAudioHealthWarning:
                             import queue as q
 
                             mock_db = MagicMock()
-                            mock_cfg = self._create_mock_config()
+                            mock_cfg = _create_mock_config()
                             mock_tts = MagicMock()
                             mock_dialogue_memory = MagicMock()
 
@@ -1116,26 +1017,6 @@ class TestResample:
 class TestSampleRateFallback:
     """Tests for InputStream sample rate fallback on Linux."""
 
-    def _create_mock_config(self, **kwargs):
-        """Create a mock config object with default values."""
-        mock_cfg = MagicMock()
-        mock_cfg.whisper_model = kwargs.get("whisper_model", "small")
-        mock_cfg.whisper_device = kwargs.get("whisper_device", "auto")
-        mock_cfg.whisper_compute_type = kwargs.get("whisper_compute_type", "int8")
-        mock_cfg.whisper_backend = kwargs.get("whisper_backend", "faster-whisper")
-        mock_cfg.sample_rate = kwargs.get("sample_rate", 16000)
-        mock_cfg.vad_enabled = kwargs.get("vad_enabled", True)
-        mock_cfg.vad_aggressiveness = kwargs.get("vad_aggressiveness", 2)
-        mock_cfg.echo_tolerance = kwargs.get("echo_tolerance", 0.3)
-        mock_cfg.echo_energy_threshold = kwargs.get("echo_energy_threshold", 2.0)
-        mock_cfg.hot_window_seconds = kwargs.get("hot_window_seconds", 3.0)
-        mock_cfg.voice_collect_seconds = kwargs.get("voice_collect_seconds", 2.0)
-        mock_cfg.voice_max_collect_seconds = kwargs.get("voice_max_collect_seconds", 60.0)
-        mock_cfg.voice_device = kwargs.get("voice_device", None)
-        mock_cfg.voice_debug = kwargs.get("voice_debug", False)
-        mock_cfg.tune_enabled = kwargs.get("tune_enabled", False)
-        return mock_cfg
-
     def test_fallback_to_native_rate_on_invalid_sample_rate(self, capsys):
         """Falls back to device native rate when 16 kHz is rejected."""
         mock_whisper_model = MagicMock()
@@ -1176,7 +1057,7 @@ class TestSampleRateFallback:
                             from jarvis.listening.listener import VoiceListener
 
                             mock_db = MagicMock()
-                            mock_cfg = self._create_mock_config()
+                            mock_cfg = _create_mock_config()
                             mock_tts = MagicMock()
                             mock_dialogue_memory = MagicMock()
 
@@ -1228,7 +1109,7 @@ class TestSampleRateFallback:
                             from jarvis.listening.listener import VoiceListener
 
                             mock_db = MagicMock()
-                            mock_cfg = self._create_mock_config()
+                            mock_cfg = _create_mock_config()
                             mock_tts = MagicMock()
                             mock_dialogue_memory = MagicMock()
 
@@ -1241,26 +1122,6 @@ class TestSampleRateFallback:
 
 class TestCorruptedWhisperCacheRecovery:
     """Tests for automatic recovery from corrupted Whisper model cache."""
-
-    def _create_mock_config(self, **kwargs):
-        """Create a mock config object with default values."""
-        mock_cfg = MagicMock()
-        mock_cfg.whisper_model = kwargs.get("whisper_model", "medium")
-        mock_cfg.whisper_device = kwargs.get("whisper_device", "auto")
-        mock_cfg.whisper_compute_type = kwargs.get("whisper_compute_type", "int8")
-        mock_cfg.whisper_backend = kwargs.get("whisper_backend", "faster-whisper")
-        mock_cfg.sample_rate = kwargs.get("sample_rate", 16000)
-        mock_cfg.vad_enabled = kwargs.get("vad_enabled", True)
-        mock_cfg.vad_aggressiveness = kwargs.get("vad_aggressiveness", 2)
-        mock_cfg.echo_tolerance = kwargs.get("echo_tolerance", 0.3)
-        mock_cfg.echo_energy_threshold = kwargs.get("echo_energy_threshold", 2.0)
-        mock_cfg.hot_window_seconds = kwargs.get("hot_window_seconds", 3.0)
-        mock_cfg.voice_collect_seconds = kwargs.get("voice_collect_seconds", 2.0)
-        mock_cfg.voice_max_collect_seconds = kwargs.get("voice_max_collect_seconds", 60.0)
-        mock_cfg.voice_device = kwargs.get("voice_device", None)
-        mock_cfg.voice_debug = kwargs.get("voice_debug", False)
-        mock_cfg.tune_enabled = kwargs.get("tune_enabled", False)
-        return mock_cfg
 
     def test_corrupted_cache_detected_and_recovered(self, tmp_path):
         """When model.bin is corrupted, cache is cleared and model reloads."""
@@ -1293,7 +1154,7 @@ class TestCorruptedWhisperCacheRecovery:
                             from jarvis.listening.listener import VoiceListener
 
                             mock_db = MagicMock()
-                            mock_cfg = self._create_mock_config()
+                            mock_cfg = _create_mock_config(whisper_model="medium")
                             mock_tts = MagicMock()
                             mock_dialogue_memory = MagicMock()
 
@@ -1329,7 +1190,7 @@ class TestCorruptedWhisperCacheRecovery:
                             from jarvis.listening.listener import VoiceListener
 
                             mock_db = MagicMock()
-                            mock_cfg = self._create_mock_config()
+                            mock_cfg = _create_mock_config(whisper_model="medium")
                             mock_tts = MagicMock()
                             mock_dialogue_memory = MagicMock()
 
@@ -1376,7 +1237,7 @@ class TestCorruptedWhisperCacheRecovery:
                             from jarvis.listening.listener import VoiceListener
 
                             mock_db = MagicMock()
-                            mock_cfg = self._create_mock_config()
+                            mock_cfg = _create_mock_config(whisper_model="medium")
                             mock_tts = MagicMock()
                             mock_dialogue_memory = MagicMock()
 
@@ -1403,7 +1264,7 @@ class TestCorruptedWhisperCacheRecovery:
                             from jarvis.listening.listener import VoiceListener
 
                             mock_db = MagicMock()
-                            mock_cfg = self._create_mock_config()
+                            mock_cfg = _create_mock_config(whisper_model="medium")
                             mock_tts = MagicMock()
                             mock_dialogue_memory = MagicMock()
 
@@ -1441,7 +1302,7 @@ class TestCorruptedWhisperCacheRecovery:
                                 from jarvis.listening.listener import VoiceListener
 
                                 mock_db = MagicMock()
-                                mock_cfg = self._create_mock_config()
+                                mock_cfg = _create_mock_config(whisper_model="medium")
                                 mock_tts = MagicMock()
                                 mock_dialogue_memory = MagicMock()
 
@@ -1474,7 +1335,7 @@ class TestCorruptedWhisperCacheRecovery:
                             from jarvis.listening.listener import VoiceListener
 
                             mock_db = MagicMock()
-                            mock_cfg = self._create_mock_config()
+                            mock_cfg = _create_mock_config(whisper_model="medium")
                             mock_tts = MagicMock()
                             mock_dialogue_memory = MagicMock()
 
@@ -1488,26 +1349,6 @@ class TestCorruptedWhisperCacheRecovery:
 
 class TestWhisperRateLimitRetry:
     """Tests for retry logic when HuggingFace returns 429 Too Many Requests."""
-
-    def _create_mock_config(self, **kwargs):
-        """Create a mock config object with default values."""
-        mock_cfg = MagicMock()
-        mock_cfg.whisper_model = kwargs.get("whisper_model", "medium")
-        mock_cfg.whisper_device = kwargs.get("whisper_device", "auto")
-        mock_cfg.whisper_compute_type = kwargs.get("whisper_compute_type", "int8")
-        mock_cfg.whisper_backend = kwargs.get("whisper_backend", "faster-whisper")
-        mock_cfg.sample_rate = kwargs.get("sample_rate", 16000)
-        mock_cfg.vad_enabled = kwargs.get("vad_enabled", True)
-        mock_cfg.vad_aggressiveness = kwargs.get("vad_aggressiveness", 2)
-        mock_cfg.echo_tolerance = kwargs.get("echo_tolerance", 0.3)
-        mock_cfg.echo_energy_threshold = kwargs.get("echo_energy_threshold", 2.0)
-        mock_cfg.hot_window_seconds = kwargs.get("hot_window_seconds", 3.0)
-        mock_cfg.voice_collect_seconds = kwargs.get("voice_collect_seconds", 2.0)
-        mock_cfg.voice_max_collect_seconds = kwargs.get("voice_max_collect_seconds", 60.0)
-        mock_cfg.voice_device = kwargs.get("voice_device", None)
-        mock_cfg.voice_debug = kwargs.get("voice_debug", False)
-        mock_cfg.tune_enabled = kwargs.get("tune_enabled", False)
-        return mock_cfg
 
     def test_429_retried_then_succeeds(self):
         """WhisperModel loading retries on 429 and succeeds."""
@@ -1534,7 +1375,7 @@ class TestWhisperRateLimitRetry:
                                 from jarvis.listening.listener import VoiceListener
 
                                 mock_db = MagicMock()
-                                mock_cfg = self._create_mock_config()
+                                mock_cfg = _create_mock_config(whisper_model="medium")
                                 mock_tts = MagicMock()
                                 mock_dialogue_memory = MagicMock()
 
@@ -1558,11 +1399,11 @@ class TestWhisperRateLimitRetry:
                         with patch("jarvis.listening.listener.sd") as mock_sd:
                             mock_sd.query_devices.return_value = [{"name": "Test Mic", "max_input_channels": 1}]
 
-                            with patch("jarvis.listening.listener.time.sleep"):
+                            with patch("jarvis.listening.listener.time.sleep") as mock_sleep:
                                 from jarvis.listening.listener import VoiceListener
 
                                 mock_db = MagicMock()
-                                mock_cfg = self._create_mock_config()
+                                mock_cfg = _create_mock_config(whisper_model="medium")
                                 mock_tts = MagicMock()
                                 mock_dialogue_memory = MagicMock()
 
@@ -1572,6 +1413,10 @@ class TestWhisperRateLimitRetry:
                                 # Should have retried multiple times then given up
                                 assert mock_class.call_count > 1
                                 assert listener.model is None
+
+                                # Verify exponential backoff: 2, 4, 8, 16
+                                sleep_values = [c.args[0] for c in mock_sleep.call_args_list]
+                                assert sleep_values == [2, 4, 8, 16]
 
     def test_non_429_error_not_retried(self):
         """Non-rate-limit errors are not retried."""
@@ -1590,7 +1435,7 @@ class TestWhisperRateLimitRetry:
                             from jarvis.listening.listener import VoiceListener
 
                             mock_db = MagicMock()
-                            mock_cfg = self._create_mock_config()
+                            mock_cfg = _create_mock_config(whisper_model="medium")
                             mock_tts = MagicMock()
                             mock_dialogue_memory = MagicMock()
 

--- a/tests/test_voice_listener.py
+++ b/tests/test_voice_listener.py
@@ -1237,3 +1237,183 @@ class TestSampleRateFallback:
 
                             # Should only have tried once — no fallback
                             assert mock_sd.InputStream.call_count == 1
+
+
+class TestCorruptedWhisperCacheRecovery:
+    """Tests for automatic recovery from corrupted Whisper model cache."""
+
+    def _create_mock_config(self, **kwargs):
+        """Create a mock config object with default values."""
+        mock_cfg = MagicMock()
+        mock_cfg.whisper_model = kwargs.get("whisper_model", "medium")
+        mock_cfg.whisper_device = kwargs.get("whisper_device", "auto")
+        mock_cfg.whisper_compute_type = kwargs.get("whisper_compute_type", "int8")
+        mock_cfg.whisper_backend = kwargs.get("whisper_backend", "faster-whisper")
+        mock_cfg.sample_rate = kwargs.get("sample_rate", 16000)
+        mock_cfg.vad_enabled = kwargs.get("vad_enabled", True)
+        mock_cfg.vad_aggressiveness = kwargs.get("vad_aggressiveness", 2)
+        mock_cfg.echo_tolerance = kwargs.get("echo_tolerance", 0.3)
+        mock_cfg.echo_energy_threshold = kwargs.get("echo_energy_threshold", 2.0)
+        mock_cfg.hot_window_seconds = kwargs.get("hot_window_seconds", 3.0)
+        mock_cfg.voice_collect_seconds = kwargs.get("voice_collect_seconds", 2.0)
+        mock_cfg.voice_max_collect_seconds = kwargs.get("voice_max_collect_seconds", 60.0)
+        mock_cfg.voice_device = kwargs.get("voice_device", None)
+        mock_cfg.voice_debug = kwargs.get("voice_debug", False)
+        mock_cfg.tune_enabled = kwargs.get("tune_enabled", False)
+        return mock_cfg
+
+    def test_corrupted_cache_detected_and_recovered(self, tmp_path):
+        """When model.bin is corrupted, cache is cleared and model reloads."""
+        mock_whisper_model = MagicMock()
+
+        # Create a fake cache directory to be deleted
+        snapshot_dir = tmp_path / "models--Systran--faster-whisper-medium" / "snapshots" / "abc123"
+        snapshot_dir.mkdir(parents=True)
+        (snapshot_dir / "model.bin").write_bytes(b"corrupted")
+
+        error_msg = f"Unable to open file 'model.bin' in model '{snapshot_dir}'"
+        call_count = 0
+
+        def whisper_model_side_effect(model_name, device, compute_type, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise RuntimeError(error_msg)
+            return mock_whisper_model
+
+        with patch("jarvis.listening.listener.sys") as mock_sys:
+            mock_sys.platform = "linux"
+            with patch("jarvis.listening.listener.FASTER_WHISPER_AVAILABLE", True):
+                with patch("jarvis.listening.listener.MLX_WHISPER_AVAILABLE", False):
+                    with patch("jarvis.listening.listener.WhisperModel", side_effect=whisper_model_side_effect) as mock_class:
+                        with patch("jarvis.listening.listener.sd") as mock_sd:
+                            mock_sd.query_devices.return_value = [{"name": "Test Mic", "max_input_channels": 1}]
+                            mock_sd.InputStream.side_effect = Exception("Stop test here")
+
+                            from jarvis.listening.listener import VoiceListener
+
+                            mock_db = MagicMock()
+                            mock_cfg = self._create_mock_config()
+                            mock_tts = MagicMock()
+                            mock_dialogue_memory = MagicMock()
+
+                            listener = VoiceListener(mock_db, mock_cfg, mock_tts, mock_dialogue_memory)
+                            listener.run()
+
+                            # Should have called WhisperModel twice: first corrupted, then retry
+                            assert mock_class.call_count == 2
+                            assert listener.model == mock_whisper_model
+
+                            # The corrupted snapshot directory should have been deleted
+                            assert not snapshot_dir.exists()
+
+    def test_corrupted_cache_retry_also_fails(self, tmp_path):
+        """When retry after cache clear also fails, model remains None."""
+        # Create a fake cache directory
+        snapshot_dir = tmp_path / "models--Systran--faster-whisper-medium" / "snapshots" / "abc123"
+        snapshot_dir.mkdir(parents=True)
+        (snapshot_dir / "model.bin").write_bytes(b"corrupted")
+
+        error_msg = f"Unable to open file 'model.bin' in model '{snapshot_dir}'"
+
+        with patch("jarvis.listening.listener.sys") as mock_sys:
+            mock_sys.platform = "linux"
+            with patch("jarvis.listening.listener.FASTER_WHISPER_AVAILABLE", True):
+                with patch("jarvis.listening.listener.MLX_WHISPER_AVAILABLE", False):
+                    with patch("jarvis.listening.listener.WhisperModel") as mock_class:
+                        mock_class.side_effect = RuntimeError(error_msg)
+
+                        with patch("jarvis.listening.listener.sd") as mock_sd:
+                            mock_sd.query_devices.return_value = [{"name": "Test Mic", "max_input_channels": 1}]
+
+                            from jarvis.listening.listener import VoiceListener
+
+                            mock_db = MagicMock()
+                            mock_cfg = self._create_mock_config()
+                            mock_tts = MagicMock()
+                            mock_dialogue_memory = MagicMock()
+
+                            listener = VoiceListener(mock_db, mock_cfg, mock_tts, mock_dialogue_memory)
+                            listener.run()
+
+                            # First attempt + retry = 2 calls
+                            assert mock_class.call_count == 2
+                            assert listener.model is None
+
+    def test_corrupted_cache_parent_model_dir_deleted(self, tmp_path):
+        """Cache cleanup deletes the parent models-- directory, not just snapshot."""
+        mock_whisper_model = MagicMock()
+
+        model_dir = tmp_path / "models--Systran--faster-whisper-medium"
+        snapshot_dir = model_dir / "snapshots" / "abc123"
+        snapshot_dir.mkdir(parents=True)
+        (snapshot_dir / "model.bin").write_bytes(b"corrupted")
+
+        # Also create blobs dir (like real HF cache)
+        blobs_dir = model_dir / "blobs"
+        blobs_dir.mkdir()
+        (blobs_dir / "sha256-fake").write_bytes(b"corrupted blob")
+
+        error_msg = f"Unable to open file 'model.bin' in model '{snapshot_dir}'"
+        call_count = 0
+
+        def whisper_model_side_effect(model_name, device, compute_type, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise RuntimeError(error_msg)
+            return mock_whisper_model
+
+        with patch("jarvis.listening.listener.sys") as mock_sys:
+            mock_sys.platform = "linux"
+            with patch("jarvis.listening.listener.FASTER_WHISPER_AVAILABLE", True):
+                with patch("jarvis.listening.listener.MLX_WHISPER_AVAILABLE", False):
+                    with patch("jarvis.listening.listener.WhisperModel", side_effect=whisper_model_side_effect):
+                        with patch("jarvis.listening.listener.sd") as mock_sd:
+                            mock_sd.query_devices.return_value = [{"name": "Test Mic", "max_input_channels": 1}]
+                            mock_sd.InputStream.side_effect = Exception("Stop test here")
+
+                            from jarvis.listening.listener import VoiceListener
+
+                            mock_db = MagicMock()
+                            mock_cfg = self._create_mock_config()
+                            mock_tts = MagicMock()
+                            mock_dialogue_memory = MagicMock()
+
+                            listener = VoiceListener(mock_db, mock_cfg, mock_tts, mock_dialogue_memory)
+                            listener.run()
+
+                            # The entire models-- directory should have been deleted (including blobs)
+                            assert not model_dir.exists()
+
+    def test_unparseable_cache_path_shows_manual_instructions(self, capsys):
+        """When error path can't be parsed, shows manual cleanup instructions."""
+        error_msg = "Unable to open file 'model.bin' somehow"
+
+        with patch("jarvis.listening.listener.sys") as mock_sys:
+            mock_sys.platform = "linux"
+            with patch("jarvis.listening.listener.FASTER_WHISPER_AVAILABLE", True):
+                with patch("jarvis.listening.listener.MLX_WHISPER_AVAILABLE", False):
+                    with patch("jarvis.listening.listener.WhisperModel") as mock_class:
+                        mock_class.side_effect = RuntimeError(error_msg)
+
+                        with patch("jarvis.listening.listener.sd") as mock_sd:
+                            mock_sd.query_devices.return_value = [{"name": "Test Mic", "max_input_channels": 1}]
+
+                            from jarvis.listening.listener import VoiceListener
+
+                            mock_db = MagicMock()
+                            mock_cfg = self._create_mock_config()
+                            mock_tts = MagicMock()
+                            mock_dialogue_memory = MagicMock()
+
+                            listener = VoiceListener(mock_db, mock_cfg, mock_tts, mock_dialogue_memory)
+                            listener.run()
+
+                            # Should NOT retry (can't parse path)
+                            mock_class.assert_called_once()
+                            assert listener.model is None
+
+                            # Should show manual cleanup hint
+                            captured = capsys.readouterr()
+                            assert "manually delet" in captured.out.lower()

--- a/tests/test_voice_listener.py
+++ b/tests/test_voice_listener.py
@@ -1484,3 +1484,119 @@ class TestCorruptedWhisperCacheRecovery:
                             # No retry — _clear_corrupted_whisper_cache returns False
                             mock_class.assert_called_once()
                             assert listener.model is None
+
+
+class TestWhisperRateLimitRetry:
+    """Tests for retry logic when HuggingFace returns 429 Too Many Requests."""
+
+    def _create_mock_config(self, **kwargs):
+        """Create a mock config object with default values."""
+        mock_cfg = MagicMock()
+        mock_cfg.whisper_model = kwargs.get("whisper_model", "medium")
+        mock_cfg.whisper_device = kwargs.get("whisper_device", "auto")
+        mock_cfg.whisper_compute_type = kwargs.get("whisper_compute_type", "int8")
+        mock_cfg.whisper_backend = kwargs.get("whisper_backend", "faster-whisper")
+        mock_cfg.sample_rate = kwargs.get("sample_rate", 16000)
+        mock_cfg.vad_enabled = kwargs.get("vad_enabled", True)
+        mock_cfg.vad_aggressiveness = kwargs.get("vad_aggressiveness", 2)
+        mock_cfg.echo_tolerance = kwargs.get("echo_tolerance", 0.3)
+        mock_cfg.echo_energy_threshold = kwargs.get("echo_energy_threshold", 2.0)
+        mock_cfg.hot_window_seconds = kwargs.get("hot_window_seconds", 3.0)
+        mock_cfg.voice_collect_seconds = kwargs.get("voice_collect_seconds", 2.0)
+        mock_cfg.voice_max_collect_seconds = kwargs.get("voice_max_collect_seconds", 60.0)
+        mock_cfg.voice_device = kwargs.get("voice_device", None)
+        mock_cfg.voice_debug = kwargs.get("voice_debug", False)
+        mock_cfg.tune_enabled = kwargs.get("tune_enabled", False)
+        return mock_cfg
+
+    def test_429_retried_then_succeeds(self):
+        """WhisperModel loading retries on 429 and succeeds."""
+        mock_whisper_model = MagicMock()
+        call_count = 0
+
+        def whisper_model_side_effect(model_name, device, compute_type, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise RuntimeError("Got: HfHubHTTPError: 429 Too Many Requests for url: https://huggingface.co/api/models/Systran/faster-whisper-medium")
+            return mock_whisper_model
+
+        with patch("jarvis.listening.listener.sys") as mock_sys:
+            mock_sys.platform = "linux"
+            with patch("jarvis.listening.listener.FASTER_WHISPER_AVAILABLE", True):
+                with patch("jarvis.listening.listener.MLX_WHISPER_AVAILABLE", False):
+                    with patch("jarvis.listening.listener.WhisperModel", side_effect=whisper_model_side_effect) as mock_class:
+                        with patch("jarvis.listening.listener.sd") as mock_sd:
+                            mock_sd.query_devices.return_value = [{"name": "Test Mic", "max_input_channels": 1}]
+                            mock_sd.InputStream.side_effect = Exception("Stop test here")
+
+                            with patch("jarvis.listening.listener.time.sleep"):  # Skip actual sleep
+                                from jarvis.listening.listener import VoiceListener
+
+                                mock_db = MagicMock()
+                                mock_cfg = self._create_mock_config()
+                                mock_tts = MagicMock()
+                                mock_dialogue_memory = MagicMock()
+
+                                listener = VoiceListener(mock_db, mock_cfg, mock_tts, mock_dialogue_memory)
+                                listener.run()
+
+                                assert mock_class.call_count == 2
+                                assert listener.model == mock_whisper_model
+
+    def test_429_gives_up_after_max_retries(self):
+        """WhisperModel loading gives up after exhausting 429 retries."""
+        error_msg = "429 Too Many Requests for url: https://huggingface.co/api/models/Systran/faster-whisper-medium"
+
+        with patch("jarvis.listening.listener.sys") as mock_sys:
+            mock_sys.platform = "linux"
+            with patch("jarvis.listening.listener.FASTER_WHISPER_AVAILABLE", True):
+                with patch("jarvis.listening.listener.MLX_WHISPER_AVAILABLE", False):
+                    with patch("jarvis.listening.listener.WhisperModel") as mock_class:
+                        mock_class.side_effect = RuntimeError(error_msg)
+
+                        with patch("jarvis.listening.listener.sd") as mock_sd:
+                            mock_sd.query_devices.return_value = [{"name": "Test Mic", "max_input_channels": 1}]
+
+                            with patch("jarvis.listening.listener.time.sleep"):
+                                from jarvis.listening.listener import VoiceListener
+
+                                mock_db = MagicMock()
+                                mock_cfg = self._create_mock_config()
+                                mock_tts = MagicMock()
+                                mock_dialogue_memory = MagicMock()
+
+                                listener = VoiceListener(mock_db, mock_cfg, mock_tts, mock_dialogue_memory)
+                                listener.run()
+
+                                # Should have retried multiple times then given up
+                                assert mock_class.call_count > 1
+                                assert listener.model is None
+
+    def test_non_429_error_not_retried(self):
+        """Non-rate-limit errors are not retried."""
+        error_msg = "Model not found: invalid_model"
+
+        with patch("jarvis.listening.listener.sys") as mock_sys:
+            mock_sys.platform = "linux"
+            with patch("jarvis.listening.listener.FASTER_WHISPER_AVAILABLE", True):
+                with patch("jarvis.listening.listener.MLX_WHISPER_AVAILABLE", False):
+                    with patch("jarvis.listening.listener.WhisperModel") as mock_class:
+                        mock_class.side_effect = RuntimeError(error_msg)
+
+                        with patch("jarvis.listening.listener.sd") as mock_sd:
+                            mock_sd.query_devices.return_value = [{"name": "Test Mic", "max_input_channels": 1}]
+
+                            from jarvis.listening.listener import VoiceListener
+
+                            mock_db = MagicMock()
+                            mock_cfg = self._create_mock_config()
+                            mock_tts = MagicMock()
+                            mock_dialogue_memory = MagicMock()
+
+                            listener = VoiceListener(mock_db, mock_cfg, mock_tts, mock_dialogue_memory)
+                            listener.run()
+
+                            # Should have only tried once — no retry
+                            mock_class.assert_called_once()
+                            assert listener.model is None


### PR DESCRIPTION
When the HuggingFace cache contains a corrupted or partially downloaded
model.bin (e.g. from an interrupted download), Whisper model loading
fails with "Unable to open file 'model.bin'". Previously this was a
terminal error requiring manual cache deletion.

Now the error is detected automatically: the corrupted models-- cache
directory is cleared and the download is retried. If the retry also
fails, a helpful message guides the user to manually delete the cache.

https://claude.ai/code/session_01ENwLxsRwhbcowsafKczLTT