### PR TITLE
fix: preserve fatal error in crash reports, prevent mic check hang and resource leak

### DIFF
--- a/src/desktop_app/app.py
+++ b/src/desktop_app/app.py
@@ -65,13 +65,77 @@ from desktop_app.face_widget import FaceWindow
 _LOG_SEPARATOR = "─" * 50
 
 
+def _trim_extension_modules(logs: str) -> str:
+    """Shorten the faulthandler 'Extension modules:' line to a brief summary.
+
+    This line typically consumes 1500-2500 chars of module names that rarely
+    help with crash diagnosis.  Replacing it frees space for the critical
+    'Fatal Python error' header and current-thread stack trace.
+    """
+    import re
+    # Match "Extension modules: mod1, mod2, ... (total: N)\n"
+    m = re.search(
+        r'^(Extension modules:) .+?\(total: (\d+)\)\s*$',
+        logs, re.MULTILINE,
+    )
+    if m:
+        return logs[:m.start()] + f"{m.group(1)} ({m.group(2)} total — trimmed for brevity)\n" + logs[m.end():]
+
+    # Fallback: line without "(total: N)" — just truncate after first few modules
+    m = re.search(
+        r'^(Extension modules:) (.{80}).+$',
+        logs, re.MULTILINE,
+    )
+    if m:
+        return logs[:m.start()] + f"{m.group(1)} {m.group(2)}... (trimmed)\n" + logs[m.end():]
+
+    return logs
+
+
+def _extract_fatal_section(logs: str) -> str:
+    """Extract the 'Fatal Python error' header + current thread stack.
+
+    In faulthandler dumps these lines carry the actual crash cause and
+    appear just before the per-thread stacks.  Returns "" if not found.
+    """
+    import re
+    # Find "Fatal Python error: ..." line
+    m = re.search(r'^Fatal Python error: .+$', logs, re.MULTILINE)
+    if not m:
+        return ""
+
+    start = m.start()
+
+    # Grab everything up to (but not including) the SECOND "Thread 0x" header
+    # (the first one is "Current thread ..."; the second is the next thread).
+    rest = logs[start:]
+    thread_headers = list(re.finditer(r'^Thread 0x', rest, re.MULTILINE))
+    if thread_headers:
+        end = start + thread_headers[0].start()
+    else:
+        # No second thread header — take up to 500 chars
+        end = start + min(500, len(rest))
+
+    return logs[start:end].rstrip() + "\n"
+
+
 def _truncate_logs_for_report(logs: str, max_len: int) -> str:
     """Truncate logs keeping init section + recent tail.
 
     Recent logs are more valuable for debugging, so we preserve the tail.
     The init section (everything up to the last separator line) is kept
     for context (version, platform, configuration info).
+
+    For faulthandler crash dumps, the bulky 'Extension modules:' line is
+    trimmed first and the 'Fatal Python error' header + current thread
+    stack are preserved as a priority section so the root cause survives
+    truncation.
     """
+    # Trim the Extension modules line before size check — it wastes ~1700
+    # chars of budget on module names that almost never help diagnose a crash.
+    if "Extension modules:" in logs:
+        logs = _trim_extension_modules(logs)
+
     if len(logs) <= max_len:
         return logs
 
@@ -90,22 +154,40 @@ def _truncate_logs_for_report(logs: str, max_len: int) -> str:
         # No separator found (e.g. crash logs); skip init preservation
         init_section = ""
 
-    if len(init_section) + len(marker) >= max_len:
-        # Init section alone exceeds budget; just keep the tail
+    # For faulthandler dumps, extract the fatal error + current thread stack
+    # as a second must-keep section (the most diagnostic part of the dump).
+    fatal_section = _extract_fatal_section(logs)
+
+    if len(init_section) + len(fatal_section) + len(marker) * 2 >= max_len:
+        # Budget too tight — keep fatal section + tail only
+        if fatal_section:
+            tail_budget = max_len - len(fatal_section) - len(marker)
+            tail_part = logs[-tail_budget:]
+            newline_idx = tail_part.find('\n')
+            if newline_idx != -1 and newline_idx < 200:
+                tail_part = tail_part[newline_idx + 1:]
+            return fatal_section + marker + tail_part
+
+        # No fatal section — just keep the tail
         tail_part = logs[-(max_len - len(marker)):]
         newline_idx = tail_part.find('\n')
         if newline_idx != -1 and newline_idx < 200:
             tail_part = tail_part[newline_idx + 1:]
         return marker.lstrip() + tail_part
 
