### PR TITLE
fix: disable pynput dictation on macOS 26+ to prevent SIGTRAP crash

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@
 - Voice-only for now—no text chat interface yet ([#35](https://github.com/isair/jarvis/issues/35))
 - No mobile apps ([#17](https://github.com/isair/jarvis/issues/17))
 - "Stop" commands during speech sometimes get filtered as echo ([#24](https://github.com/isair/jarvis/issues/24))
+- Dictation is not available on macOS 26+ (Tahoe) due to a pynput incompatibility ([#172](https://github.com/isair/jarvis/issues/172))
 
 <details>
 <summary><strong>See it in action</strong> (example conversations)</summary>

--- a/src/jarvis/daemon.py
+++ b/src/jarvis/daemon.py
@@ -439,8 +439,9 @@ def main() -> None:
             )
             dictation.start()
             _global_dictation_engine = dictation
-            hotkey_display = cfg.dictation_hotkey
-            print(f"🎙️ Dictation enabled (hold {hotkey_display} to dictate)", flush=True)
+            if dictation._started:
+                hotkey_display = cfg.dictation_hotkey
+                print(f"🎙️ Dictation enabled (hold {hotkey_display} to dictate)", flush=True)
         except Exception as e:
             debug_log(f"dictation engine init failed: {e}", "dictation")
             print(f"  ⚠ Dictation not available: {e}", flush=True)

--- a/src/jarvis/dictation/dictation.spec.md
+++ b/src/jarvis/dictation/dictation.spec.md
@@ -86,6 +86,7 @@ After transcription, text passes through these stages in order:
 | Empty transcription       | No paste occurs                                    |
 | Concurrent with assistant | Dictation works independently; pauses listener     |
 | macOS permissions         | `pynput` requires Accessibility permissions        |
+| macOS 26+ (Tahoe)         | `pynput` disabled — TSM main-thread assertion crash |
 | Linux / Wayland           | `pynput` requires X11 (limited Wayland support)    |
 | Audio rate mismatch       | Resample via linear interpolation to Whisper rate  |
 | LLM filler removal fails  | Falls back to raw transcription (5 s timeout)     |

--- a/src/jarvis/dictation/dictation_engine.py
+++ b/src/jarvis/dictation/dictation_engine.py
@@ -13,6 +13,7 @@ import math
 import os
 import platform
 import struct
+import sys
 import threading
 import time
 from typing import Any, Callable, Optional
@@ -610,6 +611,29 @@ class DictationEngine:
             return
         if self._started:
             return
+
+        # macOS 26+ enforces that TSM (Text Services Manager) calls happen on
+        # the main dispatch queue.  pynput's keyboard Listener runs a CGEventTap
+        # on a background thread whose callback triggers TSM input-source
+        # queries, violating this assertion and crashing the process (SIGTRAP).
+        # Disable pynput on macOS 26+ until an alternative backend is available.
+        if sys.platform == "darwin":
+            try:
+                mac_ver = platform.mac_ver()[0]
+                major = int(mac_ver.split(".")[0]) if mac_ver else 0
+            except (ValueError, IndexError):
+                major = 0
+            if major >= 26:
+                debug_log(
+                    f"pynput disabled on macOS {mac_ver} "
+                    "(TSM main-thread assertion)", "dictation",
+                )
+                print(
+                    "  ⚠️  Dictation is not available on macOS 26+ "
+                    "(pynput keyboard listener incompatibility)",
+                    flush=True,
+                )
+                return
 
         self._listener = pynput_keyboard.Listener(
             on_press=self._on_key_press,

--- a/tests/test_dictation.py
+++ b/tests/test_dictation.py
@@ -135,8 +135,12 @@ class TestEngineLifecycle:
         except ImportError:
             pytest.skip("pynput or sounddevice not installed")
 
+    @patch("src.jarvis.dictation.dictation_engine.platform")
+    @patch("src.jarvis.dictation.dictation_engine.sys")
     @patch("src.jarvis.dictation.dictation_engine.pynput_keyboard")
-    def test_start_creates_listener(self, mock_kb):
+    def test_start_creates_listener(self, mock_kb, mock_sys, mock_platform):
+        # Force a platform where pynput is allowed (avoid macOS 26+ guard)
+        mock_sys.platform = "linux"
         mock_listener_instance = MagicMock()
         mock_kb.Listener.return_value = mock_listener_instance
         mock_kb.Key = MagicMock()
@@ -178,6 +182,62 @@ class TestEngineLifecycle:
         engine = _make_engine()
         engine.start()
         assert engine._started is False
+
+    @patch("src.jarvis.dictation.dictation_engine.platform")
+    @patch("src.jarvis.dictation.dictation_engine.sys")
+    @patch("src.jarvis.dictation.dictation_engine.pynput_keyboard")
+    def test_start_skips_on_macos_26(self, mock_kb, mock_sys, mock_platform):
+        """pynput crashes on macOS 26+ (TSM thread assertion). Engine must skip."""
+        mock_sys.platform = "darwin"
+        mock_platform.mac_ver.return_value = ("26.2", ("", "", ""), "")
+        mock_kb.Key = MagicMock()
+        mock_kb.KeyCode = MagicMock()
+        mock_kb.Key.ctrl_l = MagicMock()
+        mock_kb.Key.shift = MagicMock()
+
+        engine = _make_engine()
+        engine.start()
+        assert engine._started is False
+        mock_kb.Listener.assert_not_called()
+
+    @patch("src.jarvis.dictation.dictation_engine.platform")
+    @patch("src.jarvis.dictation.dictation_engine.sys")
+    @patch("src.jarvis.dictation.dictation_engine.pynput_keyboard")
+    def test_start_allowed_on_macos_15(self, mock_kb, mock_sys, mock_platform):
+        """pynput should still work on macOS 15 (Sequoia) and earlier."""
+        mock_sys.platform = "darwin"
+        mock_platform.mac_ver.return_value = ("15.4", ("", "", ""), "")
+        mock_listener = MagicMock()
+        mock_kb.Listener.return_value = mock_listener
+        mock_kb.Key = MagicMock()
+        mock_kb.KeyCode = MagicMock()
+        mock_kb.Key.ctrl_l = MagicMock()
+        mock_kb.Key.shift = MagicMock()
+
+        engine = _make_engine()
+        engine.start()
+        assert engine._started is True
+        mock_listener.start.assert_called_once()
+        engine.stop()
+
+    @patch("src.jarvis.dictation.dictation_engine.platform")
+    @patch("src.jarvis.dictation.dictation_engine.sys")
+    @patch("src.jarvis.dictation.dictation_engine.pynput_keyboard")
+    def test_start_allowed_on_windows(self, mock_kb, mock_sys, mock_platform):
+        """Windows should not be affected by the macOS guard."""
+        mock_sys.platform = "win32"
+        mock_listener = MagicMock()
+        mock_kb.Listener.return_value = mock_listener
+        mock_kb.Key = MagicMock()
+        mock_kb.KeyCode = MagicMock()
+        mock_kb.Key.ctrl_l = MagicMock()
+        mock_kb.Key.shift = MagicMock()
+
+        engine = _make_engine()
+        engine.start()
+        assert engine._started is True
+        mock_listener.start.assert_called_once()
+        engine.stop()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add macOS 26+ guard in `DictationEngine.start()` to skip pynput listener creation, preventing the SIGTRAP crash caused by Apple's new TSM main-thread dispatch queue assertion
- Check `dictation._started` in daemon before printing "Dictation enabled" so the message isn't shown when dictation was silently skipped
- Document the macOS 26+ limitation in README known issues (links to #172)
- Update dictation spec with the edge case
- Add tests for the platform guard (macOS 26 blocked, macOS 15 allowed, Windows allowed)

## Context
macOS 26 (Tahoe) added a dispatch queue assertion requiring TSM (Text Services Manager) calls on the main thread. pynput's `keyboard.Listener` runs a `CGEventTap` on a background thread whose callback triggers `TSMGetInputSourceProperty`, violating this assertion and killing the process with `EXC_BREAKPOINT`/`SIGTRAP`. This is not catchable by Python's `try/except`.

Restoration of dictation on macOS 26+ is tracked in #172.

## Test plan
- [x] All 43 dictation tests pass
- [x] macOS 26+ guard returns early, no listener created
- [x] macOS 15 and Windows still create listener normally
- [x] Daemon only prints "Dictation enabled" when `_started` is True

🤖 Generated with [Claude Code](https://claude.com/claude-code)