### PR TITLE
fix: handle absolute paths in MCP command config and surface discovery errors

### DIFF
--- a/src/jarvis/daemon.py
+++ b/src/jarvis/daemon.py
@@ -306,7 +306,7 @@ def main() -> None:
     if mcps:
         print(f"📡 Discovering MCP tools from {len(mcps)} server(s)...", flush=True)
         try:
-            mcp_tools = initialize_mcp_tools(mcps, verbose=False)
+            mcp_tools, mcp_errors = initialize_mcp_tools(mcps, verbose=False)
 
             # Group tools by server for display
             tools_by_server: dict = {}
@@ -320,14 +320,16 @@ def main() -> None:
             for server_name in mcps.keys():
                 count = len(tools_by_server.get(server_name, []))
                 if count > 0:
-                    print(f"  ✓ {server_name}: {count} tools available", flush=True)
+                    print(f"  ✅ {server_name}: {count} tools available", flush=True)
+                elif server_name in mcp_errors:
+                    print(f"  ❌ {server_name}: {mcp_errors[server_name]}", flush=True)
                 else:
-                    print(f"  ⚠ {server_name}: no tools discovered", flush=True)
+                    print(f"  ⚠️ {server_name}: no tools discovered", flush=True)
 
             debug_log(f"MCP tools cached: {len(mcp_tools)} total", "mcp")
         except Exception as e:
             debug_log(f"MCP discovery failed: {e}", "mcp")
-            print(f"  ⚠ MCP discovery failed: {e}", flush=True)
+            print(f"  ⚠️ MCP discovery failed: {e}", flush=True)
     else:
         print("📡 No MCP servers configured", flush=True)
 