-    tail_budget = max_len - len(init_section) - len(marker)
+    # Build: init_section + marker + fatal_section + marker + tail
+    fixed_parts = init_section + marker + fatal_section
+    if fatal_section:
+        fixed_parts += marker
+
+    tail_budget = max_len - len(fixed_parts)
     tail_part = logs[-tail_budget:]
     # Snap to line boundary to avoid a partial first line
     newline_idx = tail_part.find('\n')
     if newline_idx != -1 and newline_idx < 200:
         tail_part = tail_part[newline_idx + 1:]
 
-    return init_section + marker + tail_part
+    return fixed_parts + tail_part
 
 
 def setup_crash_logging():

--- a/src/desktop_app/app.py
+++ b/src/desktop_app/app.py
@@ -75,7 +75,7 @@ def _trim_extension_modules(logs: str) -> str:
     import re
     # Match "Extension modules: mod1, mod2, ... (total: N)\n"
     m = re.search(
-        r'^(Extension modules:) .+?\(total: (\d+)\)\s*$',
+        r'^(Extension modules:) [^\n]+\(total: (\d+)\)\s*$',
         logs, re.MULTILINE,
     )
     if m:
@@ -96,7 +96,9 @@ def _extract_fatal_section(logs: str) -> str:
     """Extract the 'Fatal Python error' header + current thread stack.
 
     In faulthandler dumps these lines carry the actual crash cause and
-    appear just before the per-thread stacks.  Returns "" if not found.
+    appear between the fatal error line and the first other thread
+    (i.e. the first ``Thread 0x`` header after ``Current thread 0x``).
+    Returns "" if not found.
     """
     import re
     # Find "Fatal Python error: ..." line
@@ -106,17 +108,25 @@ def _extract_fatal_section(logs: str) -> str:
 
     start = m.start()
 
-    # Grab everything up to (but not including) the SECOND "Thread 0x" header
-    # (the first one is "Current thread ..."; the second is the next thread).
+    # Grab everything up to (but not including) the first "Thread 0x" header.
+    # "Current thread 0x..." uses a different prefix so won't match here.
     rest = logs[start:]
-    thread_headers = list(re.finditer(r'^Thread 0x', rest, re.MULTILINE))
-    if thread_headers:
-        end = start + thread_headers[0].start()
+    first_other_thread = next(re.finditer(r'^Thread 0x', rest, re.MULTILINE), None)
+    if first_other_thread:
+        end = start + first_other_thread.start()
     else:
-        # No second thread header — take up to 500 chars
+        # No other thread header — take up to 500 chars
         end = start + min(500, len(rest))
 
     return logs[start:end].rstrip() + "\n"
+
+
+def _snap_to_line_boundary(text: str) -> str:
+    """Advance past a partial first line so truncated output starts cleanly."""
+    newline_idx = text.find('\n')
+    if newline_idx != -1 and newline_idx < 200:
+        return text[newline_idx + 1:]
+    return text
 
 
 def _truncate_logs_for_report(logs: str, max_len: int) -> str:
@@ -158,21 +168,23 @@ def _truncate_logs_for_report(logs: str, max_len: int) -> str:
     # as a second must-keep section (the most diagnostic part of the dump).
     fatal_section = _extract_fatal_section(logs)
 
+    # Cap fatal_section so it never alone exceeds the budget
+    fatal_cap = max(0, max_len - len(marker) - 200)  # leave room for tail
+    if len(fatal_section) > fatal_cap:
+        fatal_section = fatal_section[:fatal_cap].rstrip() + "\n"
+
     if len(init_section) + len(fatal_section) + len(marker) * 2 >= max_len:
         # Budget too tight — keep fatal section + tail only
         if fatal_section:
-            tail_budget = max_len - len(fatal_section) - len(marker)
-            tail_part = logs[-tail_budget:]
-            newline_idx = tail_part.find('\n')
-            if newline_idx != -1 and newline_idx < 200:
-                tail_part = tail_part[newline_idx + 1:]
+            tail_budget = max(0, max_len - len(fatal_section) - len(marker))
+            if tail_budget == 0:
+                return fatal_section[:max_len]
+            tail_part = _snap_to_line_boundary(logs[-tail_budget:])
             return fatal_section + marker + tail_part
 
         # No fatal section — just keep the tail
