### PR TITLE
fix: skip dictation history rebuild when window is hidden

### DIFF
--- a/src/desktop_app/desktop_app.spec.md
+++ b/src/desktop_app/desktop_app.spec.md
@@ -88,6 +88,15 @@ The central controller that manages:
 | **FaceWindow** | Animated face that reacts to speaking state |
 | **SettingsWindow** | Auto-generated config editor with tabbed categories |
 | **SetupWizard** | First-run configuration (Ollama, models, profile) |
+| **DictationHistoryWindow** | Scrollable list of past dictations with copy/delete/clear actions |
+
+### DictationHistoryWindow Behaviour
+
+- **Backing store**: A file-backed `DictationHistory` (see `src/jarvis/dictation/history.py`) persisting to `~/.local/share/jarvis/dictation_history.json` (platform-equivalent path). Entries are newest-first with `id`, `text`, `timestamp`, `duration`.
+- **Visibility-gated rendering**: The `new_entry` signal slot (`_on_new_entry`) is a no-op while the window is hidden. In bundled mode the daemon runs in-process, so the engine's `on_dictation_result` callback fires on a worker thread after every successful dictation — even before the user ever opens this window. Manipulating the widget tree for a never-shown window fast-fails inside `Qt6Core.dll` on Windows (`0xc0000409`). The entry is already persisted to disk by the engine, so no data is lost.
+- **Disk-reload on show**: `showEvent` calls `history.reload_from_disk()` and rebuilds the list. This covers both (a) bundled mode where the slot was skipped while hidden and (b) subprocess mode where the daemon owns a separate in-memory `DictationHistory` instance and the only shared state is the JSON file.
+- **File-watch polling**: While visible, a 1.5 s `QTimer` polls the history file's mtime and reloads when it changes (covers subprocess-mode dictations that land while the window is open).
+- **No `setParent(None)` on rebuild**: `_reload()` removes cards via `takeAt()` + `deleteLater()` only. Promoting children to top-level by nulling their parent fast-fails on Windows (`0xc0000409`) and SIGABRTs on macOS for the equivalent NSWindow reason.
 
 ### LogViewerWindow Features
 

--- a/src/desktop_app/dictation_history.py
+++ b/src/desktop_app/dictation_history.py
@@ -370,6 +370,17 @@ class DictationHistoryWindow(QMainWindow):
         """Slot: called (via signal) when a new dictation completes."""
         if self._history is None:
             return
+        # Skip UI work while the window is hidden.  In bundled mode the daemon
+        # runs in-process, so the engine's on_dictation_result callback fires
+        # on a worker thread whenever a dictation lands, even if the user
+        # never opened this window.  Touching the widget tree while the
+        # window has never been shown fast-fails inside Qt6Core.dll on
+        # Windows (0xc0000409 — fatal app exit from an internal Qt assertion,
+        # matching the signature of setParent-related crashes seen elsewhere
+        # in this file).  The entry is already persisted to history by the
+        # engine, and showEvent() rebuilds from disk on next open.
+        if not self.isVisible():
+            return
         # Remove any placeholder labels (empty state / disabled state).
         # The isinstance(QLabel) filter is safe because _DictationCard is a
         # QFrame, not a QLabel — cards are never caught here.  Collect

--- a/tests/test_dictation_history.py
+++ b/tests/test_dictation_history.py
@@ -250,16 +250,38 @@ class TestDictationHistoryWindow:
         """A card inserted via the new-entry signal must be parented to the
         container, not promoted to a top-level widget.
         """
-        from src.desktop_app.dictation_history import DictationHistoryWindow
+        from src.desktop_app.dictation_history import (
+            DictationHistoryWindow,
+            _DictationCard,
+        )
         from src.jarvis.dictation.history import DictationHistory
 
         history = DictationHistory(path=tmp_path / "h.json")
         window = DictationHistoryWindow(history=history)
         container = window._list_widget
 
+        # _on_new_entry is a no-op while the window is hidden (see
+        # test_on_new_entry_is_safe_when_window_hidden).  To exercise the
+        # visible-path insertion without calling .show() — which hangs under
+        # QT_QPA_PLATFORM=offscreen in some configurations — monkey-patch
+        # isVisible() to report True.
+        window.isVisible = lambda: True  # type: ignore[assignment]
+
         # Start from the empty-state placeholder and add an entry.
         entry = history.add("hello world", duration=1.0)
         window._on_new_entry(entry)
+
+        # A card must actually have been inserted — otherwise this test passes
+        # vacuously and gives no coverage of the parent-ing behaviour.
+        cards = [
+            window._list_layout.itemAt(i).widget()
+            for i in range(window._list_layout.count())
+            if isinstance(window._list_layout.itemAt(i).widget(), _DictationCard)
+        ]
+        assert len(cards) == 1, (
+            "Expected exactly one _DictationCard to be inserted into the "
+            "visible window's layout."
+        )
 
         for i in range(window._list_layout.count()):
             item = window._list_layout.itemAt(i)

