### PR TITLE
fix: macOS setup wizard crash after pressing next on model choice

### DIFF
--- a/src/desktop_app/setup_wizard.py
+++ b/src/desktop_app/setup_wizard.py
@@ -1833,23 +1833,24 @@ class WhisperSetupPage(QWizardPage):
         options = self._get_current_model_options()
         n = len(options)
 
-        # Clear existing labels — detach from parent before deleteLater to
-        # prevent Qt from accessing half-deleted widgets.
+        # Clear existing labels.  The labels are already properly parented
+        # to their container widget, and takeAt() removes the layout's
+        # reference — scheduling deleteLater() is enough.  Do NOT call
+        # setParent(None) here: on macOS that promotes each QLabel to a
+        # top-level widget mid-transition, which triggers a native
+        # window creation and can SIGABRT inside QWizard.exec().
         while self._labels_layout.count():
             item = self._labels_layout.takeAt(0)
-            if item.widget():
-                item.widget().hide()
-                item.widget().setParent(None)
-                item.widget().deleteLater()
-            elif item.spacerItem():
-                pass  # Spacers are automatically cleaned up
+            widget = item.widget()
+            if widget is not None:
+                widget.deleteLater()
+            # Spacers are automatically cleaned up when the item goes out of scope.
 
         while self._size_layout.count():
             item = self._size_layout.takeAt(0)
-            if item.widget():
-                item.widget().hide()
-                item.widget().setParent(None)
-                item.widget().deleteLater()
+            widget = item.widget()
+            if widget is not None:
+                widget.deleteLater()
 
         # Add labels aligned with slider tick positions
         # Slider ticks are at 0, 1/(n-1), 2/(n-1), ..., 1 of the groove width

--- a/src/desktop_app/setup_wizard.py
+++ b/src/desktop_app/setup_wizard.py
@@ -1839,6 +1839,9 @@ class WhisperSetupPage(QWizardPage):
         # setParent(None) here: on macOS that promotes each QLabel to a
         # top-level widget mid-transition, which triggers a native
         # window creation and can SIGABRT inside QWizard.exec().
+        # Note: dictation_history.py deliberately keeps the setParent(None)
+        # pattern — it runs from a standalone window (not a QWizard
+        # transition) and needed it to fix a Windows-specific segfault.
         while self._labels_layout.count():
             item = self._labels_layout.takeAt(0)
             widget = item.widget()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -89,3 +89,18 @@ def dialogue_memory():
     from jarvis.memory.conversation import DialogueMemory
     return DialogueMemory(inactivity_timeout=300, max_interactions=20)
 
+
+@pytest.fixture
+def qapp():
+    """Provide a shared QApplication for Qt-based UI tests.
+
+    Qt requires exactly one QApplication per process.  Re-uses an existing
+    instance when present so repeated test runs inside a single session
+    don't error.
+    """
+    from PyQt6.QtWidgets import QApplication
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    yield app
+

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -598,6 +598,94 @@ class TestWhisperModelOptions:
             assert model_id.endswith(".en"), f"English model should end with .en: {model_id}"
 
 
