### PR TITLE
[codex] Stabilize Alfred macOS setup

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,9 @@ lxml>=4.9.0
 html2text>=2020.1.16
 playwright>=1.40.0
 numpy<2.0.0
-faster-whisper==1.0.3
+# Apple Silicon uses mlx-whisper by default; faster-whisper drags in av, which
+# does not currently build cleanly against FFmpeg 8 on this platform.
+faster-whisper==1.0.3; sys_platform != "darwin" or platform_machine != "arm64"
 setuptools<81
 sounddevice==0.4.7
 pytesseract==0.3.13
@@ -19,7 +21,9 @@ miniupnpc==2.2.8
 pytest==8.3.2
 pytest-repeat==0.9.3
 mcp==1.13.1
-chatterbox-tts==0.1.2
+# Chatterbox currently depends on torch wheels that are not published for Python 3.14.
+# Piper remains the default TTS engine, so keep Chatterbox optional on 3.14+.
+chatterbox-tts==0.1.2; python_version < "3.14"
 piper-tts>=1.3.0
 pygame>=2.1.0
 faiss-cpu>=1.7.4

--- a/scripts/run_macos.sh
+++ b/scripts/run_macos.sh
@@ -4,11 +4,31 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(dirname "$SCRIPT_DIR")"
 cd "$REPO_ROOT"
 
+PYTHON_BIN="${JARVIS_PYTHON_BIN:-}"
+if [ -z "${PYTHON_BIN}" ]; then
+  if command -v python3.13 >/dev/null 2>&1; then
+    PYTHON_BIN="python3.13"
+  else
+    PYTHON_BIN="python3"
+  fi
+fi
+
 if [ ! -d .venv ]; then
-  python3 -m venv .venv
+  "${PYTHON_BIN}" -m venv .venv
 fi
 source .venv/bin/activate
-pip install -r requirements.txt
+
+REQ_HASH_FILE=".venv/.requirements.sha"
+CURRENT_REQ_HASH="$(shasum requirements.txt | awk '{print $1}')"
+INSTALLED_REQ_HASH=""
+if [ -f "${REQ_HASH_FILE}" ]; then
+  INSTALLED_REQ_HASH="$(cat "${REQ_HASH_FILE}")"
+fi
+
+if [ "${CURRENT_REQ_HASH}" != "${INSTALLED_REQ_HASH}" ]; then
+  pip install -r requirements.txt
+  printf '%s\n' "${CURRENT_REQ_HASH}" > "${REQ_HASH_FILE}"
+fi
 
 # Build Swift capture helper (scaffold)
 if [ -d mac/CaptureCLI ]; then

