### PR TITLE
chore: make preview launch config cross-platform (Windows + macOS)

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -3,38 +3,20 @@
   "configurations": [
     {
       "name": "Desktop App",
-      "runtimeExecutable": "bash",
-      "runtimeArgs": ["scripts/run_desktop_app.sh"],
+      "runtimeExecutable": "python",
+      "runtimeArgs": ["scripts/launch.py", "run_desktop_app"],
       "port": 5050
     },
     {
       "name": "Desktop App (Voice Debug)",
-      "runtimeExecutable": "bash",
-      "runtimeArgs": ["scripts/run_desktop_app.sh", "--voice-debug"],
-      "port": 5050
-    },
-    {
-      "name": "Desktop App (faster-whisper)",
-      "runtimeExecutable": "bash",
-      "runtimeArgs": ["-c", "JARVIS_WHISPER_BACKEND=faster-whisper JARVIS_VOICE_DEBUG=1 bash scripts/run_desktop_app.sh --voice-debug"],
-      "port": 5050
-    },
-    {
-      "name": "Jarvis Daemon",
-      "runtimeExecutable": "bash",
-      "runtimeArgs": ["scripts/run_macos.sh"],
-      "port": null
-    },
-    {
-      "name": "Memory Viewer",
-      "runtimeExecutable": "bash",
-      "runtimeArgs": ["-c", "PYTHONPATH=src:$PYTHONPATH python -m desktop_app.memory_viewer"],
+      "runtimeExecutable": "python",
+      "runtimeArgs": ["scripts/launch.py", "run_desktop_app", "--voice-debug"],
       "port": 5050
     },
     {
       "name": "Evals",
-      "runtimeExecutable": "bash",
-      "runtimeArgs": ["scripts/run_evals.sh"],
+      "runtimeExecutable": "python",
+      "runtimeArgs": ["scripts/launch.py", "run_evals"],
       "port": null
     }
   ]

--- a/scripts/launch.py
+++ b/scripts/launch.py
@@ -1,0 +1,56 @@
+"""Cross-platform launcher for Claude Code preview_start.
+
+Detects the OS and delegates to the appropriate platform-specific script
+(bat on Windows, sh on macOS/Linux). Can be invoked with any Python 3.x.
+
+Usage:
+    python scripts/launch.py <script_name> [args...]
+
+Examples:
+    python scripts/launch.py run_desktop_app
+    python scripts/launch.py run_desktop_app --voice-debug
+    python scripts/launch.py run_evals
+"""
+
+import os
+import platform
+import subprocess
+import sys
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python scripts/launch.py <script_name> [args...]")
+        sys.exit(1)
+
+    script_name = sys.argv[1]
+    extra_args = sys.argv[2:]
+
+    project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    scripts_dir = os.path.join(project_root, "scripts")
+
+    if platform.system() == "Windows":
+        script_path = os.path.join(scripts_dir, f"{script_name}.bat")
+        if not os.path.isfile(script_path):
+            print(f"ERROR: {script_path} not found")
+            sys.exit(1)
+        result = subprocess.run(
+            [script_path] + extra_args,
+            cwd=project_root,
+            shell=True,
+        )
+    else:
+        script_path = os.path.join(scripts_dir, f"{script_name}.sh")
+        if not os.path.isfile(script_path):
+            print(f"ERROR: {script_path} not found")
+            sys.exit(1)
+        result = subprocess.run(
+            ["bash", script_path] + extra_args,
+            cwd=project_root,
+        )
+
+    sys.exit(result.returncode)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Added `scripts/launch.py` — a cross-platform launcher that detects the OS and delegates to `.bat` (Windows) or `.sh` (macOS/Linux) scripts
- Updated `.claude/launch.json` to use `python scripts/launch.py <script_name>` instead of `bash` directly
- Removed configs that only worked on macOS (faster-whisper, daemon, memory viewer) to keep configs that have both `.bat` and `.sh` counterparts

## Problem

On Windows, `bash` as `runtimeExecutable` resolved to WSL's `/bin/bash`, causing:
```
CreateProcessCommon:559: execvpe(/bin/bash) failed: No such file or directory
```

## How it works

`launch.py` checks `platform.system()` and runs the matching platform script:
- **Windows**: `scripts/<name>.bat` via `shell=True`
- **macOS/Linux**: `bash scripts/<name>.sh`

This means the same `launch.json` works on both platforms without modification.

## Test plan

- [x] Verified `preview_start` succeeds on Windows
- [ ] Verify `preview_start` succeeds on macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)