### PR TITLE
fix: surface specific intent judge failure reasons (#195)

### DIFF
--- a/src/jarvis/listening/intent_judge.py
+++ b/src/jarvis/listening/intent_judge.py
@@ -321,6 +321,10 @@ Examples:
         if not segments:
             return None
 
+        # Clear any stale reason from a prior call so callers never surface
+        # an error message that does not belong to this invocation.
+        self._last_error_reason = None
+
         try:
             system_prompt = self._build_system_prompt()
             user_prompt = self._build_user_prompt(

--- a/src/jarvis/listening/intent_judge.py
+++ b/src/jarvis/listening/intent_judge.py
@@ -160,9 +160,20 @@ Examples:
         self._available = REQUESTS_AVAILABLE
         self._last_error_time: float = 0.0
         self._error_cooldown: float = 30.0
+        self._last_error_reason: Optional[str] = None
 
         if not self._available:
             debug_log("intent judge disabled: requests not available", "voice")
+
+    @property
+    def last_error_reason(self) -> Optional[str]:
+        """Human-readable reason for the most recent failure, or None.
+
+        Cleared when a judgment succeeds. Surfaced to the user so they can
+        distinguish a slow local LLM (timeout) from Ollama being offline
+        (unreachable) from a malformed response (parse failure).
+        """
+        return self._last_error_reason
 
     @property
     def available(self) -> bool:
@@ -344,7 +355,9 @@ Examples:
             )
 
             if response.status_code != 200:
-                debug_log(f"intent judge: Ollama error {response.status_code}", "voice")
+                reason = f"Ollama HTTP {response.status_code}"
+                debug_log(f"intent judge: {reason}", "voice")
+                self._last_error_reason = reason
                 self._last_error_time = time.time()
                 return None
 
@@ -362,20 +375,42 @@ Examples:
                     "voice"
                 )
                 debug_log(f"   Reasoning: {judgment.reasoning}", "voice")
+                self._last_error_reason = None
             else:
-                debug_log(f"🧠 Intent judge: failed to parse: {response_text[:100]}", "voice")
+                reason = "parse failure (LLM returned non-JSON)"
+                debug_log(f"🧠 Intent judge: {reason}: {response_text[:100]}", "voice")
+                self._last_error_reason = reason
 
             return judgment
 
         except requests.Timeout:
-            debug_log(f"intent judge: timeout after {self.config.timeout_sec}s", "voice")
+            reason = f"timeout after {self.config.timeout_sec}s (model too slow — try a smaller model)"
+            debug_log(f"intent judge: {reason}", "voice")
+            self._last_error_reason = reason
+            return None
+        except requests.ConnectionError as e:
+            # Normalise base URL into host:port for the user-facing reason.
+            host_port = self.config.ollama_base_url
+            for prefix in ("https://", "http://"):
+                if host_port.startswith(prefix):
+                    host_port = host_port[len(prefix):]
+                    break
+            host_port = host_port.rstrip("/")
+            reason = f"Ollama unreachable at {host_port}"
+            debug_log(f"intent judge: {reason}: {e}", "voice")
+            self._last_error_reason = reason
+            self._last_error_time = time.time()
             return None
         except requests.RequestException as e:
-            debug_log(f"intent judge: request error: {e}", "voice")
+            reason = f"request error: {e}"
+            debug_log(f"intent judge: {reason}", "voice")
+            self._last_error_reason = reason
             self._last_error_time = time.time()
             return None
         except Exception as e:
-            debug_log(f"intent judge: error: {e}", "voice")
+            reason = f"unexpected error: {e}"
+            debug_log(f"intent judge: {reason}", "voice")
+            self._last_error_reason = reason
             return None
 
 

--- a/src/jarvis/listening/listener.py
+++ b/src/jarvis/listening/listener.py
@@ -583,8 +583,9 @@ class VoiceListener(threading.Thread):
                 else:
                     print(f"  🧠 Intent ({mode_str}): not directed ({intent_judgment.reasoning})", flush=True)
             else:
