### PR TITLE
fix: review follow-up for dictation Windows PR

### DIFF
--- a/src/desktop_app/setup_wizard.py
+++ b/src/desktop_app/setup_wizard.py
@@ -2447,8 +2447,6 @@ class LocationPage(QWizardPage):
 class DictationPage(QWizardPage):
     """Page for configuring dictation (hold-to-dictate) settings."""
 
-    _HOTKEY_OPTIONS = None  # Built lazily via _hotkey_options()
-
     @staticmethod
     def _hotkey_options():
         from jarvis.dictation.dictation_engine import format_hotkey_display

--- a/src/jarvis/dictation/dictation.spec.md
+++ b/src/jarvis/dictation/dictation.spec.md
@@ -20,8 +20,8 @@ Defaults are aligned with WisprFlow. Modifier-only combos are supported
 key required).
 
 The hotkey is configurable as a dropdown in both the setup wizard and settings
-window, with four preset options: `ctrl+alt`, `ctrl+cmd`, `ctrl+shift`,
-`alt+shift`.
+window, with four preset options: `ctrl+alt`, `ctrl+cmd`, `ctrl+shift+d`,
+`ctrl+shift`.
 
 ## Core Flow
 

--- a/src/jarvis/dictation/dictation_engine.py
+++ b/src/jarvis/dictation/dictation_engine.py
@@ -248,7 +248,9 @@ def _clipboard_windows(text: str) -> None:
             raise OSError("GlobalLock failed")
         ctypes.memmove(ptr, encoded, len(encoded))
         kernel32.GlobalUnlock(h)
-        user32.SetClipboardData(CF_UNICODETEXT, h)
+        if not user32.SetClipboardData(CF_UNICODETEXT, h):
+            kernel32.GlobalFree(h)
+            raise OSError("SetClipboardData failed")
     finally:
         user32.CloseClipboard()
 

--- a/tests/test_dictation.py
+++ b/tests/test_dictation.py
@@ -95,6 +95,15 @@ class TestHotkeyParsing:
         assert len(mods) == 2
         assert trigger is None
 
+    def test_parse_ctrl_win(self):
+        """'win' modifier alias should map to the same key as 'cmd'."""
+        from src.jarvis.dictation.dictation_engine import parse_hotkey
+        mods_win, trigger_win = parse_hotkey("ctrl+win")
+        mods_cmd, trigger_cmd = parse_hotkey("ctrl+cmd")
+        assert mods_win == mods_cmd
+        assert trigger_win is None
+        assert trigger_cmd is None
+
     def test_parse_empty_string_raises(self):
         from src.jarvis.dictation.dictation_engine import parse_hotkey
         with pytest.raises(ValueError):


### PR DESCRIPTION
## Summary

Follow-up from adversarial review of #188:

- **Spec drift**: `dictation.spec.md` listed `alt+shift` as a hotkey preset but code uses `ctrl+shift+d` and `ctrl+shift` — updated spec to match reality
- **Dead code**: removed unused `_HOTKEY_OPTIONS = None` class attribute from `DictationPage`
- **Defensive fix**: check `SetClipboardData` return value and `GlobalFree` handle on failure
- **Missing test**: added `test_parse_ctrl_win` to verify the `"win"` modifier alias parses identically to `"cmd"`

## Test plan

- [x] All 52 dictation tests pass
- [x] New `test_parse_ctrl_win` verifies `parse_hotkey("ctrl+win") == parse_hotkey("ctrl+cmd")`

🤖 Generated with [Claude Code](https://claude.com/claude-code)