+class TestWhisperSetupPageSliderRebuild:
+    """Regression tests for WhisperSetupPage slider rebuild lifecycle.
+
+    On macOS, promoting a child QLabel to a top-level widget (via
+    setParent(None)) during a QWizard page transition could trigger
+    a SIGABRT ('Fatal Python error: Aborted') while the next page
+    was being shown.  These tests guarantee that the slider labels
+    stay parented to their containers throughout rebuilds — the
+    safe pattern for clearing items out of a layout.
+    """
+
+    @pytest.fixture
+    def qapp(self):
+        from PyQt6.QtWidgets import QApplication
+        app = QApplication.instance()
+        if app is None:
+            app = QApplication([])
+        yield app
+
+    def test_slider_labels_keep_container_parent_after_rebuild(self, qapp):
+        """Newly-built slider labels must remain children of their containers.
+
+        If any label ends up reparented to None it becomes a top-level
+        widget, which on macOS triggers a native window creation that
+        can abort during wizard page transitions.
+        """
+        from desktop_app.setup_wizard import WhisperSetupPage
+
+        page = WhisperSetupPage()
+
+        # Toggle language mode — this fires _rebuild_slider_ui which
+        # clears the old labels and inserts a new set.
+        page._on_language_changed(True)
+        page._on_language_changed(False)
+
+        labels_container = page._labels_container
+        size_container = page._size_container
+
+        for i in range(page._labels_layout.count()):
+            item = page._labels_layout.itemAt(i)
+            w = item.widget()
+            if w is not None:
+                assert w.parent() is labels_container, (
+                    "Slider name labels must stay parented to their "
+                    "container — a None parent promotes them to top-level "
+                    "widgets, which crashes QWizard transitions on macOS."
+                )
+
+        for i in range(page._size_layout.count()):
+            item = page._size_layout.itemAt(i)
+            w = item.widget()
+            if w is not None:
+                assert w.parent() is size_container, (
+                    "Slider size labels must stay parented to their "
+                    "container — a None parent promotes them to top-level "
+                    "widgets, which crashes QWizard transitions on macOS."
+                )
+
+    def test_initialize_page_can_be_called_multiple_times(self, qapp):
+        """initializePage must be safely re-callable.
+
+        QWizard calls initializePage each time a page is shown.  The
+        first call (right after construction) has to clear the initial
+        labels that __init__ built, and subsequent calls must not
+        crash or leak top-level widgets.
+        """
+        from desktop_app.setup_wizard import WhisperSetupPage
+
+        page = WhisperSetupPage()
+
+        # Re-initialise a few times — this mirrors back/forward
+        # navigation between wizard pages.
+        for _ in range(3):
+            page.initializePage()
+
+        # All remaining labels in the layouts are still properly
+        # parented (not promoted to top-level).
+        for layout, container in [
+            (page._labels_layout, page._labels_container),
+            (page._size_layout, page._size_container),
+        ]:
+            for i in range(layout.count()):
+                item = layout.itemAt(i)
+                w = item.widget()
+                if w is not None:
+                    assert w.parent() is container
+
+
 class TestMCPPage:
     """Tests for the MCP servers wizard page."""
 

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -609,14 +609,6 @@ class TestWhisperSetupPageSliderRebuild:
     safe pattern for clearing items out of a layout.
     """
 
-    @pytest.fixture
-    def qapp(self):
-        from PyQt6.QtWidgets import QApplication
-        app = QApplication.instance()
-        if app is None:
-            app = QApplication([])
-        yield app
-
     def test_slider_labels_keep_container_parent_after_rebuild(self, qapp):
         """Newly-built slider labels must remain children of their containers.
 

--- a/tests/test_splash_screen.py
+++ b/tests/test_splash_screen.py
@@ -32,15 +32,6 @@ class TestSplashScreenImport:
 class TestSplashScreenFunctionality:
     """Tests for splash screen functionality."""
 
-    @pytest.fixture
-    def qapp(self):
-        """Create a QApplication for testing."""
-        from PyQt6.QtWidgets import QApplication
-        app = QApplication.instance()
-        if app is None:
-            app = QApplication([])
-        yield app
-
     def test_splash_screen_instantiation(self, qapp):
         """SplashScreen should instantiate without error."""
         from desktop_app.splash_screen import SplashScreen


### PR DESCRIPTION
## Summary

- Fresh-install macOS wizard SIGABRTed inside `wizard.exec()` right after the user pressed **Next** on the model choice screen — before any model was installed. Reproduced from the crash report in the original bug report.
- Root cause: #185 pre-emptively added `hide()` + `setParent(None)` before `deleteLater()` in `WhisperSetupPage._rebuild_slider_ui`. The setup-wizard code was already safe (it uses `takeAt` correctly). On macOS, `setParent(None)` promotes each child `QLabel` to a top-level widget mid-transition, attempts native `NSWindow` creation, and aborts. In PyQt6 it also invalidates the `QLayoutItem` pointer so the third `item.widget()` call returns `None`.
- Restored the plain `takeAt` + `deleteLater` pattern with `item.widget()` cached to a local, added a warning comment explaining the macOS hazard, and added two regression tests. `dictation_history.py`'s fix for the original Windows crash is left untouched — it runs from a standalone window, not during a QWizard transition.

Crash flow matched exactly: ModelsPage → Next → `WhisperSetupPage.initializePage()` → `_rebuild_slider_ui()` → abort.

### Review follow-ups

- Promoted the duplicated `qapp` fixture into `tests/conftest.py` so future Qt tests can share it.
- Added a cross-reference in the setup_wizard warning comment pointing at `dictation_history.py` so the intentional asymmetry is explicit.

## Test plan

- [x] `pytest tests/test_setup_wizard.py tests/test_splash_screen.py` — 59 tests pass, including two new regression tests and the splash tests now using the shared fixture.
- [x] New `test_slider_labels_keep_container_parent_after_rebuild` and `test_initialize_page_can_be_called_multiple_times` — both fail against the buggy code (AttributeError) and pass against the fix.
- [ ] Manual macOS check: fresh install, run wizard through Welcome → Ollama → Models → Next → lands on Whisper page without crashing.
- [ ] Windows regression sanity: re-run `tests/test_dictation_history.py` to confirm the unrelated Windows fix is untouched.

Follow-up spawned separately: verify `dictation_history.py` is actually safe on macOS (its different call context suggests yes, but worth confirming manually).

🤖 Generated with [Claude Code](https://claude.com/claude-code)