### PR TITLE
fix: dictation paste broken on Windows and hotkey displayed as 'cmd'

### DIFF
--- a/src/desktop_app/settings_window.py
+++ b/src/desktop_app/settings_window.py
@@ -71,6 +71,23 @@ CATEGORIES = [
 ]
 
 
+def _dictation_hotkey_choices() -> list:
+    """Build platform-aware dictation hotkey dropdown choices."""
+    from jarvis.dictation.dictation_engine import format_hotkey_display
+    from jarvis.config import _default_dictation_hotkey
+    default = _default_dictation_hotkey()
+    options = [
+        ("ctrl+alt", format_hotkey_display("ctrl+alt")),
+        ("ctrl+cmd", format_hotkey_display("ctrl+cmd")),
+        ("ctrl+shift+d", format_hotkey_display("ctrl+shift+d")),
+        ("ctrl+shift", format_hotkey_display("ctrl+shift")),
+    ]
+    return [
+        (val, f"{label} (default)" if val == default else label)
+        for val, label in options
+    ]
+
+
 def _build_field_metadata() -> List[FieldMeta]:
     """Build the metadata registry for all user-facing config fields."""
     fields = []
@@ -280,12 +297,7 @@ def _build_field_metadata() -> List[FieldMeta]:
       "features", "bool")
     f("dictation_hotkey", "Dictation Hotkey",
       "Key combination to hold for dictation. Double-tap for hands-free mode.",
-      "features", "choice", choices=[
-          ("ctrl+alt", "Ctrl + Alt (macOS / Linux default)"),
-          ("ctrl+cmd", "Ctrl + Win/Cmd (Windows default)"),
-          ("ctrl+shift+d", "Ctrl + Shift + D"),
-          ("ctrl+shift", "Ctrl + Shift"),
-      ])
+      "features", "choice", choices=_dictation_hotkey_choices())
     f("dictation_filler_removal", "Filler Word Removal",
       "Use the local LLM to remove filler words (um, uh, like) from dictation output",
       "features", "bool")

--- a/src/desktop_app/setup_wizard.py
+++ b/src/desktop_app/setup_wizard.py
@@ -2447,12 +2447,24 @@ class LocationPage(QWizardPage):
 class DictationPage(QWizardPage):
     """Page for configuring dictation (hold-to-dictate) settings."""
 
-    _HOTKEY_OPTIONS = [
-        ("ctrl+alt", "Ctrl + Alt (macOS / Linux default)"),
-        ("ctrl+cmd", "Ctrl + Win/Cmd (Windows default)"),
-        ("ctrl+shift+d", "Ctrl + Shift + D"),
-        ("ctrl+shift", "Ctrl + Shift"),
-    ]
+    _HOTKEY_OPTIONS = None  # Built lazily via _hotkey_options()
+
+    @staticmethod
+    def _hotkey_options():
+        from jarvis.dictation.dictation_engine import format_hotkey_display
+        from jarvis.config import _default_dictation_hotkey
+        default = _default_dictation_hotkey()
+        options = [
+            ("ctrl+alt", format_hotkey_display("ctrl+alt")),
+            ("ctrl+cmd", format_hotkey_display("ctrl+cmd")),
+            ("ctrl+shift+d", format_hotkey_display("ctrl+shift+d")),
+            ("ctrl+shift", format_hotkey_display("ctrl+shift")),
+        ]
+        # Tag the platform default
+        return [
+            (val, f"{label} (default)" if val == default else label)
+            for val, label in options
+        ]
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -2521,7 +2533,7 @@ class DictationPage(QWizardPage):
         hotkey_layout.addWidget(hotkey_desc)
 
         self._hotkey_combo = QComboBox()