--- a/src/jarvis/reply/engine.py
+++ b/src/jarvis/reply/engine.py
@@ -89,7 +89,7 @@ def run_reply_engine(db: "Database", cfg, tts: Optional[Any],
             from ..tools.registry import refresh_mcp_tools, is_mcp_cache_initialized
             if is_mcp_cache_initialized():
                 debug_log("New conversation detected, refreshing MCP tools", "mcp")
-                refresh_mcp_tools(verbose=False)
+                _tools, _errors = refresh_mcp_tools(verbose=False)
         except Exception as e:
             debug_log(f"MCP refresh on new conversation failed: {e}", "mcp")
 

--- a/src/jarvis/tools/builtin/refresh_mcp_tools.py
+++ b/src/jarvis/tools/builtin/refresh_mcp_tools.py
@@ -41,12 +41,16 @@ class RefreshMCPToolsTool(Tool):
             context.user_print("🔄 Refreshing MCP tools...")
 
             # Refresh the cache
-            mcp_tools = refresh_mcp_tools(verbose=False)
+            mcp_tools, mcp_errors = refresh_mcp_tools(verbose=False)
 
             if not mcp_tools:
+                error_details = ""
+                if mcp_errors:
+                    error_lines = [f"  {srv}: {err}" for srv, err in mcp_errors.items()]
+                    error_details = "\nServer errors:\n" + "\n".join(error_lines)
                 return ToolExecutionResult(
                     success=True,
-                    reply_text="No MCP tools discovered. Check that MCP servers are configured and running.",
+                    reply_text=f"No MCP tools discovered. Check that MCP servers are configured and running.{error_details}",
                     error_message=None
                 )
 

--- a/src/jarvis/tools/external/mcp_client.py
+++ b/src/jarvis/tools/external/mcp_client.py
@@ -21,8 +21,11 @@ class MCPClient:
         # Windows compatibility: prefer npx.cmd when requested
         if os.name == "nt" and command.lower() == "npx":
             command = "npx.cmd"
-        # Verify command is resolvable on PATH
-        if shutil.which(command) is None:
+        # Verify command exists — absolute paths checked directly, relative names resolved via PATH
+        if os.path.isabs(command):
+            if not os.path.isfile(command):
+                raise FileNotFoundError(f"MCP server command does not exist: {command}")
+        elif shutil.which(command) is None:
             raise FileNotFoundError(f"MCP server command not found on PATH: {command}. Ensure Node.js and npx are installed and available.")
         # Expand user (~) in args for filesystem paths
         raw_args = server_cfg.get("args") or []

--- a/src/jarvis/tools/registry.py
+++ b/src/jarvis/tools/registry.py
@@ -48,7 +48,7 @@ _mcp_tools_cache_lock = threading.Lock()
 _mcp_config_cache: Dict[str, Any] = {}
 
 
-def initialize_mcp_tools(mcps_config: Dict[str, Any], verbose: bool = True) -> Dict[str, "ToolSpec"]:
+def initialize_mcp_tools(mcps_config: Dict[str, Any], verbose: bool = True) -> Tuple[Dict[str, "ToolSpec"], Dict[str, str]]:
     """
     Initialize MCP tools cache at startup.
 
@@ -57,18 +57,18 @@ def initialize_mcp_tools(mcps_config: Dict[str, Any], verbose: bool = True) -> D
         verbose: Whether to print status messages
 
     Returns:
-        Dictionary of discovered MCP tools
+        Tuple of (discovered_tools, errors) where errors maps server name to error message.
     """
     global _mcp_tools_cache, _mcp_config_cache
 
     with _mcp_tools_cache_lock:
         _mcp_config_cache = mcps_config or {}
-        _mcp_tools_cache = discover_mcp_tools(mcps_config)
+        _mcp_tools_cache, errors = discover_mcp_tools(mcps_config)
 
         if verbose and _mcp_tools_cache:
             debug_log(f"MCP tools cache initialized with {len(_mcp_tools_cache)} tools", "mcp")
 
-        return _mcp_tools_cache.copy()
+        return _mcp_tools_cache.copy(), errors
 
 
 def get_cached_mcp_tools() -> Dict[str, "ToolSpec"]:
@@ -77,30 +77,30 @@ def get_cached_mcp_tools() -> Dict[str, "ToolSpec"]:
         return _mcp_tools_cache.copy()
 
 
-def refresh_mcp_tools(verbose: bool = True) -> Dict[str, "ToolSpec"]:
+def refresh_mcp_tools(verbose: bool = True) -> Tuple[Dict[str, "ToolSpec"], Dict[str, str]]:
     """
     Refresh MCP tools cache by rediscovering all tools.
 
     Returns:
-        Dictionary of discovered MCP tools
+        Tuple of (discovered_tools, errors) where errors maps server name to error message.
     """
     global _mcp_tools_cache
 
     with _mcp_tools_cache_lock:
         if not _mcp_config_cache:
             debug_log("No MCP config cached, skipping refresh", "mcp")
-            return {}
+            return {}, {}
 
         if verbose:
             print("🔄 Refreshing MCP tools...", flush=True)
 
-        _mcp_tools_cache = discover_mcp_tools(_mcp_config_cache)
+        _mcp_tools_cache, errors = discover_mcp_tools(_mcp_config_cache)
 
         if verbose:
             print(f"  ✅ Found {len(_mcp_tools_cache)} MCP tools", flush=True)
 
         debug_log(f"MCP tools cache refreshed with {len(_mcp_tools_cache)} tools", "mcp")
-        return _mcp_tools_cache.copy()
+        return _mcp_tools_cache.copy(), errors
 
 
 def is_mcp_cache_initialized() -> bool:
@@ -118,14 +118,19 @@ class ToolSpec:
     inputSchema: Optional[Dict[str, Any]] = None  # JSON Schema for arguments (matches MCP format)
 
 
-def discover_mcp_tools(mcps_config: Dict[str, Any]) -> Dict[str, ToolSpec]:
-    """Discover all tools from configured MCP servers and create ToolSpec entries for them."""
+def discover_mcp_tools(mcps_config: Dict[str, Any]) -> Tuple[Dict[str, ToolSpec], Dict[str, str]]:
+    """Discover all tools from configured MCP servers and create ToolSpec entries for them.
+
+    Returns:
+        Tuple of (discovered_tools, errors) where errors maps server name to error message.
+    """
     if not mcps_config:
-        return {}
+        return {}, {}
 
     try:
         client = MCPClient(mcps_config)
         discovered_tools = {}
+        errors: Dict[str, str] = {}
 
         for server_name in mcps_config.keys():
             try:
@@ -149,13 +154,14 @@ def discover_mcp_tools(mcps_config: Dict[str, Any]) -> Dict[str, ToolSpec]:
 
             except Exception as e:
                 debug_log(f"Failed to discover tools from MCP server '{server_name}': {e}", "mcp")
+                errors[server_name] = str(e)
                 continue
 
-        return discovered_tools
+        return discovered_tools, errors
 
     except Exception as e:
         debug_log(f"Failed to discover MCP tools: {e}", "mcp")
-        return {}
+        return {}, {"_global": str(e)}
 
 
 def generate_tools_json_schema(allowed_tools: Optional[List[str]] = None, mcp_tools: Optional[Dict[str, ToolSpec]] = None) -> List[Dict[str, Any]]:

--- a/tests/test_mcp_client.py
+++ b/tests/test_mcp_client.py
@@ -1,5 +1,82 @@
 import asyncio
+import os
 import pytest
+
+
+@pytest.mark.unit
+def test_absolute_path_command_skips_which(monkeypatch, tmp_path):
+    """Absolute paths to executables should use os.path.isfile, not shutil.which."""
+    from jarvis.tools.external.mcp_client import MCPClient
+
+    # Create a fake executable file at an absolute path
+    fake_exe = tmp_path / "node.exe"
+    fake_exe.write_text("fake")
+    fake_exe.chmod(0o755)
+
+    mcps = {
+        "test": {
+            "command": str(fake_exe),
+            "args": ["server.js"],
+        }
+    }
+
+    client = MCPClient(mcps)
+
+    # shutil.which should NOT be called for absolute paths
+    which_called = False
+    original_which = __import__("shutil").which
+
+    def tracking_which(cmd):
+        nonlocal which_called
+        which_called = True
+        return original_which(cmd)
+
+    monkeypatch.setattr("jarvis.tools.external.mcp_client.shutil.which", tracking_which)
+
+    # We need to mock stdio_client to avoid actually connecting
+    class FakeCM:
+        async def __aenter__(self):
+            return object(), object()
+        async def __aexit__(self, *a):
+            return False
+
+    class FakeSession:
+        def __init__(self, r, w):
+            pass
+        async def __aenter__(self):
+            s = type("S", (), {"initialize": lambda self: asyncio.sleep(0), "list_tools": lambda self: asyncio.sleep(0)})()
+            return s
+        async def __aexit__(self, *a):
+            return False
+
+    monkeypatch.setattr("jarvis.tools.external.mcp_client.stdio_client", lambda params: FakeCM())
+    monkeypatch.setattr("jarvis.tools.external.mcp_client.ClientSession", FakeSession)
+
+    try:
+        asyncio.run(client.list_tools_async("test"))
+    except Exception:
+        pass  # We only care that the path validation passed
+
+    assert not which_called, "shutil.which should not be called for absolute paths"
+
+
+@pytest.mark.unit
+def test_absolute_path_not_found_gives_clear_error(tmp_path):
+    """Non-existent absolute path should raise FileNotFoundError with clear message."""
+    from jarvis.tools.external.mcp_client import MCPClient
+
+    fake_path = str(tmp_path / "nonexistent" / "node.exe")
+    mcps = {
+        "test": {
+            "command": fake_path,
+            "args": [],
+        }
+    }
+
+    client = MCPClient(mcps)
+
+    with pytest.raises(FileNotFoundError, match="does not exist"):
+        client._connect_stdio(mcps["test"])
 
 
 @pytest.mark.unit

--- a/tests/test_mcp_discovery.py
+++ b/tests/test_mcp_discovery.py
@@ -25,8 +25,9 @@ class DummyDB:
 @pytest.mark.unit
 def test_discover_mcp_tools_empty_config():
     """Test that empty MCP config returns empty tools dict."""
-    result = discover_mcp_tools({})
+    result, errors = discover_mcp_tools({})
     assert result == {}
+    assert errors == {}
 
 
 @pytest.mark.unit
@@ -56,7 +57,7 @@ def test_discover_mcp_tools_with_fake_server(monkeypatch):
         }
     }
 
