### PR TITLE
fix: relaunch Jarvis after silent Windows auto-update

### DIFF
--- a/src/desktop_app/updater.py
+++ b/src/desktop_app/updater.py
@@ -399,9 +399,11 @@ def install_update_windows(download_path: Path) -> bool:
 
     temp_dir = Path(tempfile.mkdtemp())
     current_pid = os.getpid()
+    installed_exe_path = get_app_path()
 
     try:
         escaped_temp = _escape_batch_path(temp_dir)
+        escaped_installed_exe = _escape_batch_path(installed_exe_path)
 
         with zipfile.ZipFile(download_path, "r") as zf:
             zf.extractall(temp_dir)
@@ -418,6 +420,8 @@ def install_update_windows(download_path: Path) -> bool:
         # This is more reliable than a fixed timeout since the app may take time
         # to shut down (e.g., saving diary entries).
         # tasklist returns errorlevel 0 if process found, 1 if not found.
+        # After the silent installer finishes the installer's own [Run] launch
+        # step is skipped (skipifsilent), so we relaunch the upgraded exe here.
         batch_content = f'''@echo off
 echo Updating Jarvis...
 echo Waiting for process {current_pid} to exit...
@@ -429,6 +433,8 @@ if not errorlevel 1 (
 )
 echo Process exited, running installer...
 "{escaped_new_exe}" /VERYSILENT /SUPPRESSMSGBOXES /NORESTART
+echo Launching updated Jarvis...
+start "" "{escaped_installed_exe}"
 rmdir /s /q "{escaped_temp}"
 '''
         batch_script.write_text(batch_content)

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -471,6 +471,57 @@ class TestInstallUpdateWindows:
             assert "/SUPPRESSMSGBOXES" in batch_content
             assert "move /y" not in batch_content
 
+    @pytest.mark.unit
+    def test_batch_script_launches_updated_exe(self, tmp_path):
+        """After silent install, the batch script must relaunch the upgraded exe.
+
+        Inno Setup's postinstall launch is skipped under /VERYSILENT, so the
+        updater itself has to start the new version — otherwise the user is
+        left with a stopped app after a successful update.
+        """
+        import subprocess
+        import zipfile
+        from unittest.mock import patch, MagicMock
+
+        zip_path = tmp_path / "update.zip"
+        with zipfile.ZipFile(zip_path, "w") as zf:
+            zf.writestr("Jarvis.exe", b"mock executable content")
+
+        mock_app_path = tmp_path / "Program Files" / "Jarvis" / "Jarvis.exe"
+        mock_app_path.parent.mkdir(parents=True)
+        mock_app_path.write_bytes(b"old executable")
+
+        from desktop_app.updater import install_update_windows
+
+        batch_content_captured = []
+
+        def capture_popen(args, **kwargs):
+            if args[0] == "cmd" and args[1] == "/c":
+                batch_path = Path(args[2])
+                if batch_path.exists():
+                    batch_content_captured.append(batch_path.read_text())
+            return MagicMock()
+
+        with patch("desktop_app.updater.get_app_path", return_value=mock_app_path):
+            if not hasattr(subprocess, 'CREATE_NO_WINDOW'):
+                with patch.object(subprocess, 'CREATE_NO_WINDOW', 0x08000000, create=True):
+                    with patch("desktop_app.updater.subprocess.Popen", side_effect=capture_popen):
+                        install_update_windows(zip_path)
+            else:
+                with patch("desktop_app.updater.subprocess.Popen", side_effect=capture_popen):
+                    install_update_windows(zip_path)
+
+        assert len(batch_content_captured) == 1
+        batch_content = batch_content_captured[0]
+
+        # The launch must come after the installer line so the new binary is
+        # in place when it runs.
+        installer_idx = batch_content.find("/VERYSILENT")
+        launch_idx = batch_content.find(f'start "" "{mock_app_path}"')
+        assert installer_idx != -1, "installer line missing"
+        assert launch_idx != -1, "start line for upgraded exe missing"
+        assert launch_idx > installer_idx, "launch must follow install"
+
 
 class TestInstallUpdateLinux:
     """Tests for Linux update installation."""


### PR DESCRIPTION
## Summary

- Windows auto-update ran the Inno Setup installer with `/VERYSILENT`, which makes the installer's postinstall launch step (`Flags: nowait postinstall skipifsilent` in [jarvis_setup.iss](installer/windows/jarvis_setup.iss)) skip launching the app. Nothing else was starting the upgraded exe, so users were left staring at a stopped app after a successful update.
- The update batch script now appends `start "" "<installed exe>"` after the installer call, using the running `sys.executable` path (upgrade is in-place via the stable AppId, so the path doesn't change).
- Added a unit test asserting the launch line is present and ordered after the installer line.

## Test plan

- [x] `pytest tests/test_updater.py` — 33 passed, 2 skipped
- [ ] Manual: trigger an update on Windows and confirm the new version launches automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)