-                print(f"  🧠 Intent judge: unavailable (timeout or error)", flush=True)
-                debug_log("intent judge returned None — falling back", "voice")
+                reason = self._intent_judge.last_error_reason or "unavailable (timeout or error)"
+                print(f"  🧠 Intent judge: {reason}", flush=True)
+                debug_log(f"intent judge returned None — falling back ({reason})", "voice")
                 # Hot window fallback: if the early echo check already cleared
                 # this text, accept it even without the judge's verdict.
                 if could_be_hot_window:

--- a/src/jarvis/listening/listening.spec.md
+++ b/src/jarvis/listening/listening.spec.md
@@ -313,7 +313,7 @@ When components are unavailable, the system degrades gracefully:
 
 | Component | Unavailable Behaviour |
 |-----------|---------------------|
-| Intent Judge | Simple text-based wake word + query extraction; hot window override still applies |
+| Intent Judge | Simple text-based wake word + query extraction; hot window override still applies. The specific failure reason (timeout, Ollama unreachable, HTTP status, parse failure) is surfaced to the user so it is actionable rather than a generic "unavailable" message. |
 | 16 kHz sample rate | Stream at device native rate, resample to 16 kHz for Whisper |
 | Transcript Buffer | Process each utterance independently |
 

--- a/tests/test_intent_judge.py
+++ b/tests/test_intent_judge.py
@@ -331,20 +331,28 @@ class TestIntentJudgeErrorReason:
         assert "parse" in judge.last_error_reason.lower()
 
     def test_successful_judgment_clears_reason(self):
-        """A successful judgment clears any prior error reason."""
+        """A successful judgment clears any prior error reason.
+
+        Drives the full behaviour: a failing call records a reason, then a
+        subsequent successful call must clear it. Avoids poking private state.
+        """
+        import requests as real_requests
         judge = IntentJudge()
         judge._available = True
-        judge._last_error_reason = "timeout after 10.0s"
-
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = {
-            "response": '{"directed": true, "query": "hi", "stop": false, "confidence": "high", "reasoning": "ok"}'
-        }
 
         segments = [TranscriptSegment("jarvis hi", 1000.0, 1001.0)]
 
-        with patch('jarvis.listening.intent_judge.requests.post', return_value=mock_response):
+        with patch('jarvis.listening.intent_judge.requests.post', side_effect=real_requests.Timeout()):
+            judge.judge(segments, wake_timestamp=1000.5)
+        assert judge.last_error_reason is not None
+
+        success_response = MagicMock()
+        success_response.status_code = 200
+        success_response.json.return_value = {
+            "response": '{"directed": true, "query": "hi", "stop": false, "confidence": "high", "reasoning": "ok"}'
+        }
+
+        with patch('jarvis.listening.intent_judge.requests.post', return_value=success_response):
             result = judge.judge(segments, wake_timestamp=1000.5)
 
         assert result is not None

--- a/tests/test_intent_judge.py
+++ b/tests/test_intent_judge.py
@@ -250,6 +250,107 @@ class TestIntentJudge:
         assert result is None
 
 
