### PR TITLE
fix: stop reparenting list children when rebuilding dictation history window

### DIFF
--- a/src/desktop_app/dictation_history.py
+++ b/src/desktop_app/dictation_history.py
@@ -285,15 +285,18 @@ class DictationHistoryWindow(QMainWindow):
     def _reload(self) -> None:
         """Rebuild the card list from history."""
         # Remove all existing cards (but keep the stretch at the end).
-        # We must hide + setParent(None) before deleteLater to avoid
-        # Qt accessing a half-deleted widget still referenced by the layout.
+        # takeAt() removes the layout's reference, and the widget is still
+        # parented to the container — scheduling deleteLater() is enough.
+        # Do NOT call setParent(None) here: on Windows it promotes each
+        # child to a native top-level HWND mid-rebuild and fast-fails
+        # (0xc0000409) inside Qt6Core.dll; on macOS it SIGABRTs for the
+        # equivalent NSWindow reason (see setup_wizard.py for the macOS
+        # QWizard variant of the same mistake).
         while self._list_layout.count() > 1:
             item = self._list_layout.takeAt(0)
-            w = item.widget()
-            if w:
-                w.hide()
-                w.setParent(None)
-                w.deleteLater()
+            widget = item.widget()
+            if widget is not None:
+                widget.deleteLater()
 
         if self._history is None:
             self._empty_label = self._make_empty_label()
@@ -360,7 +363,10 @@ class DictationHistoryWindow(QMainWindow):
             return
         # Remove any placeholder labels (empty state / disabled state).
         # Collect indices first, then remove in reverse order so that
-        # indices stay valid.  Also detach from parent before deleteLater.
+        # indices stay valid.  takeAt() is the essential step — it
+        # removes the layout's reference to the widget so the deferred
+        # deletion is safe.  See _reload() for why setParent(None) is
+        # deliberately avoided.
         indices_to_remove = []
         for i in range(self._list_layout.count()):
             item = self._list_layout.itemAt(i)
@@ -369,11 +375,9 @@ class DictationHistoryWindow(QMainWindow):
                 indices_to_remove.append(i)
         for i in reversed(indices_to_remove):
             item = self._list_layout.takeAt(i)
-            w = item.widget()
-            if w:
-                w.hide()
-                w.setParent(None)
-                w.deleteLater()
+            widget = item.widget()
+            if widget is not None:
+                widget.deleteLater()
 
         card = _DictationCard(entry)
         card.deleted.connect(self._on_delete)

--- a/src/desktop_app/dictation_history.py
+++ b/src/desktop_app/dictation_history.py
@@ -362,16 +362,17 @@ class DictationHistoryWindow(QMainWindow):
         if self._history is None:
             return
         # Remove any placeholder labels (empty state / disabled state).
-        # Collect indices first, then remove in reverse order so that
-        # indices stay valid.  takeAt() is the essential step — it
-        # removes the layout's reference to the widget so the deferred
-        # deletion is safe.  See _reload() for why setParent(None) is
-        # deliberately avoided.
+        # The isinstance(QLabel) filter is safe because _DictationCard is a
+        # QFrame, not a QLabel — cards are never caught here.  Collect
+        # indices first, then remove in reverse order so that indices stay
+        # valid.  takeAt() is the essential step — it removes the layout's
+        # reference to the widget so the deferred deletion is safe.  See
+        # _reload() for why setParent(None) is deliberately avoided.
         indices_to_remove = []
         for i in range(self._list_layout.count()):
             item = self._list_layout.itemAt(i)
-            w = item.widget() if item else None
-            if isinstance(w, QLabel):
+            widget = item.widget() if item else None
+            if isinstance(widget, QLabel):
                 indices_to_remove.append(i)
         for i in reversed(indices_to_remove):
             item = self._list_layout.takeAt(i)

--- a/src/desktop_app/setup_wizard.py
+++ b/src/desktop_app/setup_wizard.py
@@ -1838,10 +1838,10 @@ class WhisperSetupPage(QWizardPage):
         # reference — scheduling deleteLater() is enough.  Do NOT call
         # setParent(None) here: on macOS that promotes each QLabel to a
         # top-level widget mid-transition, which triggers a native