-        for value, label in self._HOTKEY_OPTIONS:
+        for value, label in self._hotkey_options():
             self._hotkey_combo.addItem(label, value)
         self._hotkey_combo.setStyleSheet(
             "QComboBox { padding: 8px; font-size: 14px; background: #27272a; "

--- a/src/jarvis/daemon.py
+++ b/src/jarvis/daemon.py
@@ -440,7 +440,8 @@ def main() -> None:
             dictation.start()
             _global_dictation_engine = dictation
             if dictation._started:
-                hotkey_display = cfg.dictation_hotkey
+                from jarvis.dictation.dictation_engine import format_hotkey_display
+                hotkey_display = format_hotkey_display(cfg.dictation_hotkey)
                 print(f"🎙️ Dictation enabled (hold {hotkey_display} to dictate)", flush=True)
         except Exception as e:
             debug_log(f"dictation engine init failed: {e}", "dictation")

--- a/src/jarvis/dictation/dictation_engine.py
+++ b/src/jarvis/dictation/dictation_engine.py
@@ -215,21 +215,37 @@ def _clipboard_windows(text: str) -> None:
     user32 = ctypes.windll.user32
     kernel32 = ctypes.windll.kernel32
 
+    # Set proper return/argument types so handles aren't truncated on 64-bit.
+    user32.OpenClipboard.argtypes = [wintypes.HWND]
+    user32.OpenClipboard.restype = wintypes.BOOL
+    user32.CloseClipboard.restype = wintypes.BOOL
+    user32.EmptyClipboard.restype = wintypes.BOOL
+    user32.SetClipboardData.argtypes = [wintypes.UINT, wintypes.HANDLE]
+    user32.SetClipboardData.restype = wintypes.HANDLE
+    kernel32.GlobalAlloc.argtypes = [wintypes.UINT, ctypes.c_size_t]
+    kernel32.GlobalAlloc.restype = wintypes.HANDLE
+    kernel32.GlobalLock.argtypes = [wintypes.HANDLE]
+    kernel32.GlobalLock.restype = ctypes.c_void_p
+    kernel32.GlobalUnlock.argtypes = [wintypes.HANDLE]
+    kernel32.GlobalUnlock.restype = wintypes.BOOL
+    kernel32.GlobalFree.argtypes = [wintypes.HANDLE]
+    kernel32.GlobalFree.restype = wintypes.HANDLE
+
     CF_UNICODETEXT = 13
     GMEM_MOVEABLE = 0x0002
 
-    if not user32.OpenClipboard(0):
-        return
+    if not user32.OpenClipboard(None):
+        raise OSError("OpenClipboard failed")
     try:
         user32.EmptyClipboard()
         encoded = text.encode("utf-16-le") + b"\x00\x00"
         h = kernel32.GlobalAlloc(GMEM_MOVEABLE, len(encoded))
         if not h:
-            return
+            raise OSError("GlobalAlloc failed")
         ptr = kernel32.GlobalLock(h)
         if not ptr:
             kernel32.GlobalFree(h)
-            return
+            raise OSError("GlobalLock failed")
         ctypes.memmove(ptr, encoded, len(encoded))
         kernel32.GlobalUnlock(h)
         user32.SetClipboardData(CF_UNICODETEXT, h)
@@ -465,7 +481,33 @@ _MODIFIER_MAP = {
     "alt": "alt_l",
     "cmd": "cmd",
     "super": "cmd",
+    "win": "cmd",
 }
+
+
+def format_hotkey_display(combo: str) -> str:
+    """Format a hotkey string for human-readable display.
+
+    On Windows, ``cmd`` is shown as ``Win``.  On macOS, ``cmd`` stays as
+    ``Cmd`` and ``alt`` becomes ``Option``.  Key parts are title-cased and
+    joined with `` + ``.
+    """
+    system = platform.system().lower()
+    parts = [p.strip().lower() for p in combo.split("+") if p.strip()]
+
+    display_parts: list[str] = []
+    for part in parts:
+        if part in ("cmd", "super", "win"):
+            if system == "windows":
+                display_parts.append("Win")
+            else:
+                display_parts.append("Cmd")
+        elif part == "alt" and system == "darwin":
+            display_parts.append("Option")
+        else:
+            display_parts.append(part.capitalize())
+
+    return " + ".join(display_parts)
 
 
 def parse_hotkey(combo: str):

--- a/tests/test_dictation.py
+++ b/tests/test_dictation.py
@@ -672,3 +672,100 @@ class TestListenerPauseFlag:
         """VoiceListener should expose a transcribe_lock."""
         assert hasattr(listener, "transcribe_lock")
         assert isinstance(listener.transcribe_lock, type(threading.Lock()))
+
+
+# ---------------------------------------------------------------------------
+# format_hotkey_display
+# ---------------------------------------------------------------------------
+
+class TestFormatHotkeyDisplay:
+    """Tests for platform-aware hotkey display formatting."""
+
+    @patch("src.jarvis.dictation.dictation_engine.platform")
+    def test_windows_cmd_shows_win(self, mock_platform):
+        from src.jarvis.dictation.dictation_engine import format_hotkey_display
+        mock_platform.system.return_value = "Windows"
+        assert format_hotkey_display("ctrl+cmd") == "Ctrl + Win"
+
+    @patch("src.jarvis.dictation.dictation_engine.platform")
+    def test_windows_super_shows_win(self, mock_platform):
+        from src.jarvis.dictation.dictation_engine import format_hotkey_display
+        mock_platform.system.return_value = "Windows"
+        assert format_hotkey_display("ctrl+super") == "Ctrl + Win"
+
+    @patch("src.jarvis.dictation.dictation_engine.platform")
+    def test_windows_win_shows_win(self, mock_platform):
+        from src.jarvis.dictation.dictation_engine import format_hotkey_display
+        mock_platform.system.return_value = "Windows"
+        assert format_hotkey_display("ctrl+win") == "Ctrl + Win"
+
+    @patch("src.jarvis.dictation.dictation_engine.platform")
+    def test_macos_cmd_shows_cmd(self, mock_platform):
+        from src.jarvis.dictation.dictation_engine import format_hotkey_display
+        mock_platform.system.return_value = "Darwin"
+        assert format_hotkey_display("ctrl+cmd") == "Ctrl + Cmd"
+
+    @patch("src.jarvis.dictation.dictation_engine.platform")
+    def test_macos_alt_shows_option(self, mock_platform):
+        from src.jarvis.dictation.dictation_engine import format_hotkey_display
+        mock_platform.system.return_value = "Darwin"
+        assert format_hotkey_display("ctrl+alt") == "Ctrl + Option"
+
+    @patch("src.jarvis.dictation.dictation_engine.platform")
+    def test_ctrl_shift_d(self, mock_platform):
+        from src.jarvis.dictation.dictation_engine import format_hotkey_display
+        mock_platform.system.return_value = "Windows"
+        assert format_hotkey_display("ctrl+shift+d") == "Ctrl + Shift + D"
+
+    @patch("src.jarvis.dictation.dictation_engine.platform")
+    def test_linux_alt_stays_alt(self, mock_platform):
+        from src.jarvis.dictation.dictation_engine import format_hotkey_display
+        mock_platform.system.return_value = "Linux"
+        assert format_hotkey_display("ctrl+alt") == "Ctrl + Alt"
+
+
+# ---------------------------------------------------------------------------
+# _clipboard_windows ctypes correctness
+# ---------------------------------------------------------------------------
+
+class TestClipboardWindowsCtypes:
+    """Verify _clipboard_windows sets proper ctypes return types."""
+
+    @pytest.mark.skipif(
+        __import__("sys").platform != "win32",
+        reason="Windows-only clipboard API",
+    )
+    def test_clipboard_windows_roundtrip(self):
+        """Write to clipboard and read back to verify ctypes bindings."""
+        import ctypes
+        from ctypes import wintypes
+        from src.jarvis.dictation.dictation_engine import _clipboard_windows
+
+        test_text = "dictation test 🎙️"
+        _clipboard_windows(test_text)
+
+        # Read back from clipboard
+        user32 = ctypes.windll.user32
+        kernel32 = ctypes.windll.kernel32
+        user32.OpenClipboard.argtypes = [wintypes.HWND]
+        user32.OpenClipboard.restype = wintypes.BOOL
+        user32.GetClipboardData.argtypes = [wintypes.UINT]
+        user32.GetClipboardData.restype = wintypes.HANDLE
+        user32.CloseClipboard.restype = wintypes.BOOL
+        kernel32.GlobalLock.argtypes = [wintypes.HANDLE]
+        kernel32.GlobalLock.restype = ctypes.c_void_p
+        kernel32.GlobalUnlock.argtypes = [wintypes.HANDLE]
+        kernel32.GlobalUnlock.restype = wintypes.BOOL
+
+        CF_UNICODETEXT = 13
+        assert user32.OpenClipboard(None)
+        try:
+            h = user32.GetClipboardData(CF_UNICODETEXT)
+            assert h, "GetClipboardData returned NULL"
+            ptr = kernel32.GlobalLock(h)
+            assert ptr, "GlobalLock returned NULL"
+            result = ctypes.wstring_at(ptr)
+            kernel32.GlobalUnlock(h)
+            assert result == test_text
+        finally:
+            user32.CloseClipboard()


### PR DESCRIPTION
## Summary

- **Clipboard paste never worked on Windows**: `_clipboard_windows` used raw ctypes calls without setting `restype`/`argtypes` — on 64-bit Windows, handle return values were truncated from 64 to 32 bits, causing silent clipboard write failure. Now sets proper types and raises `OSError` on failure.
- **Hotkey shown as "cmd" on Windows**: UI dropdowns, daemon logs, and setup wizard all displayed the raw internal key name `ctrl+cmd` instead of `Ctrl + Win`. Added `format_hotkey_display()` that maps to platform-native labels (Win on Windows, Cmd on macOS, Option for Alt on macOS).
- Also added `"win"` as a modifier alias in the hotkey parser so users can write `ctrl+win` in config.

## Test plan

- [x] `TestFormatHotkeyDisplay` — 7 tests covering Windows/macOS/Linux label mapping
- [x] `TestClipboardWindowsCtypes::test_clipboard_windows_roundtrip` — writes to clipboard via ctypes and reads back to verify (Windows-only)
- [x] All 51 dictation tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)