+class TestIntentJudgeErrorReason:
+    """Tests that specific failure reasons are surfaced for user diagnostics."""
+
+    def test_last_error_reason_defaults_to_none(self):
+        """last_error_reason starts as None."""
+        judge = IntentJudge()
+        assert judge.last_error_reason is None
+
+    def test_timeout_records_reason(self):
+        """Timeout populates last_error_reason with the configured timeout value."""
+        import requests as real_requests
+        config = IntentJudgeConfig(timeout_sec=7.5)
+        judge = IntentJudge(config)
+        judge._available = True
+
+        segments = [TranscriptSegment("test", 1000.0, 1001.0)]
+
+        with patch('jarvis.listening.intent_judge.requests.post', side_effect=real_requests.Timeout()):
+            result = judge.judge(segments)
+
+        assert result is None
+        assert judge.last_error_reason is not None
+        assert "timeout" in judge.last_error_reason.lower()
+        assert "7.5" in judge.last_error_reason
+
+    def test_connection_error_records_reason(self):
+        """Connection refused populates last_error_reason as unreachable."""
+        import requests as real_requests
+        config = IntentJudgeConfig(ollama_base_url="http://127.0.0.1:11434")
+        judge = IntentJudge(config)
+        judge._available = True
+
+        segments = [TranscriptSegment("test", 1000.0, 1001.0)]
+
+        with patch(
+            'jarvis.listening.intent_judge.requests.post',
+            side_effect=real_requests.ConnectionError("refused"),
+        ):
+            result = judge.judge(segments)
+
+        assert result is None
+        assert judge.last_error_reason is not None
+        assert "unreachable" in judge.last_error_reason.lower()
+        assert "127.0.0.1:11434" in judge.last_error_reason
+
+    def test_http_error_records_reason(self):
+        """Non-200 response populates last_error_reason with the status code."""
+        judge = IntentJudge()
+        judge._available = True
+
+        mock_response = MagicMock()
+        mock_response.status_code = 503
+
+        segments = [TranscriptSegment("test", 1000.0, 1001.0)]
+
+        with patch('jarvis.listening.intent_judge.requests.post', return_value=mock_response):
+            result = judge.judge(segments)
+
+        assert result is None
+        assert judge.last_error_reason is not None
+        assert "503" in judge.last_error_reason
+
+    def test_parse_failure_records_reason(self):
+        """A malformed (non-JSON) LLM response populates last_error_reason."""
+        judge = IntentJudge()
+        judge._available = True
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"response": "I am not JSON at all"}
+
+        segments = [TranscriptSegment("test", 1000.0, 1001.0)]
+
+        with patch('jarvis.listening.intent_judge.requests.post', return_value=mock_response):
+            result = judge.judge(segments)
+
+        assert result is None
+        assert judge.last_error_reason is not None
+        assert "parse" in judge.last_error_reason.lower()
+
+    def test_successful_judgment_clears_reason(self):
+        """A successful judgment clears any prior error reason."""
+        judge = IntentJudge()
+        judge._available = True
+        judge._last_error_reason = "timeout after 10.0s"
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "response": '{"directed": true, "query": "hi", "stop": false, "confidence": "high", "reasoning": "ok"}'
+        }
+
+        segments = [TranscriptSegment("jarvis hi", 1000.0, 1001.0)]
+
+        with patch('jarvis.listening.intent_judge.requests.post', return_value=mock_response):
+            result = judge.judge(segments, wake_timestamp=1000.5)
+
+        assert result is not None
+        assert judge.last_error_reason is None
+
+
 class TestCreateIntentJudge:
     """Tests for create_intent_judge factory function."""
 


### PR DESCRIPTION
## Summary

- The user-facing log `🧠 Intent judge: unavailable (timeout or error)` collapsed four distinct failure modes into one uninformative line, leaving users with no way to diagnose why Jarvis stopped responding (per #195).
- `IntentJudge` now records a human-readable `last_error_reason` on every failure path — timeout, Ollama unreachable, HTTP status, parse failure, unexpected exception — and the listener surfaces that reason verbatim instead of the generic message.
- Users can now tell at a glance whether to pick a smaller model (timeout), start Ollama (unreachable), or investigate a misbehaving model (parse failure).

## Changes

- `src/jarvis/listening/intent_judge.py`: added `last_error_reason` property; every error branch (`requests.Timeout`, `requests.ConnectionError`, other `RequestException`, non-200 status, non-JSON response, unexpected exception) sets a specific reason; successful judgments clear it.
- `src/jarvis/listening/listener.py`: reads `last_error_reason` and prints it instead of the generic "unavailable (timeout or error)" line.
- `src/jarvis/listening/listening.spec.md`: updated the Fallback Behaviour row for Intent Judge to reflect that the specific reason is now surfaced.
- `tests/test_intent_judge.py`: 6 new tests covering each failure branch and the success-clears-reason invariant.

No prompt changes, so no evals to rerun.

## Test plan

- [x] `pytest tests/test_intent_judge.py` — 43 tests pass (6 new).
- [x] `pytest tests/test_listening_ux_overhaul.py tests/test_echo_detection.py tests/test_hot_window_input.py` — 147 tests pass (no regressions in related suites).

Closes #195

🤖 Generated with [Claude Code](https://claude.com/claude-code)