--- a/tests/test_dictation_history.py
+++ b/tests/test_dictation_history.py
@@ -270,6 +270,58 @@ class TestDictationHistoryWindow:
                     "entry is inserted."
                 )
 
+    def test_on_new_entry_is_safe_when_window_hidden(self, qapp, tmp_path):
+        """A dictation can complete before the user ever opens the history
+        window.  In bundled mode the daemon runs in-process, so the engine's
+        on_dictation_result callback fires while the window is still hidden.
+        That path must not manipulate the widget tree — on Windows Qt 6 the
+        combination of creating cards and triggering queued event delivery
+        while the window has never been shown fast-fails inside Qt6Core.dll
+        (0xc0000409) (installer-mode-only crash reported after a successful
+        paste).  When the user later opens the window, showEvent pulls the
+        fresh entries from history and rebuilds from scratch.
+        """
+        from src.desktop_app.dictation_history import DictationHistoryWindow
+        from src.jarvis.dictation.history import DictationHistory
+
+        history = DictationHistory(path=tmp_path / "h.json")
+        window = DictationHistoryWindow(history=history)
+        assert not window.isVisible()
+
+        # Snapshot the layout contents before the signal.
+        before = [
+            window._list_layout.itemAt(i).widget()
+            for i in range(window._list_layout.count())
+        ]
+
+        entry = history.add("late-arriving dictation", duration=1.0)
+        window._on_new_entry(entry)
+
+        # No new cards should be added while the window is hidden.
+        after = [
+            window._list_layout.itemAt(i).widget()
+            for i in range(window._list_layout.count())
+        ]
+        assert before == after, (
+            "_on_new_entry must be a no-op while the window is hidden; "
+            "widget manipulation during hidden state caused a Qt6Core.dll "
+            "fast-fail on Windows."
+        )
+
+        # Later, when the user opens the window, the new entry must appear.
+        # Exercise the same code path showEvent runs (reload + rebuild) without
+        # actually showing a window — avoids platform-specific headless issues.
+        history.reload_from_disk()
+        window._reload()
+        rendered_texts = []
+        for i in range(window._list_layout.count()):
+            item = window._list_layout.itemAt(i)
+            widget = item.widget() if item else None
+            e = getattr(widget, "_entry", None)
+            if e is not None:
+                rendered_texts.append(e["text"])
+        assert "late-arriving dictation" in rendered_texts
+
     def test_show_event_is_safely_re_callable(self, qapp, tmp_path):
         """showEvent must be callable repeatedly without orphaning widgets.
 


### PR DESCRIPTION
## Summary

- In the installed (bundled) build, Jarvis crashed immediately after a successful dictation paste with a Windows fast-fail (exception `0xc0000409`) inside `Qt6Core.dll+0x1cf68`. The dev launch script never reproduced it.
- Root cause: in bundled mode the daemon runs as a QThread **in-process**, so the engine's `on_dictation_result` callback delivers a queued Qt signal to `DictationHistoryWindow._on_new_entry` on the main thread — even when the user has never opened the history window. Manipulating that never-shown widget tree tripped an internal Qt assertion, matching the `setParent`-related signature already documented in `dictation_history.py`. In dev mode the daemon is a subprocess, so the callback never crosses into the desktop app's Qt tree, which is why it only surfaced from the installer.
- Fix: make `_on_new_entry` a no-op while the window is hidden. The entry is already persisted to the shared `DictationHistory`, and `showEvent()` reloads from disk on the next open, so the dictation still appears the first time the user looks.

## Evidence

- Windows Event Viewer: `Application Error` 1000, `Qt6Core.dll` 6.11.0.0, exception `0xc0000409`, offset `0x1cf68` (two crashes, PIDs 72744 and 84812).
- Minidumps: exception param `0x7` = `FAST_FAIL_FATAL_APP_EXIT` (`abort()` from a Qt assertion). Faulting thread stack mixed `Qt6Core` QObject/event-dispatch frames with `Qt6Widgets`/`Qt6Gui` native-window frames, consistent with a slot running on the main thread during queued signal delivery.

## Test plan

- [x] New regression test `test_on_new_entry_is_safe_when_window_hidden` fails on `develop` and passes with the fix.
- [x] Full `tests/test_dictation_history.py` suite passes (28/28) with `QT_QPA_PLATFORM=offscreen`.
- [ ] Install the resulting build and confirm a dictation completes without crashing; open the history window afterwards and confirm the new entry is listed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)