### PR TITLE
test(listening): unflake wake-word-after-narrative eval case

### DIFF
--- a/evals/test_intent_judge.py
+++ b/evals/test_intent_judge.py
@@ -381,12 +381,7 @@ MULTI_SEGMENT_TEST_CASES = [
 
 # Cases known to fail with the small model on the current prompt.
 # Track regressions / future prompt improvements here.
-KNOWN_FAILING_CASES: set = {
-    # gemma4:e2b occasionally flips this to not-directed when the wake word
-    # lands mid-utterance after a long narrative buffer. Tracked so a prompt
-    # improvement can flip it back to passing.
-    "wake_word_after_narrative_addresses_assistant",
-}
+KNOWN_FAILING_CASES: set = set()
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- Removes \`wake_word_after_narrative_addresses_assistant\` from \`KNOWN_FAILING_CASES\` so it runs as a real regression guard against mid-utterance wake-word flipping to not-directed after an ambient narrative buffer.
- The failure mode (gemma4:e2b contradicting itself — "wake word detected, but…" then directed=false) no longer reproduces: verified 3× full-suite runs at 30/30 and 8× targeted runs at 8/8. Recent work landed on develop (#214 prompt condensation, #218/#219 judge-loop fixes) appears to have resolved it incidentally.
- No prompt change required. Initial attempts at tightening the narrative rule regressed \`multi_person_weather_discussion\` (topic synthesis for "what do you think" stopped pulling in prior-segment context), so we keep the prompt unchanged.

## Test plan
- [x] \`pytest evals/test_intent_judge.py -k wake_word_after_narrative_addresses_assistant\` — passes 8/8 consecutively against live gemma4:e2b.
- [x] \`pytest evals/test_intent_judge.py\` — 30/30 passing, three consecutive runs.
- [x] \`pytest tests/test_intent_judge.py\` — 45/45 parser/plumbing unit tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)