-        tail_part = logs[-(max_len - len(marker)):]
-        newline_idx = tail_part.find('\n')
-        if newline_idx != -1 and newline_idx < 200:
-            tail_part = tail_part[newline_idx + 1:]
+        tail_budget = max(0, max_len - len(marker))
+        tail_part = _snap_to_line_boundary(logs[-tail_budget:])
         return marker.lstrip() + tail_part
 
     # Build: init_section + marker + fatal_section + marker + tail
@@ -180,12 +192,8 @@ def _truncate_logs_for_report(logs: str, max_len: int) -> str:
     if fatal_section:
         fixed_parts += marker
 
-    tail_budget = max_len - len(fixed_parts)
-    tail_part = logs[-tail_budget:]
-    # Snap to line boundary to avoid a partial first line
-    newline_idx = tail_part.find('\n')
-    if newline_idx != -1 and newline_idx < 200:
-        tail_part = tail_part[newline_idx + 1:]
+    tail_budget = max(0, max_len - len(fixed_parts))
+    tail_part = _snap_to_line_boundary(logs[-tail_budget:])
 
     return fixed_parts + tail_part
 
@@ -423,6 +431,8 @@ def show_crash_report_dialog(crash_content: str) -> None:
                 # Truncate crash info for URL (GitHub has limits)
                 # Keep init lines + recent tail (recent logs are most useful for debugging)
                 truncated = _truncate_logs_for_report(self.crash_info, 4000)
+                # Escape backtick fences so log content can't break out of the code block
+                truncated = truncated.replace('```', '`` `')
 
                 title = "Crash Report"
                 body = f"""## Crash Report
@@ -877,6 +887,8 @@ class LogViewerWindow(QMainWindow):
         # Truncate if too long for URL (GitHub has ~8000 char limit for URLs)
         # Keep init lines + recent tail (recent logs are most useful for debugging)
         redacted_logs = _truncate_logs_for_report(redacted_logs, 5000)
+        # Escape backtick fences so log content can't break out of the code block
+        redacted_logs = redacted_logs.replace('```', '`` `')
 
         title = "Bug Report"
         body = f"""## Bug Report

--- a/src/jarvis/listening/listener.py
+++ b/src/jarvis/listening/listener.py
@@ -1300,18 +1300,28 @@ class VoiceListener(threading.Thread):
         # This catches privacy settings that silently block audio access.
         # A 5-second timeout prevents indefinite hangs when Windows blocks
         # the audio device at the system level without raising an error.
+        # Uses InputStream (not sd.rec) so the stream can be explicitly closed
+        # on timeout, avoiding resource leaks that could block later audio init.
         if sys.platform == 'win32':
             try:
                 print("  🔐 Checking microphone permission...", flush=True)
-                mic_result: list = [None]
+                mic_ok = threading.Event()
                 mic_error: list = [None]
+                mic_stream: list = [None]
 
                 def _mic_check():
                     try:
-                        mic_result[0] = sd.rec(
-                            int(0.1 * self._samplerate),
-                            samplerate=self._samplerate, channels=1, blocking=True,
+                        stream = sd.InputStream(
+                            samplerate=self._samplerate, channels=1,
+                            dtype="float32", blocksize=int(self._samplerate * 0.1),
                         )
+                        mic_stream[0] = stream
+                        stream.start()
+                        time.sleep(0.15)
+                        stream.stop()
+                        stream.close()
+                        mic_stream[0] = None
+                        mic_ok.set()
                     except Exception as exc:
                         mic_error[0] = exc
 
@@ -1320,7 +1330,15 @@ class VoiceListener(threading.Thread):
                 check_thread.join(timeout=5.0)
 
                 if check_thread.is_alive():
+                    # Clean up the stream if the thread is still blocked
                     debug_log("microphone permission check timed out after 5s", "voice")
+                    stream_ref = mic_stream[0]
+                    if stream_ref is not None:
+                        try:
+                            stream_ref.abort()
+                            stream_ref.close()
+                        except Exception:
+                            pass
                     print("  ⚠️  Microphone permission check timed out", flush=True)
                     print("     This may indicate Windows is blocking microphone access.", flush=True)
                     print("     Continuing anyway — voice input may not work.", flush=True)
@@ -1344,7 +1362,7 @@ class VoiceListener(threading.Thread):
                         print("  └─────────────────────────────────────────────────────────┘", flush=True)
                         print("", flush=True)
                     return
-                elif mic_result[0] is not None and len(mic_result[0]) > 0:
+                elif mic_ok.is_set():
                     print("  ✅ Microphone permission OK", flush=True)
                 else:
                     print("  ⚠️  Microphone returned empty audio", flush=True)

--- a/src/jarvis/listening/listener.py
+++ b/src/jarvis/listening/listener.py
@@ -1297,35 +1297,60 @@ class VoiceListener(threading.Thread):
             return
 
         # Windows 11: Test microphone permission by attempting a brief recording
-        # This catches privacy settings that silently block audio access
+        # This catches privacy settings that silently block audio access.
+        # A 5-second timeout prevents indefinite hangs when Windows blocks
+        # the audio device at the system level without raising an error.
         if sys.platform == 'win32':
             try:
                 print("  🔐 Checking microphone permission...", flush=True)
-                # Try to record 0.1 seconds - will fail immediately if permission denied
-                test_recording = sd.rec(int(0.1 * self._samplerate), samplerate=self._samplerate, channels=1, blocking=True)
-                if test_recording is not None and len(test_recording) > 0:
+                mic_result: list = [None]
+                mic_error: list = [None]
+
+                def _mic_check():
+                    try:
+                        mic_result[0] = sd.rec(
+                            int(0.1 * self._samplerate),
+                            samplerate=self._samplerate, channels=1, blocking=True,
+                        )
+                    except Exception as exc:
+                        mic_error[0] = exc
+
+                check_thread = threading.Thread(target=_mic_check, daemon=True)
+                check_thread.start()
+                check_thread.join(timeout=5.0)
+
+                if check_thread.is_alive():
+                    debug_log("microphone permission check timed out after 5s", "voice")
+                    print("  ⚠️  Microphone permission check timed out", flush=True)
+                    print("     This may indicate Windows is blocking microphone access.", flush=True)
+                    print("     Continuing anyway — voice input may not work.", flush=True)
+                elif mic_error[0] is not None:
+                    e = mic_error[0]
+                    error_str = str(e).lower()
+                    print(f"  ❌ Microphone permission check failed: {e}", flush=True)
+                    if "unapproved" in error_str or "denied" in error_str or "access" in error_str or "-9999" in str(e):
+                        print("", flush=True)
+                        print("  ┌─────────────────────────────────────────────────────────┐", flush=True)
+                        print("  │  🔒 MICROPHONE ACCESS BLOCKED BY WINDOWS               │", flush=True)
+                        print("  │                                                         │", flush=True)
+                        print("  │  To fix this:                                          │", flush=True)
+                        print("  │  1. Open Windows Settings                              │", flush=True)
+                        print("  │  2. Go to Privacy & security → Microphone              │", flush=True)
+                        print("  │  3. Turn ON 'Microphone access'                        │", flush=True)
+                        print("  │  4. Turn ON 'Let apps access your microphone'          │", flush=True)
+                        print("  │  5. Turn ON 'Let desktop apps access your microphone'  │", flush=True)
+                        print("  │                                                         │", flush=True)
+                        print("  │  Then restart Jarvis.                                  │", flush=True)
+                        print("  └─────────────────────────────────────────────────────────┘", flush=True)
+                        print("", flush=True)
+                    return
+                elif mic_result[0] is not None and len(mic_result[0]) > 0:
                     print("  ✅ Microphone permission OK", flush=True)
                 else:
                     print("  ⚠️  Microphone returned empty audio", flush=True)
             except Exception as e:
-                error_str = str(e).lower()
-                print(f"  ❌ Microphone permission check failed: {e}", flush=True)
-                if "unapproved" in error_str or "denied" in error_str or "access" in error_str or "-9999" in str(e):
-                    print("", flush=True)
-                    print("  ┌─────────────────────────────────────────────────────────┐", flush=True)
-                    print("  │  🔒 MICROPHONE ACCESS BLOCKED BY WINDOWS               │", flush=True)
-                    print("  │                                                         │", flush=True)
-                    print("  │  To fix this:                                          │", flush=True)
-                    print("  │  1. Open Windows Settings                              │", flush=True)
-                    print("  │  2. Go to Privacy & security → Microphone              │", flush=True)
-                    print("  │  3. Turn ON 'Microphone access'                        │", flush=True)
-                    print("  │  4. Turn ON 'Let apps access your microphone'          │", flush=True)
-                    print("  │  5. Turn ON 'Let desktop apps access your microphone'  │", flush=True)
-                    print("  │                                                         │", flush=True)
-                    print("  │  Then restart Jarvis.                                  │", flush=True)
-                    print("  └─────────────────────────────────────────────────────────┘", flush=True)
-                    print("", flush=True)
-                return
+                debug_log(f"microphone permission check error: {e}", "voice")
+                print(f"  ⚠️  Microphone check error: {e}", flush=True)
 
         # Determine and initialise Whisper backend
         self._whisper_backend = self._determine_whisper_backend()

--- a/tests/test_desktop_app.py
+++ b/tests/test_desktop_app.py
@@ -428,6 +428,70 @@ class TestLogViewerReportIssue:
         # Early lines should be truncated
         assert "line 0:" not in result
 
+    def test_faulthandler_dump_preserves_fatal_error_line(self):
+        """Faulthandler crash dumps should preserve 'Fatal Python error' and current thread."""
+        from desktop_app.app import _truncate_logs_for_report, _LOG_SEPARATOR
+
+        # Simulate realistic crash log: init section + separator + faulthandler dump
+        init_block = (
+            "=== Jarvis Desktop App Crash Log ===\n"
+            "Timestamp: 2026-04-13\n"
+            "Platform: win32\n"
+            "==================================================\n"
+            "\nStarting Jarvis Desktop App...\n"
+            "Creating QApplication...\n"
+            "🚀 Jarvis daemon started\n"
+            f"{_LOG_SEPARATOR}\n"
+        )
+        # Faulthandler dump: Fatal error + current thread + many other threads + extension modules
+        fatal_line = "Fatal Python error: Segmentation fault\n"
+        current_thread = (
+            "\nCurrent thread 0x00007c54 (most recent call first):\n"
+            "  File \"some_module.py\", line 42 in critical_function\n"
+            "  File \"app.py\", line 100 in main\n"
+        )
+        other_threads = "\n".join([
+            f"\nThread 0x0000{i:04x} (most recent call first):\n"
+            f"  File \"threading.py\", line 331 in wait\n"
+            f"  File \"module_{i}.py\", line {i * 10} in some_func\n"
+            f"  File \"threading.py\", line 1045 in _bootstrap_inner\n"
+            f"  File \"threading.py\", line 1002 in _bootstrap\n"
+            for i in range(20)
+        ])
+        # Large extension modules list (~1700 chars)
+        ext_modules = "Extension modules: " + ", ".join([f"mod_{i}.sub_{i}" for i in range(120)]) + " (total: 120)\n"
+
+        crash_log = init_block + fatal_line + current_thread + other_threads + ext_modules
+
+        result = _truncate_logs_for_report(crash_log, 4000)
+
+        assert len(result) <= 4000
+        # Critical: the Fatal error line and current thread MUST be preserved
+        assert "Fatal Python error: Segmentation fault" in result
+        assert "critical_function" in result
+        # Init section should be preserved
+        assert "Jarvis Desktop App Crash Log" in result
+        # Extension modules should be summarised, not fully listed
+        assert "mod_119.sub_119" not in result
+
+    def test_faulthandler_extension_modules_trimmed(self):
+        """Extension modules line in faulthandler dumps should be shortened."""
+        from desktop_app.app import _truncate_logs_for_report
+
+        # Short log with a huge Extension modules line — should be trimmed even if total is within budget
+        fatal = "Fatal Python error: Aborted\n\nCurrent thread 0x1234:\n  File \"x.py\", line 1\n\n"
+        ext_modules = "Extension modules: " + ", ".join([f"mod_{i}" for i in range(100)]) + " (total: 100)\n"
+        log = fatal + ext_modules
+
+        result = _truncate_logs_for_report(log, 4000)
+
+        # Fatal error should be preserved
+        assert "Fatal Python error: Aborted" in result
+        # The full module list should be trimmed
+        assert "mod_99" not in result
+        # But summary count should remain
+        assert "100" in result
+
     def test_redaction_handles_multiple_sensitive_patterns(self):
         """Redaction should handle multiple types of sensitive data."""
         from jarvis.utils.redact import redact

--- a/tests/test_desktop_app.py
+++ b/tests/test_desktop_app.py
@@ -492,6 +492,55 @@ class TestLogViewerReportIssue:
         # But summary count should remain
         assert "100" in result
 
+    def test_faulthandler_budget_too_tight_caps_fatal_section(self):
+        """When fatal section exceeds the budget, output must still respect max_len."""
+        from desktop_app.app import _truncate_logs_for_report, _LOG_SEPARATOR
+
+        # Simulate a deep recursion crash: huge fatal section (~5000 chars)
+        init_block = f"Header\n{_LOG_SEPARATOR}\n"
+        fatal_line = "Fatal Python error: maximum recursion depth exceeded\n"
+        deep_stack = "\n".join(
+            [f"  File \"module.py\", line {i} in func_{i}" for i in range(300)]
+        )
+        current_thread = f"\nCurrent thread 0x1234 (most recent call first):\n{deep_stack}\n"
+        other_thread = "\nThread 0x5678 (most recent call first):\n  File \"t.py\", line 1\n"
+        crash_log = init_block + fatal_line + current_thread + other_thread
+
+        result = _truncate_logs_for_report(crash_log, 2000)
+
+        # Must never exceed the budget
+        assert len(result) <= 2000
+        # The fatal error line itself should still be present
+        assert "Fatal Python error: maximum recursion depth exceeded" in result
+
+    def test_faulthandler_fatal_without_thread_headers(self):
+        """Fatal error without any 'Thread 0x' headers should extract up to 500 chars."""
+        from desktop_app.app import _extract_fatal_section
+
+        fatal = "Fatal Python error: Aborted\n\nCurrent thread 0x1234 (most recent call first):\n  File \"x.py\", line 1 in main\n"
+        result = _extract_fatal_section(fatal)
+
+        assert "Fatal Python error: Aborted" in result
+        assert "main" in result
+
+    def test_faulthandler_extension_modules_without_total(self):
+        """Extension modules line without '(total: N)' should use the fallback trim."""
+        from desktop_app.app import _trim_extension_modules
+
+        # No "(total: N)" suffix — should trigger the fallback regex
+        ext_line = "Extension modules: " + ", ".join([f"mod_{i}" for i in range(100)]) + "\n"
+        log = "Some log content\n" + ext_line
+
+        result = _trim_extension_modules(log)
+
+        # Should be trimmed (much shorter than original)
+        assert len(result) < len(log)
+        assert "... (trimmed)" in result
+        # Should keep the first ~80 chars of modules
+        assert "mod_0" in result
+        # Should not contain later modules
+        assert "mod_99" not in result
+
     def test_redaction_handles_multiple_sensitive_patterns(self):
         """Redaction should handle multiple types of sensitive data."""
         from jarvis.utils.redact import redact


### PR DESCRIPTION
## Summary

- **Crash report truncator** now preserves the `Fatal Python error:` line and current-thread stack trace in faulthandler dumps. The bulky `Extension modules:` line (~1700 chars) is trimmed to a brief summary to free budget.
- **Budget overflow fix**: `fatal_section` is capped and all `tail_budget` calculations guarded with `max(0, ...)` so output never exceeds `max_len` (previously a deep recursion crash could produce 6-14x over budget).
- **Windows microphone permission check** uses `sd.InputStream` (not `sd.rec`) with a 5-second timeout and explicit `abort()`/`close()` on timeout to prevent resource leaks that could block later audio initialisation.
- **Markdown injection**: triple backticks in crash/bug report logs are escaped before embedding in code fences.
- **Code quality**: extracted `_snap_to_line_boundary()` helper (was duplicated 3x), replaced `.+?` with `[^\n]+` in regex to prevent backtracking, used `next(re.finditer)` instead of `list()` materialisation.

Addresses #182 (crash during Whisper model download — root cause was truncated out of the report), related to #169 (same call chain, reopened). Also addresses #184 (app freeze at mic permission check perceived as crash).

## Test plan

- [x] All 42 `test_desktop_app.py` tests pass (no regressions)
- [x] Faulthandler dump with separator + Fatal error + 20 threads + Extension modules — Fatal error line and current thread preserved within 4000-char budget
- [x] Budget-too-tight path: deep recursion crash (~5000 char fatal section) capped within 2000-char budget
- [x] Fatal error without Thread headers: gracefully extracts up to 500 chars
- [x] Extension modules without `(total: N)`: fallback trim works correctly
- [x] Extension modules with `(total: N)`: primary trim works correctly
- [ ] Manual: verify on Windows that mic permission timeout fires correctly when access is blocked

https://claude.ai/code/session_01WBGnU6DE3Bdj1eUhpHAnE1