-    result = discover_mcp_tools(mcps_config)
+    result, errors = discover_mcp_tools(mcps_config)
 
     # Should create tools with server__toolname format
     expected_tools = {
@@ -95,11 +96,35 @@ def test_discover_mcp_tools_handles_server_errors(monkeypatch):
         "bad-server": {"command": "bad"}
     }
 
-    result = discover_mcp_tools(mcps_config)
+    result, errors = discover_mcp_tools(mcps_config)
 
     # Should still get tools from the good server
     assert "good-server__tool1" in result
     assert len(result) == 1
+
+    # Should report the error for the bad server
+    assert "bad-server" in errors
+    assert "Server failed" in errors["bad-server"]
+
+
+@pytest.mark.unit
+def test_discover_mcp_tools_returns_empty_errors_on_success(monkeypatch):
+    """Test that successful discovery returns empty errors dict."""
+    class FakeClient:
+        def __init__(self, config):
+            self.config = config
+
+        def list_tools(self, server_name):
+            return [{"name": "tool1", "description": "A tool"}]
+
+    import jarvis.tools.registry as registry_mod
+    monkeypatch.setattr(registry_mod, "MCPClient", FakeClient)
+
+    mcps_config = {"server": {"command": "cmd"}}
+    result, errors = discover_mcp_tools(mcps_config)
+
+    assert len(result) == 1
+    assert errors == {}
 
 
 @pytest.mark.unit

