### PR TITLE
fix: move dictation stream teardown off the pynput listener thread (#184)

### DIFF
--- a/src/jarvis/dictation/dictation.spec.md
+++ b/src/jarvis/dictation/dictation.spec.md
@@ -96,6 +96,14 @@ After transcription, text passes through these stages in order:
 
 - `threading.Lock` around shared Whisper model transcription calls.
 - Dedicated audio stream; never touches the listener's stream.
+- The `pynput` key handlers (`_on_key_press` / `_on_key_release`) must return
+  quickly — Windows silently removes low-level keyboard hooks that take more
+  than ~5 s to return, leaving pynput in an inconsistent state that can
+  segfault on the next `Controller` call from the paste thread. `_stop_recording`
+  therefore only flips state under the lock and dispatches audio-stream
+  teardown, beep playback, transcription, and paste to a background thread.
+  The `discard=True` path keeps the synchronous teardown so shutdown can
+  reliably wait for everything to finish.
 
 ## Beeps
 

--- a/src/jarvis/dictation/dictation_engine.py
+++ b/src/jarvis/dictation/dictation_engine.py
@@ -553,6 +553,24 @@ def parse_hotkey(combo: str):
 
 
 # ---------------------------------------------------------------------------
+# Stream cleanup
+# ---------------------------------------------------------------------------
+
+def _close_stream(stream: Any) -> None:
+    """Stop and close a sounddevice InputStream, swallowing errors."""
+    if stream is None:
+        return
+    try:
+        stream.stop()
+    except Exception as exc:
+        debug_log(f"stream.stop() failed: {exc}", "dictation")
+    try:
+        stream.close()
+    except Exception as exc:
+        debug_log(f"stream.close() failed: {exc}", "dictation")
+
+
+# ---------------------------------------------------------------------------
 # Main engine
 # ---------------------------------------------------------------------------
 
@@ -911,41 +929,60 @@ class DictationEngine:
         self._audio_frames.append(indata[:, 0].copy())
 
     def _stop_recording(self, discard: bool = False) -> None:
+        # Flip state and snapshot the work queue atomically, under minimal
+        # lock scope.  All heavy work (stream teardown, beep, transcribe,
+        # paste) then runs off-thread so the pynput hotkey callback can
+        # return immediately.  This matters on Windows: low-level keyboard
+        # hooks are silently removed by the OS when a callback takes more
+        # than ~5 s, which leaves pynput in an inconsistent state and can
+        # segfault on the next Controller.press/release issued by the paste
+        # thread (issue #184).
         with self._lock:
             if not self._recording:
                 return
             self._recording = False
             self._hands_free = False
-
-        # Stop audio stream
-        if self._stream is not None:
-            try:
-                self._stream.stop()
-                self._stream.close()
-            except Exception:
-                pass
+            stream = self._stream
             self._stream = None
+            audio_frames = self._audio_frames
+            self._audio_frames = []
+            start_time = self._record_start_time
 
         if discard:
-            self._audio_frames = []
+            # Shutdown path — tear down synchronously so the caller knows
+            # everything is finished before the engine is gone.
+            _close_stream(stream)
             if self._on_dictation_end:
-                self._on_dictation_end()
+                try:
+                    self._on_dictation_end()
+                except Exception:
+                    pass
             return
 
-        # Play stop beep
-        _play_beep(_get_stop_beep())
-
-        duration = time.time() - self._record_start_time
-        debug_log(f"dictation recording stopped ({duration:.1f}s)", "dictation")
-
-        # Transcribe in a thread to avoid blocking the key listener
-        audio_frames = self._audio_frames
-        self._audio_frames = []
         threading.Thread(
-            target=self._transcribe_and_paste,
-            args=(audio_frames,),
+            target=self._finalise_and_transcribe,
+            args=(stream, audio_frames, start_time),
             daemon=True,
         ).start()
+
+    def _finalise_and_transcribe(
+        self,
+        stream: Any,
+        audio_frames: list,
+        start_time: float,
+    ) -> None:
+        """Worker: close stream, play beep, transcribe, paste.
+
+        Runs on a background thread so the pynput hotkey callback returns
+        immediately.  See ``_stop_recording`` for the rationale.
+        """
+        _close_stream(stream)
+        _play_beep(_get_stop_beep())
+
+        duration = time.time() - start_time
+        debug_log(f"dictation recording stopped ({duration:.1f}s)", "dictation")
+
+        self._transcribe_and_paste(audio_frames)
 
     # ------------------------------------------------------------------
     # Transcription & paste

--- a/src/jarvis/dictation/dictation_engine.py
+++ b/src/jarvis/dictation/dictation_engine.py
@@ -917,6 +917,11 @@ class DictationEngine:
 
     def _audio_callback(self, indata, frames, time_info, status) -> None:
         """sounddevice callback — accumulate audio frames."""
+        # ``self._recording`` is read without the engine lock.  This is safe
+        # because writes happen under the lock in _start_recording and
+        # _stop_recording, and a single-word bool read/write is atomic under
+        # the GIL.  Worst case is one extra frame captured just after stop
+        # or one missed frame just after start — both benign.
         if not self._recording:
             return
         # Enforce max duration
@@ -975,14 +980,32 @@ class DictationEngine:
 
         Runs on a background thread so the pynput hotkey callback returns
         immediately.  See ``_stop_recording`` for the rationale.
+
+        ``_on_dictation_end`` is normally fired from ``_transcribe_and_paste``'s
+        finally block.  We wrap the whole body in try/except so a failure in
+        ``_close_stream`` or ``_play_beep`` (before we reach the transcribe
+        step) still unpauses the voice listener and resets the face state —
+        otherwise a single beep error would strand the UI in ``DICTATING``.
         """
-        _close_stream(stream)
-        _play_beep(_get_stop_beep())
+        end_fired = False
+        try:
+            _close_stream(stream)
+            _play_beep(_get_stop_beep())
 
-        duration = time.time() - start_time
-        debug_log(f"dictation recording stopped ({duration:.1f}s)", "dictation")
+            duration = time.time() - start_time
+            debug_log(f"dictation recording stopped ({duration:.1f}s)", "dictation")
 
-        self._transcribe_and_paste(audio_frames)
+            # _transcribe_and_paste has its own finally that fires
+            # _on_dictation_end, so we defer to it on the happy path.
+            end_fired = True
+            self._transcribe_and_paste(audio_frames)
+        except Exception as exc:
+            debug_log(f"dictation finalise error: {exc}", "dictation")
+            if not end_fired and self._on_dictation_end:
+                try:
+                    self._on_dictation_end()
+                except Exception:
+                    pass
 
     # ------------------------------------------------------------------
     # Transcription & paste

--- a/tests/test_dictation.py
+++ b/tests/test_dictation.py
@@ -296,6 +296,80 @@ class TestRecordingStateMachine:
         assert engine._audio_frames == []
         assert engine._recording is False
 
+    def test_stop_recording_returns_fast_on_slow_stream_close(self):
+        """The non-discard path must not block the caller on stream.close().
+
+        Rationale: ``_stop_recording`` is invoked from the pynput low-level
+        keyboard hook callback.  Windows silently removes low-level keyboard
+        hooks that take more than ~5 s to return, which leaves pynput in an
+        inconsistent state that can crash the process when the paste thread
+        subsequently calls Controller.press/tap/release (issue #184).
+
+        The listener callback must return in a handful of milliseconds even
+        if closing the audio device is slow.
+        """
+        import numpy as np
+        slow_stream = MagicMock()
+
+        def slow_close(*_args, **_kwargs):
+            time.sleep(1.0)
+
+        slow_stream.stop.side_effect = slow_close
+        slow_stream.close.side_effect = slow_close
+
+        engine = _make_engine()
+        engine._recording = True
+        engine._stream = slow_stream
+        # Short (< 0.3 s) audio so transcribe_and_paste exits quickly.
+        engine._audio_frames = [np.zeros(1600, dtype=np.float32)]
+
+        with patch("src.jarvis.dictation.dictation_engine._play_beep"):
+            t0 = time.time()
+            engine._stop_recording()
+            elapsed = time.time() - t0
+
+        # The caller (simulating the pynput hook) must return quickly.
+        assert elapsed < 0.2, (
+            f"_stop_recording blocked for {elapsed:.2f}s in the listener "
+            "thread — stream.close() must be off the hot path"
+        )
+
+        # The stream must still be closed eventually, off-thread.
+        deadline = time.time() + 5.0
+        while time.time() < deadline and not slow_stream.close.called:
+            time.sleep(0.05)
+        assert slow_stream.close.called, "stream.close() never ran"
+
+    def test_stop_recording_idempotent_under_concurrent_calls(self):
+        """Rapid double-release of the hotkey must not double-close the stream.
+
+        On Windows ``ctrl+cmd`` the user releases two keys in quick succession;
+        both releases can fire the listener callback before either has finished.
+        Only one teardown should reach the stream.
+        """
+        import numpy as np
+        engine = _make_engine()
+        engine._recording = True
+        stream_mock = MagicMock()
+        engine._stream = stream_mock
+        engine._audio_frames = [np.zeros(1600, dtype=np.float32)]
+
+        with patch("src.jarvis.dictation.dictation_engine._play_beep"):
+            # Two near-simultaneous calls from the listener.
+            t1 = threading.Thread(target=engine._stop_recording)
+            t2 = threading.Thread(target=engine._stop_recording)
+            t1.start()
+            t2.start()
+            t1.join()
+            t2.join()
+
+        # Wait for the spawned teardown thread to run close().
+        deadline = time.time() + 5.0
+        while time.time() < deadline and not stream_mock.close.called:
+            time.sleep(0.05)
+        # Only one of the two calls should have reached the stream.
+        assert stream_mock.close.call_count == 1
+
     def test_on_dictation_callbacks_called(self):
         """Start/end callbacks should be invoked."""
         start_called = threading.Event()

--- a/tests/test_dictation.py
+++ b/tests/test_dictation.py
@@ -329,6 +329,9 @@ class TestRecordingStateMachine:
             elapsed = time.time() - t0
 
         # The caller (simulating the pynput hook) must return quickly.
+        # 200 ms is generous headroom vs. the ~5 s Windows LowLevelHooksTimeout
+        # — the method should actually return in microseconds, since it just
+        # flips a bool and spawns a daemon thread.
         assert elapsed < 0.2, (
             f"_stop_recording blocked for {elapsed:.2f}s in the listener "
             "thread — stream.close() must be off the hot path"
@@ -369,6 +372,64 @@ class TestRecordingStateMachine:
             time.sleep(0.05)
         # Only one of the two calls should have reached the stream.
         assert stream_mock.close.call_count == 1
+
+    def test_max_duration_callback_still_stops_recording(self):
+        """Hitting the 60s cap must still close the stream and fire the end
+        callback, even though the new teardown path runs off-thread.
+
+        ``_audio_callback`` spawns a daemon thread that calls
+        ``_stop_recording()``; that then dispatches ``_finalise_and_transcribe``
+        which closes the stream and eventually invokes ``_on_dictation_end``
+        (via ``_transcribe_and_paste``'s finally).
+        """
+        import numpy as np
+        end_called = threading.Event()
+        engine = _make_engine(
+            on_dictation_end=lambda: end_called.set(),
+            whisper_model_ref=lambda: None,  # short-circuits transcribe
+            whisper_backend_ref=lambda: "faster-whisper",
+        )
+        stream_mock = MagicMock()
+        engine._recording = True
+        engine._stream = stream_mock
+        # Pre-fill up to the limit so one more frame triggers the cap.
+        engine._max_frames = 100
+        engine._audio_frames = [np.zeros(100, dtype=np.float32)]
+
+        with patch("src.jarvis.dictation.dictation_engine._play_beep"):
+            indata = np.random.randn(1600, 1).astype(np.float32)
+            engine._audio_callback(indata, 1600, None, None)
+            # _stop_recording runs in a daemon thread; wait for close().
+            assert end_called.wait(timeout=5.0), "on_dictation_end never fired"
+
+        assert stream_mock.close.called, "stream.close() never ran"
+        assert engine._recording is False
+
+    def test_finalise_fires_on_dictation_end_when_beep_raises(self):
+        """A failure in ``_play_beep`` must not strand the listener paused.
+
+        ``_on_dictation_end`` is normally fired from
+        ``_transcribe_and_paste``'s finally, but that step is never reached
+        if ``_close_stream`` or ``_play_beep`` raises.  ``_finalise_and_transcribe``
+        must therefore guarantee the callback fires on any error.
+        """
+        import numpy as np
+        end_called = threading.Event()
+        engine = _make_engine(on_dictation_end=lambda: end_called.set())
+
+        with patch(
+            "src.jarvis.dictation.dictation_engine._play_beep",
+            side_effect=RuntimeError("beep broken"),
+        ):
+            engine._finalise_and_transcribe(
+                stream=None,
+                audio_frames=[np.zeros(1600, dtype=np.float32)],
+                start_time=time.time(),
+            )
+
+        assert end_called.is_set(), (
+            "_on_dictation_end must fire even when _play_beep raises"
+        )
 
     def test_on_dictation_callbacks_called(self):
         """Start/end callbacks should be invoked."""


### PR DESCRIPTION
## Summary
- Dictation on Windows could crash right after a successful paste (issue #184). Cause: `_stop_recording` ran `stream.stop()`/`close()` synchronously inside the `pynput` low-level keyboard hook callback. On Windows, hooks that take >~5s return get silently removed by the OS, leaving pynput in an inconsistent state that can segfault on the next `Controller.press`/`release` issued by the paste thread.
- Fix: under the engine lock, flip `_recording`/`_hands_free` only and snapshot the work (stream, frames, start time), then dispatch stream teardown, beep, transcription, and paste to a daemon thread. The listener callback now returns in <1 ms no matter how slow `stream.close()` is on the device.
- Shutdown (`discard=True`) keeps the synchronous teardown so callers can reliably wait for everything to finish.
- Added `_close_stream` helper that swallows + logs errors per step.
- Spec updated with the threading rule so this doesn't regress.

### Follow-up commit (review findings)
- Wrap `_finalise_and_transcribe` body in try/except so a failure in `_close_stream` or `_play_beep` still fires `_on_dictation_end` — otherwise a beep error could have stranded the voice listener paused and the face widget in `DICTATING`.
- Added test for the 60s max-duration path interacting with the new worker-thread teardown.
- Added test locking in the `_on_dictation_end` guarantee when `_play_beep` raises.
- Annotated the lockless `self._recording` read in `_audio_callback`.
- Tied the 200 ms test threshold to the Windows `LowLevelHooksTimeout` budget.

## Test plan
- [x] `tests/test_dictation.py::test_stop_recording_returns_fast_on_slow_stream_close` — listener-side call returns in <200 ms even when `stream.close()` sleeps 1 s (fails on `develop`, passes with this change).
- [x] `tests/test_dictation.py::test_stop_recording_idempotent_under_concurrent_calls` — rapid double-release reaches `stream.close()` exactly once.
- [x] `tests/test_dictation.py::test_max_duration_callback_still_stops_recording` — 60 s cap path still closes stream and fires end callback.
- [x] `tests/test_dictation.py::test_finalise_fires_on_dictation_end_when_beep_raises` — beep failure doesn't strand the listener.
- [x] Full `tests/test_dictation.py` + `tests/test_dictation_history.py` + `tests/test_face_widget.py` + `tests/test_desktop_app.py` (now 139 tests) all pass.
- [ ] Manual smoke test: Ctrl+Win hold-to-dictate on Windows, repeat several times, verify no crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)