### PR TITLE
fix: prevent import modal from reappearing after diary import completes

### DIFF
--- a/src/desktop_app/memory_viewer.py
+++ b/src/desktop_app/memory_viewer.py
@@ -1808,6 +1808,7 @@ def index() -> str:
         let currentTab = 'memories';
         let selectedTopics = new Set();
         let searchQuery = '';
+        let diaryImportDone = false;
         let fromDate = '';
         let toDate = '';
         let searchDebounce = null;
@@ -2105,7 +2106,7 @@ def index() -> str:
 
             // First-time migration: offer to import diary entries if the graph
             // is empty (only root node) but the user has diary data
-            if (totalNodes <= 1 && totalMemories > 0) {
+            if (totalNodes <= 1 && totalMemories > 0 && !diaryImportDone) {
                 showImportDiaryModal(true);
             }
         }
@@ -2868,6 +2869,7 @@ def index() -> str:
                                         <button class="modal-btn primary" onclick="this.closest('.modal-overlay').remove()">Done</button>
                                     `;
                                     delete overlay.dataset.importing;
+                                    diaryImportDone = true;
                                     loadGraphData();
                                     loadTreeData();
                                     loadStats();

--- a/tests/test_diary_import.py
+++ b/tests/test_diary_import.py
@@ -232,3 +232,27 @@ class TestImportDiaryEndpoint:
 
         complete_msg = next(m for m in messages if m["type"] == "complete")
         assert complete_msg["processed"] == 2
+
+
+@pytest.mark.unit
+@pytest.mark.skipif(not _HAS_FLASK, reason="Flask not available")
+class TestImportDialogueDismissal:
+    """Regression: after diary import succeeds, loadStats must not re-show the modal."""
+
+    def test_html_contains_diary_import_done_guard(self):
+        """The loadStats check should be gated by diaryImportDone flag."""
+        from src.desktop_app.memory_viewer import app
+
+        app.config["TESTING"] = True
+        client = app.test_client()
+        resp = client.get("/")
+        html = resp.data.decode("utf-8")
+
+        # The flag must be declared
+        assert "let diaryImportDone = false;" in html
+
+        # The flag must be set on import completion
+        assert "diaryImportDone = true;" in html
+
+        # The loadStats check must include the guard
+        assert "&& !diaryImportDone" in html


### PR DESCRIPTION
## Summary

After a successful knowledge graph diary import, the \"Build Your Knowledge Graph\" dialogue failed to dismiss — it would briefly show the \"Done\" button and then get replaced by a fresh first-time prompt modal.

## Root cause

On import completion, the frontend calls \`loadStats()\` to refresh the stats badges. \`loadStats()\` re-evaluates the first-time migration condition (\`totalNodes <= 1 && totalMemories > 0\`) and calls \`showImportDiaryModal(true)\`. Because \`showImportDiaryModal\` removes any existing \`.modal-overlay\` before creating a new one, this destroyed the just-completed import modal and replaced it with a fresh \"Build Your Knowledge Graph\" dialogue — making it look like the modal refused to dismiss.

## Fix

Added a session-scoped \`diaryImportDone\` flag that is set to \`true\` when the import completes successfully. The \`loadStats()\` guard now checks \`!diaryImportDone\` before re-showing the modal.

Behaviour preserved:
- Page load with empty graph + diary entries → modal appears (unchanged)
- User closes with \"Not Now\" and reloads → modal appears again (flag is session-only)
- After import completes → modal stays dismissed for the rest of the page session

## Test plan

- [x] Added \`TestImportDialogueDismissal::test_html_contains_diary_import_done_guard\` verifying the guard logic is rendered in the HTML
- [x] All 9 tests in \`tests/test_diary_import.py\` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)