--- a/tests/test_mcp_e2e.py
+++ b/tests/test_mcp_e2e.py
@@ -77,7 +77,7 @@ def test_mcp_discovery_with_mock():
 
     try:
         with patch('src.jarvis.tools.registry.MCPClient', FakeMCPClient):
-            mcp_tools = discover_mcp_tools(fake_mcps)
+            mcp_tools, _errors = discover_mcp_tools(fake_mcps)
 
         expected_tools = {
             "test-server__read",
@@ -171,7 +171,7 @@ def test_tool_name_format():
     try:
         with patch('src.jarvis.tools.registry.MCPClient', FakeMCPClient):
             mcps_config = {"my-server": {"command": "test"}}
-            mcp_tools = discover_mcp_tools(mcps_config)
+            mcp_tools, _errors = discover_mcp_tools(mcps_config)
 
         expected_names = {
             "my-server__tool_with_underscores",
@@ -216,7 +216,7 @@ def test_error_handling():
                 "bad-server": {"command": "bad"},
                 "empty-server": {"command": "empty"}
             }
-            mcp_tools = discover_mcp_tools(mcps_config)
+            mcp_tools, mcp_errors = discover_mcp_tools(mcps_config)
 
         # Should only get tools from the good server
         if len(mcp_tools) == 1 and "good-server__working_tool" in mcp_tools:

--- a/tests/test_mcp_integration.py
+++ b/tests/test_mcp_integration.py
@@ -31,7 +31,7 @@ def test_mcp_tools_integrated_with_reply_engine():
     with patch('jarvis.tools.registry.MCPClient', FakeMCPClient):
         # Test discovery
         mcps_config = {"test-server": {"command": "fake"}}
-        mcp_tools = discover_mcp_tools(mcps_config)
+        mcp_tools, _errors = discover_mcp_tools(mcps_config)
         
         # Test tool registration (simulate what reply engine does)
         allowed_tools = PROFILE_ALLOWED_TOOLS.get("developer", []).copy()


### PR DESCRIPTION
## Summary
- **Fix absolute path validation**: `shutil.which()` was used to validate all MCP server commands, but it's unnecessary and potentially unreliable for absolute paths (especially in PyInstaller EXE builds). Now absolute paths are validated with `os.path.isfile()` directly, while relative command names still use `shutil.which()` for PATH resolution.
- **Surface discovery errors to users**: When MCP tool discovery failed, errors were silently swallowed into `debug_log` — users only saw "⚠ server_name: no tools discovered" with zero context. Now the actual error message is displayed at startup (`❌ server_name: <error>`), in the `refreshMCPTools` tool output, and returned from all discovery functions.

Closes #163

## Test plan
- [x] New unit test: absolute path commands skip `shutil.which` and use `os.path.isfile` instead
- [x] New unit test: non-existent absolute path gives clear "does not exist" error
- [x] New unit test: `discover_mcp_tools` returns errors dict alongside tools
- [x] New unit test: successful discovery returns empty errors dict
- [x] All 176 existing unit tests still pass
- [ ] Manual test on Windows EXE build with absolute `node.exe` path

🤖 Generated with [Claude Code](https://claude.com/claude-code)