### PR TITLE
fix(setup_wizard): update quick tips to reflect transcript-first wake detection

### DIFF
--- a/src/desktop_app/setup_wizard.py
+++ b/src/desktop_app/setup_wizard.py
@@ -2837,7 +2837,8 @@ class CompletePage(QWizardPage):
         card_layout.addSpacing(8)
 
         tips = QLabel(
-            "• Say 'Jarvis' followed by your question to activate the assistant\n"
+            "• Say your wake word (e.g. 'Jarvis') anywhere in your sentence to activate the assistant\n"
+            "• After Jarvis replies, speak your follow-up — no need to repeat the wake word\n"
             "• Jarvis will appear in your system tray (menu bar on macOS)\n"
             "• Right-click the tray icon to access settings and controls\n"
             "• View logs by clicking '📝 View Logs' in the tray menu"


### PR DESCRIPTION
## Summary

- Corrects the wake-word tip: the transcript-first architecture allows the wake word to appear **anywhere** in an utterance, not only before the question. The old wording ("Say 'Jarvis' followed by your question") implied a strict ordering that the system doesn't enforce.
- Adds a missing tip about **hot window follow-up mode**: after Jarvis replies, the user can speak a follow-up without repeating the wake word.
- Rewords the wake word reference to "your wake word (e.g. 'Jarvis')" to acknowledge that the wake word is configurable.

## Test plan

- [ ] Run the setup wizard and verify the Complete page shows the updated tips
- [ ] Confirm the existing test suite passes: `pytest tests/test_setup_wizard.py`