-        # window creation and can SIGABRT inside QWizard.exec().
-        # Note: dictation_history.py deliberately keeps the setParent(None)
-        # pattern — it runs from a standalone window (not a QWizard
-        # transition) and needed it to fix a Windows-specific segfault.
+        # NSWindow creation and can SIGABRT inside QWizard.exec().  On
+        # Windows the same reparent creates a native HWND and fast-fails
+        # (0xc0000409) inside Qt6Core.dll — see dictation_history.py
+        # where the same mistake crashed the history window.
         while self._labels_layout.count():
             item = self._labels_layout.takeAt(0)
             widget = item.widget()

--- a/tests/test_dictation_history.py
+++ b/tests/test_dictation_history.py
@@ -214,33 +214,88 @@ class TestDictationHistoryWindow:
         # We can't call set_history fully without Qt, but verify the method exists
         assert callable(win.set_history)
 
-    def test_reload_detaches_widgets_before_delete(self):
-        """_reload must call setParent(None) on removed widgets to prevent
-        Qt from accessing half-deleted objects (fixes segfault in Qt6Core.dll).
+    def test_reload_keeps_list_items_parented_to_container(self, qapp, tmp_path):
+        """Cards/placeholders must stay parented to the list container after
+        a rebuild.  A None parent promotes the widget to a top-level window,
+        which on Windows allocates a native HWND and fast-fails (0xc0000409)
+        inside Qt6Core.dll when done in a loop — the crash that opening the
+        dictation history tray menu item triggered.
         """
-        import inspect
         from src.desktop_app.dictation_history import DictationHistoryWindow
-        source = inspect.getsource(DictationHistoryWindow._reload)
-        # The safe pattern: takeAt → hide → setParent(None) → deleteLater
-        assert "setParent(None)" in source, (
-            "_reload must detach widgets with setParent(None) before deleteLater"
-        )
+        from src.jarvis.dictation.history import DictationHistory
 
-    def test_on_new_entry_removes_from_layout_before_delete(self):
-        """_on_new_entry must takeAt (remove from layout) before deleteLater
-        to avoid dangling layout references to deleted widgets.
+        history = DictationHistory(path=tmp_path / "h.json")
+        history.add("first")
+        history.add("second")
+        history.add("third")
+
+        window = DictationHistoryWindow(history=history)
+        container = window._list_widget
+
+        # Rebuild a few times to mirror show/hide/show from the tray menu.
+        for _ in range(3):
+            window._reload()
+
+        for i in range(window._list_layout.count()):
+            item = window._list_layout.itemAt(i)
+            widget = item.widget()
+            if widget is not None:
+                assert widget.parent() is container, (
+                    "List items must stay parented to the container — a None "
+                    "parent promotes them to top-level widgets, which crashes "
+                    "on Windows (0xc0000409 inside Qt6Core.dll)."
+                )
+
+    def test_on_new_entry_keeps_new_card_parented_to_container(self, qapp, tmp_path):
+        """A card inserted via the new-entry signal must be parented to the
+        container, not promoted to a top-level widget.
         """
-        import inspect
         from src.desktop_app.dictation_history import DictationHistoryWindow
