### PR TITLE
fix(listening): clear stale wake timestamp between utterances

### DIFF
--- a/src/jarvis/listening/listener.py
+++ b/src/jarvis/listening/listener.py
@@ -415,6 +415,13 @@ class VoiceListener(threading.Thread):
 
         text_lower = text.strip().lower()
 
+        # Reset wake timestamp — it must reflect only the current utterance.
+        # If this utterance contains a wake word, the early-beep check below
+        # will set it. Without this reset, a prior rejected wake-worded
+        # utterance would vouch for subsequent unrelated utterances via the
+        # `_wake_timestamp is not None` guard in the intent-judge accept path.
+        self._wake_timestamp = None
+
         start_time_str = datetime.fromtimestamp(utterance_start_time).strftime('%H:%M:%S.%f')[:-3] if utterance_start_time > 0 else "N/A"
         end_time_str = datetime.fromtimestamp(utterance_end_time).strftime('%H:%M:%S.%f')[:-3] if utterance_end_time > 0 else "N/A"
         debug_log(f"heard: '{text}' (utterance from {start_time_str} to {end_time_str})", "voice")

--- a/tests/test_hot_window_input.py
+++ b/tests/test_hot_window_input.py
@@ -1232,3 +1232,62 @@ class TestSpeechIgnoredOutsideHotWindow:
 
         assert _accepted_query(listener) == ""
         listener.state_manager.stop()
+
+
+# ---------------------------------------------------------------------------
+# Tests: Stale wake timestamp must not leak across utterances
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestStaleWakeTimestampAcrossUtterances:
+    """After the intent judge rejects a wake-worded utterance, the next
+    utterance without a wake word must not be accepted just because the
+    previous utterance had one.
+
+    Real-world bug: user said "Jarvis, remember..." (rejected by judge),
+    then said "Hey Google, TV off." The judge saw the previous "Jarvis"
+    in its buffer and returned directed=true with query="tv off". The
+    verification guard `_wake_timestamp is not None` short-circuited true
+    because it was never cleared, so the unrelated "Hey Google" command
+    was accepted.
+    """
+
+    @patch("builtins.print")
+    def test_rejected_wake_utterance_does_not_vouch_for_next_utterance(self, _print):
+        """A prior rejected wake-worded utterance must not authorise a later
+        utterance that lacks a wake word."""
+        listener, _ = _create_listener(echo_tolerance=0.3, hot_window_seconds=3.0)
+
+        # First utterance: has "jarvis", judge rejects as not directed
+        _install_intent_judge(listener, _make_judgment(
+            directed=False, query="", confidence="high",
+            reasoning="statement to self, not directed"))
+
+        now = time.time()
+        listener._process_transcript(
+            "jarvis i want you to remember that my other office days are thursdays",
+            utterance_energy=0.01,
+            utterance_start_time=now,
+            utterance_end_time=now + 2.0,
+        )
+        assert _accepted_query(listener) == ""
+
+        # Second utterance: no wake word, judge hallucinates directed=true
+        # (e.g. because the earlier "jarvis" is still in its context buffer)
+        _install_intent_judge(listener, _make_judgment(
+            directed=True, query="tv off", confidence="high",
+            reasoning="synthesised from buffer"))
+
+        listener._process_transcript(
+            "hey google, tv off.",
+            utterance_energy=0.01,
+            utterance_start_time=now + 5.0,
+            utterance_end_time=now + 6.0,
+        )
+
+        # Must be rejected — no wake word in this utterance, no hot window
+        assert _accepted_query(listener) == "", (
+            "Second utterance without wake word must not be accepted just "
+            "because a prior utterance set _wake_timestamp")
+        listener.state_manager.stop()


### PR DESCRIPTION
## Summary

- Reset `_wake_timestamp` at the start of `_process_transcript` so it reflects only the current utterance.
- Previously, the field was cleared only inside `_clear_audio_buffers` (called on acceptance). After an intent-judge rejection, a prior utterance's wake detection would persist and vouch for the next, unrelated utterance.

## The bug

User said "Jarvis, I want you to remember…" — judge rejected as not directed, but `_wake_timestamp` stayed set. Next the user said "Hey Google, TV off." The judge's transcript buffer still contained the earlier "Jarvis", so it returned `directed=true` with query `"tv off"`. The verification guard

```python
has_wake_word = self._wake_timestamp is not None or is_wake_word_detected(text_lower, ...)
```

short-circuited true on the stale timestamp, so the "Hey Google" command was accepted as a Jarvis request.

## Fix

One-line reset at the top of `_process_transcript`. If the current utterance contains a wake word, the early-beep path still sets the timestamp as before. If it doesn't, the guard correctly falls through to `is_wake_word_detected(text_lower, ...)` on the current text.

## Test

Added `TestStaleWakeTimestampAcrossUtterances` in `tests/test_hot_window_input.py` replaying the exact two-utterance scenario. Fails on develop, passes with the fix.

## Test plan

- [x] New regression test passes
- [x] Full `test_hot_window_input.py` + `test_query_validation.py` suites green (72 tests)
- [x] Wider listening-related suites green (pre-existing unrelated CUDA-detection failures confirmed on develop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)