### PR TITLE
fix: detect HfHubHTTPError 429 via response.status_code, not just string (#169)

### DIFF
--- a/src/jarvis/listening/listener.py
+++ b/src/jarvis/listening/listener.py
@@ -1369,9 +1369,10 @@ class VoiceListener(threading.Thread):
                     break
                 except Exception as e:
                     error_str = str(e).lower()
-                    is_rate_limited = any(x in error_str for x in [
-                        "429", "too many requests", "rate limit",
-                    ])
+                    is_rate_limited = (
+                        any(x in error_str for x in ["429", "too many requests", "rate limit"])
+                        or getattr(getattr(e, "response", None), "status_code", None) == 429
+                    )
                     if is_rate_limited and attempt < max_retries:
                         wait = 2 ** (attempt + 1)
                         debug_log(f"rate limited loading MLX Whisper (attempt {attempt + 1}): {e}", "voice")
@@ -1538,10 +1539,12 @@ class VoiceListener(threading.Thread):
                             print(f"  ❌ Failed to load Whisper model: {e}", flush=True)
                             print("  💡 Try manually deleting the Whisper model cache directory and restarting", flush=True)
                             return
-                    # Check for rate limiting (HTTP 429)
-                    is_rate_limited = any(x in error_str for x in [
-                        "429", "too many requests", "rate limit",
-                    ])
+                    # Check for rate limiting (HTTP 429) — check string and response status code
+                    # (HfHubHTTPError may carry the status on .response without "429" in str(e))
+                    is_rate_limited = (
+                        any(x in error_str for x in ["429", "too many requests", "rate limit"])
+                        or getattr(getattr(e, "response", None), "status_code", None) == 429
+                    )
 
                     if is_rate_limited:
                         _max_retries = 4

--- a/tests/test_voice_listener.py
+++ b/tests/test_voice_listener.py
@@ -1418,6 +1418,47 @@ class TestWhisperRateLimitRetry:
                                 sleep_values = [c.args[0] for c in mock_sleep.call_args_list]
                                 assert sleep_values == [2, 4, 8, 16]
 
+    def test_hfhub_429_via_response_status_code_retried(self):
+        """HfHubHTTPError with response.status_code=429 is retried even when '429' is absent from str(e)."""
+        mock_whisper_model = MagicMock()
+        call_count = 0
+
+        class _FakeHfHubHTTPError(Exception):
+            """Minimal stand-in for HfHubHTTPError: no '429' in str(), but status_code on response."""
+            def __init__(self):
+                super().__init__("Request quota exceeded. Please retry later.")
+                self.response = MagicMock(status_code=429)
+
+        def whisper_model_side_effect(model_name, device, compute_type, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise _FakeHfHubHTTPError()
+            return mock_whisper_model
+
+        with patch("jarvis.listening.listener.sys") as mock_sys:
+            mock_sys.platform = "linux"
+            with patch("jarvis.listening.listener.FASTER_WHISPER_AVAILABLE", True):
+                with patch("jarvis.listening.listener.MLX_WHISPER_AVAILABLE", False):
+                    with patch("jarvis.listening.listener.WhisperModel", side_effect=whisper_model_side_effect) as mock_class:
+                        with patch("jarvis.listening.listener.sd") as mock_sd:
+                            mock_sd.query_devices.return_value = [{"name": "Test Mic", "max_input_channels": 1}]
+                            mock_sd.InputStream.side_effect = Exception("Stop test here")
+
+                            with patch("jarvis.listening.listener.time.sleep"):
+                                from jarvis.listening.listener import VoiceListener
+
+                                mock_db = MagicMock()
+                                mock_cfg = _create_mock_config(whisper_model="medium")
+                                mock_tts = MagicMock()
+                                mock_dialogue_memory = MagicMock()
+
+                                listener = VoiceListener(mock_db, mock_cfg, mock_tts, mock_dialogue_memory)
+                                listener.run()
+
+                                assert mock_class.call_count == 2
+                                assert listener.model == mock_whisper_model
+
     def test_non_429_error_not_retried(self):
         """Non-rate-limit errors are not retried."""
         error_msg = "Model not found: invalid_model"


### PR DESCRIPTION
## Summary

- The `is_rate_limited` check in `listener.py` matched "429"/"rate limit" in `str(e)`, which works for most `HfHubHTTPError` cases but can silently miss edge-case messages (e.g. quota-exceeded responses where the HTTP status code isn't embedded in the text).
- Add a secondary guard: if the exception carries `.response.status_code == 429`, treat it as rate-limited regardless of message text — matching the approach already used in `tts.py`.
- Applies to both the **faster-whisper** and **MLX Whisper** backends.
- A new test (`test_hfhub_429_via_response_status_code_retried`) uses a fake exception with no "429" in `str(e)` but `response.status_code=429`; it failed before this change and passes after.

## Test plan

- [x] New test `TestWhisperRateLimitRetry::test_hfhub_429_via_response_status_code_retried` — fails before fix, passes after
- [x] All existing `TestWhisperRateLimitRetry` tests still pass (string-based detection unchanged)