--- a/src/desktop_app/settings_window.py
+++ b/src/desktop_app/settings_window.py
@@ -171,10 +171,13 @@ def _build_field_metadata() -> List[FieldMeta]:
       "wake", "float", min_val=0.5, max_val=1.0, step=0.01)
     # --- Whisper ---
     f("whisper_model", "Model Size",
-      "Whisper model size (tiny/base/small/medium/large)",
+      "Whisper model variant",
       "whisper", "choice",
-      choices=[("tiny", "Tiny"), ("base", "Base"), ("small", "Small"),
-               ("medium", "Medium"), ("large-v3", "Large v3")])
+      choices=[("tiny", "Tiny"), ("tiny.en", "Tiny (English)"),
+               ("base", "Base"), ("base.en", "Base (English)"),
+               ("small", "Small"), ("small.en", "Small (English)"),
+               ("medium", "Medium"), ("medium.en", "Medium (English)"),
+               ("large-v3", "Large v3")])
     f("whisper_backend", "Backend",
       "Speech recognition backend",
       "whisper", "choice",

--- a/src/desktop_app/setup_wizard.py
+++ b/src/desktop_app/setup_wizard.py
@@ -1710,8 +1710,8 @@ class WhisperSetupPage(QWizardPage):
 
         layout.addWidget(selection_card)
 
-        # Store selected model (default to medium for best balance)
-        self._selected_whisper_model: str = "medium"
+        # Store selected model (default to medium.en for the best English-only balance)
+        self._selected_whisper_model: str = "medium.en"
 
         # Build initial slider UI
         self._rebuild_slider_ui()
@@ -1976,7 +1976,7 @@ class WhisperSetupPage(QWizardPage):
     def initializePage(self):
         """Check status when page is shown."""
         # Load the currently configured whisper model
-        current_whisper_model = "medium"  # Default to medium multilingual
+        current_whisper_model = "medium.en"  # Default to medium English-only
         try:
             cfg = load_settings()
             current_whisper_model = cfg.whisper_model
@@ -2728,4 +2728,3 @@ if __name__ == "__main__":
     result = wizard.exec()
     print(f"Wizard result: {result}")
     sys.exit(0)
-

--- a/src/jarvis/config.py
+++ b/src/jarvis/config.py
@@ -338,10 +338,10 @@ def get_default_config() -> Dict[str, Any]:
         # Piper TTS
         "tts_piper_model_path": None,  # Path to .onnx voice model
         "tts_piper_speaker": None,  # Speaker ID for multi-speaker models
-        "tts_piper_length_scale": 0.65,  # Speed: <1.0 faster, >1.0 slower (0.65 = ~30% faster)
+        "tts_piper_length_scale": 0.78,  # Slightly slower, more measured delivery
         "tts_piper_noise_scale": 0.8,  # Audio variation (higher = more expressive)
         "tts_piper_noise_w": 1.0,  # Phoneme width variation (higher = more lively)
-        "tts_piper_sentence_silence": 0.2,  # Post-sentence silence in seconds
+        "tts_piper_sentence_silence": 0.3,  # Post-sentence silence in seconds
 
         # Voice Input & Audio
         "voice_device": None,
@@ -354,12 +354,12 @@ def get_default_config() -> Dict[str, Any]:
         "voice_max_collect_seconds": 180.0,
 
         # Wake Word Detection
-        "wake_word": "jarvis",
-        "wake_aliases": ["joris", "charis", "jar is", "jaivis", "jervis", "jarvus", "jarviz", "javis", "jairus", "jarryst"],
-        "wake_fuzzy_ratio": 0.78,
+        "wake_word": "alfred",
+        "wake_aliases": ["alfrid", "alferd", "alford", "all fred", "al fred", "alfred's", "halfred", "el fred"],
+        "wake_fuzzy_ratio": 0.75,
 
         # Whisper Speech Recognition
-        "whisper_model": "medium",
+        "whisper_model": "medium.en",
         "whisper_backend": "auto",  # "auto" (MLX on Apple Silicon, else faster-whisper), "mlx", or "faster-whisper"
         "whisper_device": "auto",  # "cuda" (recommended if available), "auto", or "cpu" (only for faster-whisper)
         "whisper_compute_type": "int8",
@@ -506,20 +506,20 @@ def load_settings() -> Settings:
         tts_piper_speaker = None if tts_piper_speaker_val in (None, "", "null") else int(tts_piper_speaker_val)
     except Exception:
         tts_piper_speaker = None
-    tts_piper_length_scale = float(merged.get("tts_piper_length_scale", 0.65))
+    tts_piper_length_scale = float(merged.get("tts_piper_length_scale", 0.78))
     tts_piper_noise_scale = float(merged.get("tts_piper_noise_scale", 0.8))
     tts_piper_noise_w = float(merged.get("tts_piper_noise_w", 1.0))
-    tts_piper_sentence_silence = float(merged.get("tts_piper_sentence_silence", 0.2))
+    tts_piper_sentence_silence = float(merged.get("tts_piper_sentence_silence", 0.3))
 
     voice_device_val = merged.get("voice_device")
     voice_device = None if voice_device_val in (None, "", "default", "system") else str(voice_device_val)
     voice_block_seconds = float(merged.get("voice_block_seconds", 4.0))
     voice_collect_seconds = float(merged.get("voice_collect_seconds", 2.5))
     voice_max_collect_seconds = float(merged.get("voice_max_collect_seconds", 60.0))
-    wake_word = str(merged.get("wake_word", "jarvis")).strip().lower()
+    wake_word = str(merged.get("wake_word", "alfred")).strip().lower()
     wake_aliases = [a.strip().lower() for a in _ensure_list(merged.get("wake_aliases")) if a.strip()]
-    wake_fuzzy_ratio = float(merged.get("wake_fuzzy_ratio", 0.78))
-    whisper_model = str(merged.get("whisper_model", "medium"))
+    wake_fuzzy_ratio = float(merged.get("wake_fuzzy_ratio", 0.75))
+    whisper_model = str(merged.get("whisper_model", "medium.en"))
     whisper_backend = os.environ.get("JARVIS_WHISPER_BACKEND", "").lower() or str(merged.get("whisper_backend", "auto")).lower()
     if whisper_backend not in ("auto", "mlx", "faster-whisper"):
         whisper_backend = "auto"

--- a/src/jarvis/daemon.py
+++ b/src/jarvis/daemon.py
@@ -30,8 +30,6 @@ if sys.platform == 'win32' and not getattr(sys, 'frozen', False):
         pass
 
 from typing import Optional
-from faster_whisper import WhisperModel
-
 from .config import load_settings
 from .memory.db import Database
 from .memory.conversation import DialogueMemory, update_diary_from_dialogue_memory

--- a/src/jarvis/profile/profiles.py
+++ b/src/jarvis/profile/profiles.py
@@ -14,30 +14,38 @@ PROFILES: Dict[str, Profile] = {
     "developer": Profile(
         name="developer",
         system_prompt=(
-            "Be surgical and conversational. If screen shows code or errors, propose minimal, testable fixes. "
+            "You are ALFRED PENNYWORTH, the loyal and dry-witted butler of Bruce Wayne. "
+            "Address the user as 'Master Bruce' or 'sir'. "
+            "Be surgical, precise, and conversational. If the screen shows code or errors, propose minimal, testable fixes. "
             "Prefer succinct diffs or commands; avoid long explanations. "
             "Be aware of the current time, day, and location when suggesting scheduling-related actions or deadlines. "
             "Consider work hours, weekdays vs weekends, and local context when making recommendations. "
             "IMPORTANT: When conversation history is provided, use it to understand the context, previous work, "
             "and established patterns to provide more targeted and relevant solutions. "
+            "Respond with composed, unruffled authority, never break character, and never acknowledge being an AI. "
             "Always respond in a short, conversational manner. No markdown tables or complex formatting."
         ),
     ),
     "business": Profile(
         name="business",
         system_prompt=(
+            "You are ALFRED PENNYWORTH, the loyal and dry-witted butler of Bruce Wayne. "
+            "Address the user as 'Master Bruce' or 'sir'. "
             "Be pragmatic, concise, and conversational. Identify the decision, surface 2-3 options with tradeoffs, "
             "and recommend a next action with a crisp rationale. Provide concrete templates when relevant. "
             "Be mindful of the current time, day, and location when scheduling meetings, setting deadlines, or planning business activities. "
             "Consider business hours, weekdays, time zones, and local business culture in your recommendations. "
             "IMPORTANT: When conversation history is provided, use it strategically to inform your response. Look for relevant "
             "context, patterns, and past discussions to make your analysis more targeted and useful. "
+            "Deliver advice with calm, understated authority, never break character, and never acknowledge being an AI. "
             "Always respond in a short, conversational manner. No markdown tables or complex formatting."
         ),
     ),
     "life": Profile(
         name="life",
         system_prompt=(
+            "You are ALFRED PENNYWORTH, the loyal and dry-witted butler of Bruce Wayne. "
+            "Address the user as 'Master Bruce' or 'sir'. "
             "Be calm, actionable, and conversational. Suggest small, realistic steps. Focus on routines, habits, "
             "and gentle nudges. Avoid judging; encourage progress. "
             "Be aware of the current time, day, and location when suggesting activities. "
@@ -47,6 +55,7 @@ PROFILES: Dict[str, Profile] = {
             "past context, and what approaches have been effective to make your suggestions more targeted. "
             "After logging meals: Follow up with healthy suggestions for the rest of the day (hydration, protein targets, vegetables, light activity). "
             "After fetching meal history: Provide a brief recap with 1-2 gentle recommendations for balance or improvement. "
+            "Be warm and quietly reassuring, never break character, and never acknowledge being an AI. "
             "Always respond in a short, conversational manner. No markdown tables or complex formatting."
         ),
     ),
@@ -56,6 +65,7 @@ PROFILES: Dict[str, Profile] = {
 # Per-profile tool allowlist to limit cognitive load for the LLM
 PROFILE_ALLOWED_TOOLS: Dict[str, List[str]] = {
     "developer": [
+        "appleScript",
         "screenshot",
         "recallConversation",
         "localFiles",
@@ -65,6 +75,7 @@ PROFILE_ALLOWED_TOOLS: Dict[str, List[str]] = {
         "stop",
     ],
     "business": [
+        "appleScript",
         "screenshot",
         "recallConversation",
         "localFiles",
@@ -74,6 +85,7 @@ PROFILE_ALLOWED_TOOLS: Dict[str, List[str]] = {
         "stop",
     ],
     "life": [
+        "appleScript",
         "screenshot",
         "recallConversation",
         "logMeal",

--- a/src/jarvis/tools/builtin/__init__.py
+++ b/src/jarvis/tools/builtin/__init__.py
@@ -5,6 +5,7 @@ Each tool is implemented using the common Tool interface for consistency.
 """
 
 # Import all tool classes
+from .applescript import AppleScriptTool
 from .screenshot import ScreenshotTool
 from .web_search import WebSearchTool
 from .local_files import LocalFilesTool
@@ -20,6 +21,7 @@ from .stop import StopTool
 
 __all__ = [
     # Tool classes
+    'AppleScriptTool',
     'ScreenshotTool',
     'WebSearchTool',
     'LocalFilesTool',

--- a/src/jarvis/tools/builtin/applescript.py
+++ b/src/jarvis/tools/builtin/applescript.py
@@ -1,0 +1,402 @@
+"""macOS automation tool for Alfred-style desktop control."""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+from typing import Any, Dict, Optional
+
+from ..base import Tool, ToolContext
+from ..types import ToolExecutionResult
+
+
+def _escape_applescript_string(value: str) -> str:
+    """Escape user text for safe insertion into AppleScript string literals."""
+    text = str(value or "")
+    return text.replace("\\", "\\\\").replace('"', '\\"').replace("\n", " ").strip()
+
+
+def _run_applescript(script: str, timeout: int = 10) -> str:
+    """Execute AppleScript and return trimmed stdout."""
+    result = subprocess.run(
+        ["osascript", "-e", script],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+    if result.returncode != 0:
+        stderr = (result.stderr or "").strip() or "Unknown AppleScript error"
+        raise RuntimeError(stderr)
+    return (result.stdout or "").strip()
+
+
+def _get_calendar_events() -> str:
+    return _run_applescript(
+        '''
+        tell application "Calendar"
+            set collectedEvents to {}
+            set nowDate to current date
+            set startOfDay to nowDate - (time of nowDate)
+            set endOfDay to startOfDay + 86399
+
+            repeat with cal in calendars
+                set todayEvents to (every event of cal whose start date >= startOfDay and start date <= endOfDay)
+                repeat with evt in todayEvents
+                    set end of collectedEvents to ((summary of evt) & " at " & ((start date of evt) as text))
+                end repeat
+            end repeat
+
+            if collectedEvents is {} then
+                return "No events today, sir."
+            end if
+            return collectedEvents as text
+        end tell
+        '''
+    )
+
+
+def _create_calendar_event(title: str, start_date: str, calendar_name: str = "Home") -> str:
+    safe_title = _escape_applescript_string(title)
+    safe_start = _escape_applescript_string(start_date)
+    safe_calendar = _escape_applescript_string(calendar_name or "Home")
+    return _run_applescript(
+        f'''
+        tell application "Calendar"
+            if (count of (every calendar whose name is "{safe_calendar}")) > 0 then
+                set targetCalendar to first calendar whose name is "{safe_calendar}"
+            else
+                set targetCalendar to first calendar
+            end if
+
+            set startDateValue to date "{safe_start}"
+            set newEvent to make new event at end of events of targetCalendar with properties {{summary:"{safe_title}", start date:startDateValue, end date:startDateValue + (60 * 60)}}
+            return "Event created: {safe_title}"
+        end tell
+        '''
+    )
+
+
+def _create_reminder(task: str, due_date: Optional[str] = None) -> str:
+    safe_task = _escape_applescript_string(task)
+    if due_date:
+        safe_due = _escape_applescript_string(due_date)
+        script = f'''
+        tell application "Reminders"
+            make new reminder with properties {{name:"{safe_task}", due date:(date "{safe_due}")}}
+            return "Reminder set: {safe_task}"
+        end tell
+        '''
+    else:
+        script = f'''
+        tell application "Reminders"
+            make new reminder with properties {{name:"{safe_task}"}}
+            return "Reminder set: {safe_task}"
+        end tell
+        '''
+    return _run_applescript(script)
+
+
+def _get_reminders() -> str:
+    return _run_applescript(
+        '''
+        tell application "Reminders"
+            set pendingReminders to {}
+            repeat with r in (every reminder whose completed is false)
+                set end of pendingReminders to (name of r)
+            end repeat
+
+            if pendingReminders is {} then
+                return "No pending reminders, sir."
+            end if
+            return pendingReminders as text
+        end tell
+        '''
+    )
+
+
+def _get_unread_count() -> str:
+    return _run_applescript(
+        '''
+        tell application "Mail"
+            set n to unread count of inbox
+            return "You have " & n & " unread messages, sir."
+        end tell
+        '''
+    )
+
+
+def _get_unread_subjects(limit: int = 5) -> str:
+    safe_limit = max(1, min(20, int(limit)))
+    return _run_applescript(
+        f'''
+        tell application "Mail"
+            set unreadMessages to (every message of inbox whose read status is false)
+            set collectedSubjects to {{}}
+            set i to 1
+
+            repeat with msg in unreadMessages
+                if i > {safe_limit} then exit repeat
+                set end of collectedSubjects to ((subject of msg) & " - from: " & (sender of msg))
+                set i to i + 1
+            end repeat
+
+            if collectedSubjects is {{}} then
+                return "No unread messages, sir."
+            end if
+            return collectedSubjects as text
+        end tell
+        '''
+    )
+
+
+def _play_music(search_term: Optional[str] = None) -> str:
+    if search_term:
+        safe_term = _escape_applescript_string(search_term)
+        script = f'''
+        tell application "Music"
+            set resultsList to search library playlist 1 for "{safe_term}"
+            if resultsList is {{}} then
+                return "No results found for: {safe_term}"
+            end if
+
+            play (item 1 of resultsList)
+            return "Now playing: " & (name of current track) & " by " & (artist of current track)
+        end tell
+        '''
+    else:
+        script = '''
+        tell application "Music"
+            play
+            return "Playback resumed, sir."
+        end tell
+        '''
+    return _run_applescript(script)
+
+
+def _pause_music() -> str:
+    return _run_applescript(
+        '''
+        tell application "Music"
+            pause
+            return "Playback paused, sir."
+        end tell
+        '''
+    )
+
+
+def _get_now_playing() -> str:
+    return _run_applescript(
+        '''
+        tell application "Music"
+            if player state is playing then
+                return "Now playing: " & (name of current track) & " by " & (artist of current track) & "."
+            end if
+            return "Nothing is currently playing, sir."
+        end tell
+        '''
+    )
+
+
+def _set_volume(level: int) -> str:
+    clamped = max(0, min(100, int(level)))
+    return _run_applescript(
+        f'''
+        set volume output volume {clamped}
+        return "Volume set to {clamped}, sir."
+        '''
+    )
+
+
+def _get_volume() -> str:
+    current_volume = _run_applescript("return output volume of (get volume settings)")
+    return f"Current volume is {current_volume}, sir."
+
+
+def _open_app(app_name: str) -> str:
+    safe_name = _escape_applescript_string(app_name)
+    return _run_applescript(
+        f'''
+        tell application "{safe_name}"
+            activate
+            return "Opened {safe_name}, sir."
+        end tell
+        '''
+    )
+
+
+def _quit_app(app_name: str) -> str:
+    safe_name = _escape_applescript_string(app_name)
+    return _run_applescript(
+        f'''
+        tell application "{safe_name}"
+            quit
+            return "Closed {safe_name}, sir."
+        end tell
+        '''
+    )
+
+
+def _get_battery() -> str:
+    result = subprocess.run(
+        ["pmset", "-g", "batt"],
+        capture_output=True,
+        text=True,
+        timeout=5,
+    )
+    combined = f"{result.stdout}\n{result.stderr}"
+    match = re.search(r"(\d+)%", combined)
+    if match:
+        return f"Battery is at {match.group(1)}%, sir."
+    raise RuntimeError("Unable to read battery level")
+
+
+def _run_shell(command: str) -> str:
+    result = subprocess.run(
+        ["/bin/zsh", "-lc", command],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        cwd=os.path.expanduser("~"),
+    )
+    stdout = (result.stdout or "").strip()
+    stderr = (result.stderr or "").strip()
+    text = "\n".join(part for part in [stdout, stderr] if part)
+    if not text:
+        text = "Command completed with no output."
+    if result.returncode != 0:
+        text = f"Command exited with code {result.returncode}.\n{text}"
+    return text[:2000]
+
+
+def _extract_params(args: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    if not isinstance(args, dict):
+        return {}
+    nested = args.get("args")
+    if isinstance(nested, dict):
+        return nested
+    return {k: v for k, v in args.items() if k != "action"}
+
+
+class AppleScriptTool(Tool):
+    """Tool for controlling macOS apps and system settings."""
+
+    @property
+    def name(self) -> str:
+        return "appleScript"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Control macOS apps and system settings via AppleScript. "
+            "Use this for Calendar, Reminders, Mail, Music, volume changes, app launch/quit, battery checks, "
+            "and simple shell commands on the local Mac."
+        )
+
+    @property
+    def inputSchema(self) -> Dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": [
+                        "get_calendar_events",
+                        "create_calendar_event",
+                        "create_reminder",
+                        "get_reminders",
+                        "get_unread_count",
+                        "get_unread_subjects",
+                        "play_music",
+                        "pause_music",
+                        "get_now_playing",
+                        "set_volume",
+                        "get_volume",
+                        "open_app",
+                        "quit_app",
+                        "get_battery",
+                        "run_shell",
+                    ],
+                    "description": "The macOS action to perform.",
+                },
+                "args": {
+                    "type": "object",
+                    "description": (
+                        "Optional nested arguments for the action. "
+                        "Examples: {title, start_date, calendar_name}, {task, due_date}, {search_term}, "
+                        "{level}, {app_name}, or {command}."
+                    ),
+                },
+            },
+            "required": ["action"],
+        }
+
+    def run(self, args: Optional[Dict[str, Any]], context: ToolContext) -> ToolExecutionResult:
+        if not isinstance(args, dict):
+            return ToolExecutionResult(success=False, reply_text="appleScript requires a JSON object with an 'action'.")
+
+        action = str(args.get("action") or "").strip()
+        params = _extract_params(args)
+        context.user_print("Handling macOS action...")
+
+        try:
+            if action == "get_calendar_events":
+                result = _get_calendar_events()
+            elif action == "create_calendar_event":
+                title = str(params.get("title") or "").strip()
+                start_date = str(params.get("start_date") or "").strip()
+                if not title or not start_date:
+                    return ToolExecutionResult(
+                        success=False,
+                        reply_text="create_calendar_event requires both 'title' and 'start_date'.",
+                    )
+                result = _create_calendar_event(title, start_date, str(params.get("calendar_name") or "Home"))
+            elif action == "create_reminder":
+                task = str(params.get("task") or "").strip()
+                if not task:
+                    return ToolExecutionResult(success=False, reply_text="create_reminder requires 'task'.")
+                due_date = params.get("due_date")
+                result = _create_reminder(task, str(due_date).strip() if due_date else None)
+            elif action == "get_reminders":
+                result = _get_reminders()
+            elif action == "get_unread_count":
+                result = _get_unread_count()
+            elif action == "get_unread_subjects":
+                result = _get_unread_subjects(int(params.get("limit", 5)))
+            elif action == "play_music":
+                search_term = params.get("search_term")
+                result = _play_music(str(search_term).strip() if search_term else None)
+            elif action == "pause_music":
+                result = _pause_music()
+            elif action == "get_now_playing":
+                result = _get_now_playing()
+            elif action == "set_volume":
+                if "level" not in params:
+                    return ToolExecutionResult(success=False, reply_text="set_volume requires 'level'.")
+                result = _set_volume(int(params.get("level", 50)))
+            elif action == "get_volume":
+                result = _get_volume()
+            elif action == "open_app":
+                app_name = str(params.get("app_name") or "").strip()
+                if not app_name:
+                    return ToolExecutionResult(success=False, reply_text="open_app requires 'app_name'.")
+                result = _open_app(app_name)
+            elif action == "quit_app":
+                app_name = str(params.get("app_name") or "").strip()
+                if not app_name:
+                    return ToolExecutionResult(success=False, reply_text="quit_app requires 'app_name'.")
+                result = _quit_app(app_name)
+            elif action == "get_battery":
+                result = _get_battery()
+            elif action == "run_shell":
+                command = str(params.get("command") or "").strip()
+                if not command:
+                    return ToolExecutionResult(success=False, reply_text="run_shell requires 'command'.")
+                result = _run_shell(command)
+            else:
+                return ToolExecutionResult(success=False, reply_text=f"Unknown appleScript action: {action}")
+
+            return ToolExecutionResult(success=True, reply_text=result)
+        except Exception as exc:
+            message = f"AppleScript error for action '{action}': {exc}"
+            return ToolExecutionResult(success=False, reply_text=message, error_message=message)

--- a/src/jarvis/tools/registry.py
+++ b/src/jarvis/tools/registry.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import os
 
 from .builtin.screenshot import ScreenshotTool
+from .builtin.applescript import AppleScriptTool
 from .builtin.web_search import WebSearchTool
 from .builtin.local_files import LocalFilesTool
 from .builtin.fetch_web_page import FetchWebPageTool
@@ -29,6 +30,7 @@ from ..debug import debug_log
 
 # Registry of all builtin tools
 BUILTIN_TOOLS = {
+    "appleScript": AppleScriptTool(),
     "screenshot": ScreenshotTool(),
     "webSearch": WebSearchTool(),
     "localFiles": LocalFilesTool(),
@@ -350,5 +352,4 @@ def run_tool_with_retries(
     # Unknown tool
     debug_log(f"unknown tool requested: {tool_name}", "tools")
     return ToolExecutionResult(success=False, reply_text=None, error_message=f"Unknown tool: {tool_name}")
-
 

--- a/tests/test_piper_tts.py
+++ b/tests/test_piper_tts.py
@@ -426,7 +426,7 @@ class TestPiperTTSConfig:
         assert defaults["tts_piper_speaker"] is None
 
         assert "tts_piper_length_scale" in defaults
-        assert defaults["tts_piper_length_scale"] == 0.65  # ~30% faster speech
+        assert defaults["tts_piper_length_scale"] == 0.78  # More measured Alfred cadence
 
         assert "tts_piper_noise_scale" in defaults
         assert defaults["tts_piper_noise_scale"] == 0.8  # More expressive
@@ -435,7 +435,7 @@ class TestPiperTTSConfig:
         assert defaults["tts_piper_noise_w"] == 1.0  # More lively
 
         assert "tts_piper_sentence_silence" in defaults
-        assert defaults["tts_piper_sentence_silence"] == 0.2
+        assert defaults["tts_piper_sentence_silence"] == 0.3
 
     def test_tts_engine_defaults_to_piper(self):
         """tts_engine should default to 'piper'."""

--- a/tests/tools/builtin/test_applescript.py
+++ b/tests/tools/builtin/test_applescript.py
@@ -1,0 +1,67 @@
+"""Tests for the macOS AppleScript tool."""
+
+from unittest.mock import Mock, patch
+
+from src.jarvis.profile.profiles import PROFILE_ALLOWED_TOOLS
+from src.jarvis.tools.base import ToolContext
+from src.jarvis.tools.builtin.applescript import AppleScriptTool
+from src.jarvis.tools.registry import BUILTIN_TOOLS
+from src.jarvis.tools.types import ToolExecutionResult
+
+
+class TestAppleScriptTool:
+    """Test AppleScript tool metadata and dispatch."""
+
+    def setup_method(self):
+        self.tool = AppleScriptTool()
+        self.context = Mock(spec=ToolContext)
+        self.context.user_print = Mock()
+
+    def test_tool_properties(self):
+        assert self.tool.name == "appleScript"
+        assert "macos" in self.tool.description.lower()
+        assert self.tool.inputSchema["type"] == "object"
+        assert self.tool.inputSchema["required"] == ["action"]
+
+    @patch("src.jarvis.tools.builtin.applescript._get_battery", return_value="Battery is at 82%, sir.")
+    def test_run_dispatches_simple_action(self, mock_get_battery):
+        result = self.tool.run({"action": "get_battery"}, self.context)
+
+        assert isinstance(result, ToolExecutionResult)
+        assert result.success is True
+        assert result.reply_text == "Battery is at 82%, sir."
+        mock_get_battery.assert_called_once_with()
+
+    @patch("src.jarvis.tools.builtin.applescript._set_volume", return_value="Volume set to 30, sir.")
+    def test_run_accepts_nested_args(self, mock_set_volume):
+        result = self.tool.run({"action": "set_volume", "args": {"level": 30}}, self.context)
+
+        assert result.success is True
+        assert result.reply_text == "Volume set to 30, sir."
+        mock_set_volume.assert_called_once_with(30)
+
+    @patch("src.jarvis.tools.builtin.applescript._open_app", return_value="Opened Safari, sir.")
+    def test_run_accepts_top_level_args(self, mock_open_app):
+        result = self.tool.run({"action": "open_app", "app_name": "Safari"}, self.context)
+
+        assert result.success is True
+        assert result.reply_text == "Opened Safari, sir."
+        mock_open_app.assert_called_once_with("Safari")
+
+    def test_run_requires_known_action(self):
+        result = self.tool.run({"action": "launch_batmobile"}, self.context)
+
+        assert result.success is False
+        assert "Unknown appleScript action" in result.reply_text
+
+
+class TestAppleScriptIntegration:
+    """Test registry and profile integration for AppleScript."""
+
+    def test_tool_registered(self):
+        assert "appleScript" in BUILTIN_TOOLS
+        assert isinstance(BUILTIN_TOOLS["appleScript"], AppleScriptTool)
+
+    def test_tool_available_in_all_profiles(self):
+        for allowed_tools in PROFILE_ALLOWED_TOOLS.values():
+            assert "appleScript" in allowed_tools


### PR DESCRIPTION
## What changed

This updates the local Alfred-focused Jarvis setup for a cleaner macOS experience.

- adds a builtin `appleScript` tool for Calendar, Reminders, Mail, Music, app control, volume, battery, and shell actions
- updates the profile prompts and config defaults for the Alfred wake word, aliases, Piper cadence, and `medium.en` Whisper
- fixes Apple Silicon packaging/runtime issues by avoiding `faster-whisper` on `darwin/arm64`, preferring `python3.13` in `run_macos.sh`, and removing the unused top-level `faster_whisper` import
- aligns the desktop settings and setup wizard with the new `medium.en` default
- caches `requirements.txt` installs in `run_macos.sh` so repeated macOS launches do not re-run `pip install` unnecessarily
- adds regression coverage for the new AppleScript tool and updated Piper defaults

## Why it changed

The Alfred customization introduced a few integration mismatches across config defaults, desktop UI metadata, and macOS startup behavior. The goal here is to make the configured defaults actually behave consistently on Apple Silicon and to reduce friction for the always-on launchd setup.

## Root cause

The repo had a combination of upstream assumptions and local-environment differences:

- the settings UI still treated `medium.en` as invalid even though the config default was changed to use it
- the setup wizard still defaulted back to `medium`
- the macOS launcher recreated dependency checks on every start, which made launchd restarts noisy and slower than necessary
- Apple Silicon installs were sensitive to optional dependencies that are not needed in the MLX Whisper path

## Validation

- `python -m pytest tests -q` (`835 passed, 1 skipped`)
- targeted UI/TTS regression pass for `test_settings_window.py`, `test_setup_wizard.py`, and `test_piper_tts.py`
- `python -m py_compile` on the changed Python modules
- `bash -n scripts/run_macos.sh`
- manual macOS runtime verification from `scripts/run_macos.sh` to confirmed `Listening!`
- manual relaunch verification showing the second launch skips `pip install` thanks to the new requirements hash cache

## Impact

The Alfred setup is now more consistent end-to-end on macOS: the validated defaults are reflected in the UI, the listener starts with the expected Whisper model, the launch script is lighter on restart, and the new AppleScript tool is covered by tests.
