### PR TITLE
ci: cache pip downloads across test and build jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,6 +78,8 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: '3.11'
+          cache: pip
+          cache-dependency-path: requirements.txt
 
       - name: 📝 Generate version file
         id: version
@@ -158,6 +160,8 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: '3.11'
+          cache: pip
+          cache-dependency-path: requirements.txt
 
       - name: 📝 Generate version file
         run: |
@@ -236,6 +240,8 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: '3.11'
+          cache: pip
+          cache-dependency-path: requirements.txt
 
       - name: 📦 Install system dependencies
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,6 +14,8 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: '3.11'
+          cache: pip
+          cache-dependency-path: requirements.txt
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y portaudio19-dev libegl1 libxkbcommon0
       - name: Install deps


### PR DESCRIPTION
## Summary
- Enable `actions/setup-python` built-in pip caching (keyed on `requirements.txt`) for the unit-test job and all three release build jobs (Windows, macOS, Linux).
- Avoids re-downloading the full dependency set on every CI run.

## Test plan
- [x] First run on this PR populates the cache (expected behaviour).
- [ ] Second push to this branch reuses the cache — check "Set up Python" step logs for "Cache restored successfully".

🤖 Generated with [Claude Code](https://claude.com/claude-code)