### PR TITLE
fix(listening): stop intent judge from freezing the audio loop on ambient speech

### DIFF
--- a/src/jarvis/listening/intent_judge.py
+++ b/src/jarvis/listening/intent_judge.py
@@ -327,7 +327,11 @@ Examples:
             transcript_preview = "; ".join(s.text[:30] for s in segments[-3:])
             debug_log(f"🧠 Intent judge [{mode}]: \"{transcript_preview}...\"", "voice")
 
-            # Call Ollama API
+            # Call Ollama API. keep_alive keeps the model resident between
+            # calls so we don't pay the ~5s cold-reload on each engagement
+            # (which was the original timeout culprit). Ollama's default is
+            # 5m; we pin to 30m because voice sessions can have long quiet
+            # stretches and reloading mid-conversation is a bad experience.
             response = requests.post(
                 f"{self.config.ollama_base_url}/api/generate",
                 json={
@@ -336,6 +340,7 @@ Examples:
                     "system": system_prompt,
                     "stream": False,
                     "think": self.config.thinking,
+                    "keep_alive": "30m",
                     "options": {
                         "temperature": 0.0,
                         "num_predict": 200,
@@ -345,10 +350,12 @@ Examples:
             )
 
             if response.status_code != 200:
+                # Don't back off on transient HTTP errors — voice is high-turn
+                # and a 503 from an overloaded Ollama shouldn't kill the next
+                # 30s of intent judging. Retry on the next engagement signal.
                 reason = f"HTTP {response.status_code} from Ollama"
                 debug_log(f"intent judge: {reason}", "voice")
                 self._last_failure_reason = reason
-                self._last_error_time = time.time()
                 return None
 
             result = response.json()
@@ -373,11 +380,12 @@ Examples:
             return judgment
 
         except requests.Timeout:
-            # Timeouts must trigger the backoff cooldown so a slow/overloaded
-            # Ollama doesn't get hammered on every subsequent utterance.
+            # Do NOT back off on timeout. Voice is high-turn: a single slow
+            # call must not lock out intent judging for the next 30s. The
+            # engagement-signal gate upstream already prevents calling the
+            # judge on ambient speech, so timeouts don't hammer Ollama.
             self._last_failure_reason = f"timeout after {self.config.timeout_sec}s"
             debug_log(f"intent judge: {self._last_failure_reason}", "voice")
-            self._last_error_time = time.time()
             return None
         except requests.RequestException as e:
             self._last_failure_reason = f"request error: {e}"

--- a/src/jarvis/listening/intent_judge.py
+++ b/src/jarvis/listening/intent_judge.py
@@ -23,6 +23,41 @@ except ImportError:
     REQUESTS_AVAILABLE = False
 
 
+def _extract_json_object(text: str) -> str:
+    """Return the first balanced `{...}` object in `text`, or "" if none.
+
+    Walks character-by-character tracking brace depth while respecting string
+    literals and escapes. Handles markdown code fences and values containing
+    braces — cases a simple regex cannot.
+    """
+    start = text.find("{")
+    if start == -1:
+        return ""
+
+    depth = 0
+    in_string = False
+    escape = False
+    for i in range(start, len(text)):
+        ch = text[i]
+        if in_string:
+            if escape:
+                escape = False
+            elif ch == "\\":
+                escape = True
+            elif ch == '"':
+                in_string = False
+            continue
+        if ch == '"':
+            in_string = True
+        elif ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return text[start:i + 1]
+    return ""
+
+
 @dataclass
 class IntentJudgment:
     """Result of intent judgment."""
@@ -43,7 +78,7 @@ class IntentJudgeConfig:
     aliases: list = None
     model: str = "gemma4:e2b"
     ollama_base_url: str = "http://127.0.0.1:11434"
-    timeout_sec: float = 10.0
+    timeout_sec: float = 15.0
     thinking: bool = False
 
     def __post_init__(self):
@@ -118,9 +153,15 @@ Examples:
         self._available = REQUESTS_AVAILABLE
         self._last_error_time: float = 0.0
         self._error_cooldown: float = 30.0
+        self._last_failure_reason: str = ""
 
         if not self._available:
             debug_log("intent judge disabled: requests not available", "voice")
+
+    @property
+    def last_failure_reason(self) -> str:
+        """Human-readable reason the most recent judge() call failed, if any."""
+        return self._last_failure_reason
 
     @property
     def available(self) -> bool:
@@ -219,14 +260,16 @@ Examples:
         Returns:
             IntentJudgment or None if parsing failed
         """
-        # Try to extract JSON from response
-        json_match = re.search(r'\{[^{}]*\}', response_text, re.DOTALL)
-        if not json_match:
+        # Locate the outermost JSON object by brace-matching. This handles
+        # markdown code fences and JSON whose string values contain braces
+        # — cases the old `\{[^{}]*\}` regex missed.
+        json_text = _extract_json_object(response_text)
+        if not json_text:
             debug_log(f"intent judge: no JSON found in response: {response_text[:100]}", "voice")
             return None
 
         try:
-            data = json.loads(json_match.group())
+            data = json.loads(json_text)
 
             return IntentJudgment(
                 directed=bool(data.get("directed", False)),
@@ -295,14 +338,16 @@ Examples:
                     "think": self.config.thinking,
                     "options": {
                         "temperature": 0.0,
-                        "num_predict": 800,
+                        "num_predict": 200,
                     },
                 },
                 timeout=self.config.timeout_sec,
             )
 
             if response.status_code != 200:
-                debug_log(f"intent judge: Ollama error {response.status_code}", "voice")
+                reason = f"HTTP {response.status_code} from Ollama"
+                debug_log(f"intent judge: {reason}", "voice")
+                self._last_failure_reason = reason
                 self._last_error_time = time.time()
                 return None
 
@@ -312,6 +357,7 @@ Examples:
             judgment = self._parse_response(response_text)
 
             if judgment:
+                self._last_failure_reason = ""
                 direction = "✅ DIRECTED" if judgment.directed else "❌ NOT DIRECTED"
                 stop_str = " [STOP]" if judgment.stop else ""
                 query_str = f" → \"{judgment.query}\"" if judgment.query else ""
@@ -321,19 +367,26 @@ Examples:
                 )
                 debug_log(f"   Reasoning: {judgment.reasoning}", "voice")
             else:
+                self._last_failure_reason = f"unparseable response: {response_text[:80]}"
                 debug_log(f"🧠 Intent judge: failed to parse: {response_text[:100]}", "voice")
 
             return judgment
 
         except requests.Timeout:
-            debug_log(f"intent judge: timeout after {self.config.timeout_sec}s", "voice")
+            # Timeouts must trigger the backoff cooldown so a slow/overloaded
+            # Ollama doesn't get hammered on every subsequent utterance.
+            self._last_failure_reason = f"timeout after {self.config.timeout_sec}s"
+            debug_log(f"intent judge: {self._last_failure_reason}", "voice")
+            self._last_error_time = time.time()
             return None
         except requests.RequestException as e:
-            debug_log(f"intent judge: request error: {e}", "voice")
+            self._last_failure_reason = f"request error: {e}"
+            debug_log(f"intent judge: {self._last_failure_reason}", "voice")
             self._last_error_time = time.time()
             return None
         except Exception as e:
-            debug_log(f"intent judge: error: {e}", "voice")
+            self._last_failure_reason = f"error: {e}"
+            debug_log(f"intent judge: {self._last_failure_reason}", "voice")
             return None
 
 

--- a/src/jarvis/listening/listener.py
+++ b/src/jarvis/listening/listener.py
@@ -544,27 +544,55 @@ class VoiceListener(threading.Thread):
         is_speaking_now = self.tts and self.tts.is_speaking()
         intent_judgment = None
 
+        # Determine if this could be a hot window follow-up.
+        # Only use formal hot window state — no time-based grace period.
+        # The state manager already handles the timing (echo_tolerance
+        # delay before activation, hot_window_seconds before expiry).
+        # A generous grace period caused false hot window claims after
+        # the user had already seen "Returning to wake word mode".
+        could_be_hot_window = self.state_manager.was_speech_during_hot_window(
+            utterance_start_time, utterance_end_time
+        )
+
         # Use the upgraded intent judge if available (with full transcript context)
         # Allow during TTS for longer utterances (>3 words) that might be user responses
         word_count = len(text_lower.split())
         skip_intent_judge_during_tts = is_speaking_now and word_count <= 3
-        if not skip_intent_judge_during_tts and self._intent_judge is not None and self._intent_judge.available:
+
+        # Gate the intent judge on an engagement signal. Without this check the
+        # judge was called on every ambient utterance, blocking the audio loop
+        # for up to `timeout_sec` on each background chatter — which could
+        # cascade into UI freezes when many utterances queued up during a slow
+        # or loaded Ollama. The judge adds value only when one of:
+        #   1. A wake word was detected in the current utterance
+        #   2. We are in (or pending) a hot window following TTS
+        #   3. TTS is currently speaking (intent judge can catch responses / stops
+        #      that the fast text-based stop command check missed)
+        has_engagement_signal = (
+            self._wake_timestamp is not None
+            or could_be_hot_window
+            or is_speaking_now
+        )
+
+        if not has_engagement_signal:
+            debug_log(
+                f"skipping intent judge — no wake word, no hot window, no TTS "
+                f"(ambient: \"{text_lower[:40]}{'...' if len(text_lower) > 40 else ''}\")",
+                "voice",
+            )
+
+        if (
+            not skip_intent_judge_during_tts
+            and has_engagement_signal
+            and self._intent_judge is not None
+            and self._intent_judge.available
+        ):
             # Get recent transcript segments for context (full buffer)
             context_segments = self._transcript_buffer.get_last_seconds(self._buffer_duration)
 
             # Get TTS context for echo detection
             last_tts_text = self.echo_detector._last_tts_text or ""
             last_tts_finish_time = self.echo_detector._last_tts_finish_time or 0.0
-
-            # Determine if this could be a hot window follow-up.
-            # Only use formal hot window state — no time-based grace period.
-            # The state manager already handles the timing (echo_tolerance
-            # delay before activation, hot_window_seconds before expiry).
-            # A generous grace period caused false hot window claims after
-            # the user had already seen "Returning to wake word mode".
-            could_be_hot_window = self.state_manager.was_speech_during_hot_window(
-                utterance_start_time, utterance_end_time
-            )
 
             intent_judgment = self._intent_judge.judge(
                 segments=context_segments,
@@ -583,8 +611,9 @@ class VoiceListener(threading.Thread):
                 else:
                     print(f"  🧠 Intent ({mode_str}): not directed ({intent_judgment.reasoning})", flush=True)
             else:
-                print(f"  🧠 Intent judge: unavailable (timeout or error)", flush=True)
-                debug_log("intent judge returned None — falling back", "voice")
+                reason = self._intent_judge.last_failure_reason or "no segments or unavailable"
+                print(f"  🧠 Intent judge: unavailable ({reason})", flush=True)
+                debug_log(f"intent judge returned None — falling back ({reason})", "voice")
                 # Hot window fallback: if the early echo check already cleared
                 # this text, accept it even without the judge's verdict.
                 if could_be_hot_window:

--- a/src/jarvis/listening/listening.spec.md
+++ b/src/jarvis/listening/listening.spec.md
@@ -83,6 +83,8 @@ The intent judge receives full context and makes intelligent decisions:
 - Sees pre-wake-word context → can understand "...what do YOU think, Jarvis?"
 - Extracts clean query → removes filler words, false starts
 
+**Gating:** The judge is called only when there is an engagement signal — (a) a wake word was detected in the current utterance, (b) the utterance falls inside (or pending) a hot window, or (c) TTS is currently speaking. Pure ambient speech skips the judge entirely. This keeps the synchronous audio loop from blocking up to `intent_judge_timeout_sec` on every background utterance, which would otherwise freeze the UI when Ollama is slow or contended.
+
 ## The Three Listening Modes
 
 ### 1. Wake Word Mode (Default)

--- a/tests/test_hot_window_input.py
+++ b/tests/test_hot_window_input.py
@@ -1291,3 +1291,67 @@ class TestStaleWakeTimestampAcrossUtterances:
             "Second utterance without wake word must not be accepted just "
             "because a prior utterance set _wake_timestamp")
         listener.state_manager.stop()
+
+
+@pytest.mark.unit
+class TestIntentJudgeGating:
+    """The intent judge must not be called on pure ambient speech.
+
+    Calling it on every utterance blocks the audio loop for up to
+    `intent_judge_timeout_sec` on each background chatter, which can
+    cascade into UI freezes when many utterances queue up during a slow
+    or loaded Ollama. The judge adds value only when there's an
+    engagement signal: wake word, hot window, or active TTS.
+    """
+
+    @patch("builtins.print")
+    def test_judge_not_called_for_ambient_speech(self, _print):
+        """Ambient speech with no wake word / hot window / TTS must not hit the judge."""
+        listener, _ = _create_listener()
+
+        mock_judge = _install_intent_judge(
+            listener, _make_judgment(directed=False, query=""))
+
+        # No hot window, no TTS, no wake word in the text
+        listener._process_transcript(
+            "random background chatter about the weather",
+            utterance_energy=0.01,
+        )
+
+        assert mock_judge.judge.call_count == 0, (
+            "Intent judge must be gated on an engagement signal; ambient "
+            "speech should skip the judge to avoid blocking the audio loop")
+        listener.state_manager.stop()
+
+    @patch("builtins.print")
+    def test_judge_called_when_wake_word_detected(self, _print):
+        """Utterances containing the wake word do reach the judge."""
+        listener, _ = _create_listener()
+
+        mock_judge = _install_intent_judge(
+            listener, _make_judgment(
+                directed=True, query="what time is it"))
+
+        listener._process_transcript(
+            "jarvis what time is it", utterance_energy=0.01,
+        )
+
+        assert mock_judge.judge.call_count == 1
+        listener.state_manager.stop()
+
+    @patch("builtins.print")
+    def test_judge_called_in_hot_window(self, _print):
+        """Utterances during the hot window do reach the judge."""
+        listener, _ = _create_listener(echo_tolerance=0.02, hot_window_seconds=3.0)
+
+        listener.echo_detector.track_tts_start("Here you go.")
+        _simulate_tts_finish(listener)
+        _wait_for_hot_window_active(listener)
+
+        mock_judge = _install_intent_judge(
+            listener, _make_judgment(directed=True, query="thanks"))
+
+        listener._process_transcript("thanks", utterance_energy=0.01)
+
+        assert mock_judge.judge.call_count == 1
+        listener.state_manager.stop()

--- a/tests/test_intent_judge.py
+++ b/tests/test_intent_judge.py
@@ -249,12 +249,14 @@ class TestIntentJudge:
 
         assert result is None
 
-    def test_timeout_sets_error_backoff(self):
-        """Timeouts should trigger the error cooldown so we don't hammer Ollama.
+    def test_timeout_does_not_trigger_backoff(self):
+        """Timeouts must NOT trigger the 30s cooldown.
 
-        Previously only RequestException set _last_error_time — timeouts would
-        retry on every utterance with no backoff, producing a flood of "Intent
-        judge: unavailable (timeout or error)" lines in the console.
+        Voice is a high-turn environment: a single slow call must not lock out
+        intent judging for the next half-minute of conversation. The upstream
+        engagement-signal gate (wake word / hot window / TTS) already prevents
+        hammering Ollama on ambient speech, so individual timeouts are safe to
+        retry immediately on the next real engagement.
         """
         import requests as real_requests
         judge = IntentJudge()
@@ -266,8 +268,51 @@ class TestIntentJudge:
         with patch('jarvis.listening.intent_judge.requests.post', side_effect=real_requests.Timeout()):
             judge.judge(segments)
 
-        assert judge._last_error_time > 0.0, "timeout must trigger backoff cooldown"
-        assert judge.available is False, "judge must be unavailable during cooldown"
+        assert judge._last_error_time == 0.0, "timeout must NOT lock out future calls"
+        assert judge.available is True, "judge must remain available after a single timeout"
+
+    def test_http_error_does_not_trigger_backoff(self):
+        """Transient HTTP errors (503 etc.) must NOT trigger the 30s cooldown.
+
+        Same reasoning as timeouts — we want to retry on the next engagement
+        signal, not lock out intent judging.
+        """
+        judge = IntentJudge()
+        judge._available = True
+        judge._last_error_time = 0.0
+
+        mock_response = MagicMock()
+        mock_response.status_code = 503
+        segments = [TranscriptSegment("test", 1000.0, 1001.0)]
+
+        with patch('jarvis.listening.intent_judge.requests.post', return_value=mock_response):
+            judge.judge(segments)
+
+        assert judge._last_error_time == 0.0
+        assert judge.available is True
+
+    def test_connection_error_does_trigger_backoff(self):
+        """Connection errors (Ollama actually down) DO trigger the 30s cooldown.
+
+        If the server is unreachable, retrying on every engagement just wastes
+        time. This is the one case where backoff is appropriate — it gives
+        Ollama a chance to come back up.
+        """
+        import requests as real_requests
+        judge = IntentJudge()
+        judge._available = True
+        judge._last_error_time = 0.0
+
+        segments = [TranscriptSegment("test", 1000.0, 1001.0)]
+
+        with patch(
+            'jarvis.listening.intent_judge.requests.post',
+            side_effect=real_requests.ConnectionError("refused"),
+        ):
+            judge.judge(segments)
+
+        assert judge._last_error_time > 0.0
+        assert judge.available is False
 
     def test_last_failure_reason_recorded_on_timeout(self):
         """Judge should remember why the last call failed so the listener can surface it."""
@@ -286,6 +331,8 @@ class TestIntentJudge:
         """HTTP non-200 responses should be recorded as a failure reason."""
         judge = IntentJudge()
         judge._available = True
+        # Clear any stray _last_error_time from earlier test setup
+        judge._last_error_time = 0.0
 
         mock_response = MagicMock()
         mock_response.status_code = 503

--- a/tests/test_intent_judge.py
+++ b/tests/test_intent_judge.py
@@ -20,7 +20,7 @@ class TestIntentJudgeConfig:
         config = IntentJudgeConfig()
         assert config.assistant_name == "Jarvis"
         assert config.model == "gemma4:e2b"
-        assert config.timeout_sec == 10.0
+        assert config.timeout_sec == 15.0
         assert config.aliases == []
 
     def test_custom_config(self):
@@ -248,6 +248,100 @@ class TestIntentJudge:
             result = judge.judge(segments)
 
         assert result is None
+
+    def test_timeout_sets_error_backoff(self):
+        """Timeouts should trigger the error cooldown so we don't hammer Ollama.
+
+        Previously only RequestException set _last_error_time — timeouts would
+        retry on every utterance with no backoff, producing a flood of "Intent
+        judge: unavailable (timeout or error)" lines in the console.
+        """
+        import requests as real_requests
+        judge = IntentJudge()
+        judge._available = True
+        judge._last_error_time = 0.0
+
+        segments = [TranscriptSegment("test", 1000.0, 1001.0)]
+
+        with patch('jarvis.listening.intent_judge.requests.post', side_effect=real_requests.Timeout()):
+            judge.judge(segments)
+
+        assert judge._last_error_time > 0.0, "timeout must trigger backoff cooldown"
+        assert judge.available is False, "judge must be unavailable during cooldown"
+
+    def test_last_failure_reason_recorded_on_timeout(self):
+        """Judge should remember why the last call failed so the listener can surface it."""
+        import requests as real_requests
+        judge = IntentJudge()
+        judge._available = True
+
+        segments = [TranscriptSegment("test", 1000.0, 1001.0)]
+
+        with patch('jarvis.listening.intent_judge.requests.post', side_effect=real_requests.Timeout()):
+            judge.judge(segments)
+
+        assert "timeout" in judge.last_failure_reason.lower()
+
+    def test_last_failure_reason_recorded_on_http_error(self):
+        """HTTP non-200 responses should be recorded as a failure reason."""
+        judge = IntentJudge()
+        judge._available = True
+
+        mock_response = MagicMock()
+        mock_response.status_code = 503
+        segments = [TranscriptSegment("test", 1000.0, 1001.0)]
+
+        with patch('jarvis.listening.intent_judge.requests.post', return_value=mock_response):
+            judge.judge(segments)
+
+        assert "503" in judge.last_failure_reason
+
+    def test_last_failure_reason_cleared_on_success(self):
+        """Successful judgments clear the last failure reason."""
+        judge = IntentJudge()
+        judge._available = True
+        judge._last_failure_reason = "timeout"
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "response": '{"directed": false, "query": "", "stop": false, "confidence": "high", "reasoning": "ok"}'
+        }
+        segments = [TranscriptSegment("test", 1000.0, 1001.0)]
+
+        with patch('jarvis.listening.intent_judge.requests.post', return_value=mock_response):
+            result = judge.judge(segments)
+
+        assert result is not None
+        assert judge.last_failure_reason == ""
+
+
+class TestResponseParserRobustness:
+    """Tests for response parser edge cases seen in the wild."""
+
+    def test_parse_response_with_nested_braces(self):
+        """Parser handles JSON where a string value contains braces.
+
+        The old regex `\\{[^{}]*\\}` failed on any nested brace, producing
+        spurious "unavailable" errors when the model quoted code in reasoning.
+        """
+        judge = IntentJudge()
+        response = '{"directed": true, "query": "format as {json}", "stop": false, "confidence": "high", "reasoning": "user asked about {formatting}"}'
+        result = judge._parse_response(response)
+
+        assert result is not None
+        assert result.directed is True
+        assert "json" in result.query
+
+    def test_parse_response_with_markdown_code_fence(self):
+        """Parser handles JSON wrapped in ```json ... ``` fences."""
+        judge = IntentJudge()
+        response = '```json\n{"directed": true, "query": "hi", "stop": false, "confidence": "high", "reasoning": "ok"}\n```'
+        result = judge._parse_response(response)
+
+        assert result is not None
+        assert result.directed is True
+        assert result.query == "hi"
 
 
 class TestCreateIntentJudge:


### PR DESCRIPTION
## Summary

- Gate the intent judge on an engagement signal (wake word / hot window / active TTS). Ambient background speech now skips the judge entirely instead of synchronously blocking the audio loop for up to `intent_judge_timeout_sec` per utterance — which was causing UI freezes when Ollama was slow or contended.
- Stop tripping the 30 s cooldown on transient failures. Timeouts and HTTP 5xx now record a `last_failure_reason` and retry on the next engagement. Only `ConnectionError` (Ollama actually down) still backs off. Voice is high-turn — one slow call must not silently kill intent judging for the next half-minute of conversation.
- Add `keep_alive: 30m` to the Ollama request so the intent-judge model stays resident between calls. Ollama's default 5 m eviction was the root cause of timeouts: a cold reload (~5 s) plus a long prompt could push past the 15 s timeout mid-conversation.
- Surface the real failure reason in the console: `unavailable (timeout after 15.0s)` / `HTTP 503 from Ollama` / `unparseable response: ...` instead of the opaque `(timeout or error)` so the next time this happens we know what actually failed.
- Replace the brittle `\{[^{}]*\}` JSON regex with a brace-matching extractor that handles markdown code fences and JSON values containing braces.
- Lower `num_predict` from 800 → 200 (ample for the expected JSON) and align default timeout with the spec (10 s → 15 s).

## Why

User reported a flood of `Intent judge: unavailable (timeout or error)` on pure ambient chatter, followed this session by the whole computer freezing after a 15 s timeout. Root cause: the judge was called synchronously on every transcribed utterance, even ambient speech with no wake word / hot window / TTS. Each call blocked the audio loop for up to the timeout — when Ollama was slow (cold reload, GPU pressure, contention), the timeouts cascaded. The pre-existing 30 s backoff then locked out intent judging after a single hiccup, which is the wrong default for voice.

## Test plan

- [x] 43 intent-judge unit tests pass, including new coverage for timeout/HTTP-error no-backoff behaviour, ConnectionError backoff, parser robustness on nested braces and markdown fences, and `last_failure_reason` tracking.
- [x] 3 new listener integration tests lock in the gating behaviour: judge not called on ambient speech, is called when wake word detected, is called in hot window.
- [x] 147 total listening-related tests pass (only the 2 pre-existing `TestWindowsCudaDetection` failures remain, unrelated).
- [ ] Manual verification: run Jarvis in a conversational environment, confirm no "unavailable" spam on ambient speech and no UI freeze when Ollama is slow.

## Notes for reviewer

- Spec updated in `src/jarvis/listening/listening.spec.md` to document the engagement-signal gate.
- The engagement-signal gate means the judge no longer sees ambient pre-wake-word chatter at all. Per-segment context synthesis still works because the transcript buffer is read when the judge IS called (on wake word / hot window), and older segments are still in the buffer then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)