### PR TITLE
fix: base diary-import prompt on graph knowledge, not node count

### DIFF
--- a/src/desktop_app/memory_viewer.py
+++ b/src/desktop_app/memory_viewer.py
@@ -465,6 +465,7 @@ def graph_stats() -> Response:
     try:
         return jsonify({
             "total_nodes": store.get_node_count(),
+            "total_tokens": store.get_total_tokens(),
         })
     except Exception as e:
         return jsonify({"error": str(e)}), 500
@@ -2149,7 +2150,7 @@ def index() -> str:
 
         async function loadStats() {
             let totalMemories = 0;
-            let totalNodes = 0;
+            let totalTokens = 0;
 
             try {
                 const stats = await fetchStats();
@@ -2161,13 +2162,13 @@ def index() -> str:
             // Load graph stats separately
             try {
                 const graphStats = await (await fetch('/api/graph/stats')).json();
-                totalNodes = graphStats.total_nodes || 0;
-                document.getElementById('stats-nodes').textContent = totalNodes;
+                totalTokens = graphStats.total_tokens || 0;
+                document.getElementById('stats-nodes').textContent = graphStats.total_nodes || 0;
             } catch (e) {}
 
             // First-time migration: offer to import diary entries if the graph
-            // is empty (only root node) but the user has diary data
-            if (totalNodes <= 1 && totalMemories > 0 && !diaryImportDone) {
+            // holds no knowledge yet but the user has diary data.
+            if (totalTokens === 0 && totalMemories > 0 && !diaryImportDone) {
                 showImportDiaryModal(true);
             }
         }
@@ -2876,15 +2877,17 @@ def index() -> str:
                         <div id="import-log" style="margin-top: 12px; max-height: 200px; overflow-y: auto; font-size: 0.8em; font-family: 'JetBrains Mono', monospace; color: var(--text-muted); line-height: 1.6;"></div>
                     </div>
                     <div class="modal-actions" id="import-actions">
-                        <button class="modal-btn secondary" onclick="this.closest('.modal-overlay').remove()">${cancelLabel}</button>
+                        <button class="modal-btn secondary" id="btn-cancel-import">${cancelLabel}</button>
                         <button class="modal-btn primary" id="btn-start-import">Start Import</button>
                     </div>
                 </div>
             `;
             document.body.appendChild(overlay);
 
+            const dismiss = () => overlay.remove();
+            document.getElementById('btn-cancel-import').addEventListener('click', dismiss);
             overlay.addEventListener('click', (e) => {
-                if (e.target === overlay && !overlay.dataset.importing) overlay.remove();
+                if (e.target === overlay && !overlay.dataset.importing) dismiss();
             });
 
             document.getElementById('btn-start-import').addEventListener('click', async () => {

--- a/src/jarvis/memory/graph.py
+++ b/src/jarvis/memory/graph.py
@@ -422,6 +422,14 @@ class GraphMemoryStore:
             row = self.conn.execute("SELECT COUNT(*) as cnt FROM memory_nodes").fetchone()
             return row["cnt"]
 
+    def get_total_tokens(self) -> int:
+        """Return total data tokens across all nodes. Zero means no knowledge stored."""
+        with self._lock:
+            row = self.conn.execute(
+                "SELECT COALESCE(SUM(data_token_count), 0) as total FROM memory_nodes"
+            ).fetchone()
+            return int(row["total"])
+
     # ── Search ─────────────────────────────────────────────────────────
 
     def search_nodes(self, query: str, limit: int = 10) -> list[MemoryNode]:

--- a/src/jarvis/memory/graph.spec.md
+++ b/src/jarvis/memory/graph.spec.md
@@ -183,7 +183,7 @@ The graph explorer appears as the **Knowledge** tab in the memory viewer, positi
 | DELETE | `/api/graph/node/<id>` | Delete node (not root) |
 | GET | `/api/graph/recent` | Recently accessed nodes |
 | GET | `/api/graph/top` | Most frequently accessed nodes |
-| GET | `/api/graph/stats` | Node count |
+| GET | `/api/graph/stats` | Node count and total data tokens (`total_tokens = 0` means the graph holds no knowledge) |
 | POST | `/api/graph/import-diary` | Import all diary summaries into graph (streaming NDJSON) |
 
 ### Import from Diary

--- a/tests/test_diary_import.py
+++ b/tests/test_diary_import.py
@@ -256,3 +256,9 @@ class TestImportDialogueDismissal:
 
         # The loadStats check must include the guard
         assert "&& !diaryImportDone" in html
+
+        # The gate must be based on stored knowledge (total_tokens), not node count.
+        # Guards against a regression to the old `totalNodes <= 1` condition that kept
+        # re-prompting after a successful import filled the root node.
+        assert "totalTokens === 0" in html
+        assert "totalNodes <= 1" not in html

--- a/tests/test_graph_memory.py
+++ b/tests/test_graph_memory.py
@@ -84,6 +84,24 @@ class TestGraphMemoryStoreBootstrap:
     def test_node_count_starts_at_one(self, store):
         assert store.get_node_count() == 1  # root only
 
+    def test_total_tokens_zero_for_empty_graph(self, store):
+        assert store.get_total_tokens() == 0
+
+    def test_total_tokens_reflects_stored_data(self, store):
+        store.create_node(
+            name="Facts",
+            description="Things I know",
+            data="The sky is blue. Water boils at 100C.",
+            parent_id="root",
+        )
+        assert store.get_total_tokens() > 0
+
+    def test_total_tokens_stays_zero_when_root_only_and_empty(self, store):
+        # Even after touching/updating the root without data, tokens remain zero.
+        root = store.get_root()
+        store.update_node(root.id, description="updated description")
+        assert store.get_total_tokens() == 0
+
 
 @pytest.mark.unit
 class TestNodeCRUD:


### PR DESCRIPTION
## Summary

- The memory viewer auto-opened the **Import from Diary** modal whenever the graph had one node and any diary entries existed. After a successful import the root holds all imported knowledge but stays the sole node, so the prompt reappeared on every viewer open.
- Gate the prompt on `total_tokens === 0` instead of node count. `/api/graph/stats` now returns the total data-token count across all nodes, so the modal shows only when the graph truly has no stored knowledge.
- Added unit tests for the new `GraphMemoryStore.get_total_tokens()` helper.

## Test plan

- [x] `pytest tests/test_graph_memory.py` — passes (48 tests).
- [x] Manually open the memory viewer with an imported graph (root node only, non-zero tokens) and confirm the import dialogue does not appear.
- [x] Manually open the memory viewer with an empty graph and existing diary entries and confirm the import dialogue does appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)