-        source = inspect.getsource(DictationHistoryWindow._on_new_entry)
-        assert "takeAt" in source, (
-            "_on_new_entry must remove widgets from layout (takeAt) before "
-            "calling deleteLater"
-        )
-        assert "setParent(None)" in source, (
-            "_on_new_entry must detach widgets with setParent(None) before "
-            "deleteLater"
-        )
+        from src.jarvis.dictation.history import DictationHistory
+
+        history = DictationHistory(path=tmp_path / "h.json")
+        window = DictationHistoryWindow(history=history)
+        container = window._list_widget
+
+        # Start from the empty-state placeholder and add an entry.
+        entry = history.add("hello world", duration=1.0)
+        window._on_new_entry(entry)
+
+        for i in range(window._list_layout.count()):
+            item = window._list_layout.itemAt(i)
+            widget = item.widget()
+            if widget is not None:
+                assert widget.parent() is container, (
+                    "Widgets must stay parented to the container after a new "
+                    "entry is inserted."
+                )
+
+    def test_show_event_is_safely_re_callable(self, qapp, tmp_path):
+        """showEvent must be callable repeatedly without orphaning widgets.
+
+        The tray menu opens the window every time, so show/hide cycles over a
+        session need to keep the list layout healthy.
+        """
+        from src.desktop_app.dictation_history import DictationHistoryWindow
+        from src.jarvis.dictation.history import DictationHistory
+
+        history = DictationHistory(path=tmp_path / "h.json")
+        for i in range(5):
+            history.add(f"entry {i}")
+
+        window = DictationHistoryWindow(history=history)
+        container = window._list_widget
+
+        # Mimic several tray-menu open/close cycles.
+        for _ in range(3):
+            window.show()
+            window.hide()
+
+        for i in range(window._list_layout.count()):
+            item = window._list_layout.itemAt(i)
+            widget = item.widget()
+            if widget is not None:
+                assert widget.parent() is container
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Opening the 🎙️ Dictation History tray menu item on Windows still crashes with `STATUS_STACK_BUFFER_OVERRUN (0xc0000409)` in `Qt6Core.dll` on develop builds that already include PR #185's fix.

Crash log the user supplied (confirmed build timestamp 2026-04-15 22:13:59 UTC, after #185 and #194 landed):

```
Faulting application name: Jarvis.exe
Faulting module name: Qt6Core.dll
Exception code: 0xc0000409
```

### Root cause

PR #185 tried to fix this crash by adding `hide()` + `setParent(None)` before every `deleteLater()` in `_reload` / `_on_new_entry`. That reparent step is exactly what's harmful:

- `setParent(None)` on a `QWidget` that was in a layout promotes it to a top-level window.
- On Windows that allocates a new native **HWND** even for hidden widgets; doing it in a tight loop over every list child on every window open is what fast-fails inside Qt6Core.dll.
- PR #193 already hit the same class of bug on macOS (NSWindow creation mid `QWizard` transition → SIGABRT) and reverted `setParent(None)` there, with a comment explicitly warning against it. The comment claimed `dictation_history.py` "needed" the reparent to fix a Windows-specific segfault, but that claim turned out to be wrong — the Windows crash was never fixed.

The **genuine** bug #185 was trying to address was `_on_new_entry` calling `deleteLater()` without a preceding `takeAt()`. That part is correct and stays. The reparent is what gets dropped.

### Fix

Use the canonical Qt pattern in both `_reload` and `_on_new_entry`:

```python
while layout.count() > 1:
    item = layout.takeAt(0)
    widget = item.widget()
    if widget is not None:
        widget.deleteLater()
```

`takeAt()` removes the layout's reference; `deleteLater()` defers destruction through the event loop; Qt's parent/child machinery handles the rest. No native window churn. Same pattern `setup_wizard.py` has used since PR #193.

Also updated the cross-reference comment in `setup_wizard.py` so the two files match.

### Tests

Replaced the two source-inspection tests that asserted the harmful `setParent(None)` pattern with behavioural ones that mirror the setup_wizard regression tests in PR #193:

- `test_reload_keeps_list_items_parented_to_container` — runs several rebuild cycles and asserts every remaining layout child is still parented to `_list_widget` (never promoted to a top-level).
- `test_on_new_entry_keeps_new_card_parented_to_container` — same assertion after inserting a new entry.
- `test_show_event_is_safely_re_callable` — covers the tray-menu open/close cycle path.

## Test plan

- [x] `pytest tests/test_dictation_history.py` — 22 passed, 4 skipped (pynput unavailable in dev env)
- [x] `pytest tests/test_setup_wizard.py` — slider rebuild regression tests still pass (2 unrelated MCP failures from missing `mcp_client` module in dev env)
- [ ] Install the resulting develop build on Windows and open the 🎙️ Dictation History tray item repeatedly with an empty history, a few entries, and a full 500-entry history — no crash
- [ ] Same on macOS — no regression in the history window or the setup wizard slider page
