### PR TITLE
docs(listening): document intent-judge keep_alive trade-off + add TTS-gate tests and wake-after-narrative eval

### DIFF
--- a/evals/test_intent_judge.py
+++ b/evals/test_intent_judge.py
@@ -356,12 +356,37 @@ MULTI_SEGMENT_TEST_CASES = [
         expected_directed=True,
         expected_query_contains="germany",
     ),
+    # Wake word mid-utterance after narrative buffer, addressing the assistant.
+    # Real-world case: user was discussing Mata Hari in the background, then
+    # turned to the assistant with "Jarvis, do you know what she's talking about,
+    # about Mata Hari?". The small model mis-classified as "not directed" with
+    # reasoning that contradicted the verdict. The wake word is mid-utterance
+    # here but the trailing clause addresses the assistant directly ("do YOU
+    # know"), so this must be DIRECTED.
+    MultiSegmentTestCase(
+        name="wake_word_after_narrative_addresses_assistant",
+        segments=[
+            ("The dude was a lie upon the lie", False),
+            ("Mata Hari was never a traitor, she was an honest woman", False),
+            ("Jarvis, do you know what she's talking about, about Mata Hari?", False),
+        ],
+        last_tts_text="",
+        in_hot_window=False,
+        wake_timestamp=1004.5,
+        expected_directed=True,
+        expected_query_contains="mata hari",
+    ),
 ]
 
 
 # Cases known to fail with the small model on the current prompt.
-# Kept empty during baseline runs so we observe true pass/fail.
-KNOWN_FAILING_CASES: set = set()
+# Track regressions / future prompt improvements here.
+KNOWN_FAILING_CASES: set = {
+    # gemma4:e2b occasionally flips this to not-directed when the wake word
+    # lands mid-utterance after a long narrative buffer. Tracked so a prompt
+    # improvement can flip it back to passing.
+    "wake_word_after_narrative_addresses_assistant",
+}
 
 
 # =============================================================================

--- a/src/jarvis/listening/listening.spec.md
+++ b/src/jarvis/listening/listening.spec.md
@@ -85,6 +85,8 @@ The intent judge receives full context and makes intelligent decisions:
 
 **Gating:** The judge is called only when there is an engagement signal — (a) a wake word was detected in the current utterance, (b) the utterance falls inside (or pending) a hot window, or (c) TTS is currently speaking. Pure ambient speech skips the judge entirely. This keeps the synchronous audio loop from blocking up to `intent_judge_timeout_sec` on every background utterance, which would otherwise freeze the UI when Ollama is slow or contended.
 
+**Model residency (`keep_alive: 30m`):** Each intent-judge request asks Ollama to keep the model resident for 30 minutes after the call. This avoids cold reloads between utterances — without it, Ollama evicts the model after its default 5-minute idle window and the next judge call pays the full reload cost (seconds of extra latency), which is long enough to hit `intent_judge_timeout_sec` and abort. The trade-off is memory: the judge model (default `gemma4:e2b`, ~2 GB) stays resident in RAM/VRAM during active voice sessions. On memory-constrained devices the user can switch to a smaller judge model or override `keep_alive` via a custom Ollama setup.
+
 ## The Three Listening Modes
 
 ### 1. Wake Word Mode (Default)

--- a/tests/test_hot_window_input.py
+++ b/tests/test_hot_window_input.py
@@ -1355,3 +1355,50 @@ class TestIntentJudgeGating:
 
         assert mock_judge.judge.call_count == 1
         listener.state_manager.stop()
+
+    @patch("builtins.print")
+    def test_judge_skipped_for_short_utterance_during_tts(self, _print):
+        """Short utterances (<=3 words) during active TTS bypass the judge.
+
+        The fast text-based stop-command check already handles short
+        interruptions like "stop" / "shut up" while TTS is speaking. Sending
+        these to the judge would block the audio loop for the judge's
+        timeout on every short echo chunk during playback.
+        """
+        listener, mock_tts = _create_listener(tts_speaking=True)
+
+        mock_judge = _install_intent_judge(
+            listener, _make_judgment(directed=False, query=""))
+
+        listener._process_transcript(
+            "uh huh yeah", utterance_energy=0.01,
+        )
+
+        assert mock_judge.judge.call_count == 0, (
+            "Short utterances during TTS must be handled by the stop-command "
+            "path, not the judge, to avoid blocking the audio loop")
+        listener.state_manager.stop()
+
+    @patch("builtins.print")
+    def test_judge_called_for_longer_utterance_during_tts(self, _print):
+        """Longer utterances (>3 words) during TTS still reach the judge.
+
+        Active TTS is itself an engagement signal — the user may be
+        interrupting with a real follow-up or correction, and the judge
+        needs to see it to catch intents the fast text-based stop-command
+        check misses.
+        """
+        listener, mock_tts = _create_listener(tts_speaking=True)
+
+        mock_judge = _install_intent_judge(
+            listener, _make_judgment(
+                directed=True, query="what about tomorrow's weather"))
+
+        # >3 words, no stop-command keywords, not echo
+        listener._process_transcript(
+            "actually what about tomorrow's weather",
+            utterance_energy=0.01,
+        )
+
+        assert mock_judge.judge.call_count == 1
+        listener.state_manager.stop()


### PR DESCRIPTION
## Summary
Addresses the three follow-ups flagged in the PR #218 review, plus documents the real-world wake-word misclassification observed during manual testing.

- 📝 **Document `keep_alive: 30m` trade-off** in `listening.spec.md`. The judge model now stays resident in RAM for 30 minutes after each call to avoid cold reloads that would otherwise blow through `intent_judge_timeout_sec`. The trade-off (≈2 GB resident for `gemma4:e2b`) is now explicit in the spec.
- 🧪 **TTS-branch gating tests** in `tests/test_hot_window_input.py`: short utterances (≤3 words) during active TTS bypass the judge (handled by the fast stop-command path), while longer utterances still reach it because TTS playback is itself an engagement signal.
- 🧠 **Eval case for the Mata Hari misclassification** in `evals/test_intent_judge.py`. A user was discussing Mata Hari ambiently, then said "Jarvis, do you know what she's talking about, about Mata Hari?" — `gemma4:e2b` flipped this to not-directed with self-contradictory reasoning. Added as a known-failing case (`xfail`) so a future prompt improvement can flip it back to passing.

## Test plan
- [x] `pytest tests/test_hot_window_input.py::TestIntentJudgeGating` — 5 passed (3 existing + 2 new).
- [x] `pytest tests/test_intent_judge.py` — all passed.
- [x] Full suite: only pre-existing failures (setup wizard, splash, CUDA detection) — nothing in listening/intent_judge touched.
- [ ] Manual: run Jarvis, confirm intent judge is still gated on ambient speech and responsive on wake/hot-window paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)