### PR TITLE
feat(listening): warm up chat, intent judge, and Whisper models before listening

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,6 +458,8 @@ Get API key at [composio.dev](https://composio.dev)
 <details>
 <summary><strong>Common issues</strong></summary>
 
+**First startup takes a bit** - Jarvis pre-warms the Whisper, chat, and intent-judge models before announcing "Listening!" so the first engagement feels instant. This adds a few seconds on cold start and is bounded at 60 s — if Ollama is slow, Jarvis will start listening anyway and load the models on demand.
+
 **Jarvis doesn't hear me** - Check microphone permissions, speak clearly after "Jarvis"
 
 **Responses are slow** - Ensure you have enough VRAM (8GB+ for default model; see System Requirements for other models)

--- a/src/jarvis/listening/intent_judge.py
+++ b/src/jarvis/listening/intent_judge.py
@@ -23,6 +23,39 @@ except ImportError:
     REQUESTS_AVAILABLE = False
 
 
+def warm_up_ollama_model(base_url: str, model: str, timeout: float) -> bool:
+    """Ask Ollama to load ``model`` into memory with a 30m keep_alive.
+
+    Issues a minimal ``/api/generate`` request so the weights are resident
+    before the first real request. Best-effort — errors are logged and
+    swallowed so callers never crash on warmup failure.
+    """
+    if not REQUESTS_AVAILABLE or not base_url or not model:
+        return False
+    try:
+        response = requests.post(
+            f"{base_url}/api/generate",
+            json={
+                "model": model,
+                "prompt": "",
+                "stream": False,
+                "keep_alive": "30m",
+                "options": {"num_predict": 1},
+            },
+            timeout=timeout,
+        )
+        ok = response.status_code == 200
+        debug_log(
+            f"ollama warmup {'ok' if ok else f'failed HTTP {response.status_code}'} "
+            f"(model={model})",
+            "voice",
+        )
+        return ok
+    except Exception as e:
+        debug_log(f"ollama warmup error (model={model}): {e}", "voice")
+        return False
+
+
 def _extract_json_object(text: str) -> str:
     """Return the first balanced `{...}` object in `text`, or "" if none.
 
@@ -284,36 +317,14 @@ Examples:
             return None
 
     def warm_up(self) -> bool:
-        """Trigger Ollama to load the model into memory ahead of first use.
-
-        Issues a trivial generation request with ``keep_alive=30m`` so the
-        cold-load cost is paid before the user speaks. Returns True on
-        success. Errors are swallowed — warmup is best-effort.
-        """
+        """Trigger Ollama to load the model into memory ahead of first use."""
         if not self._available:
             return False
-        try:
-            response = requests.post(
-                f"{self.config.ollama_base_url}/api/generate",
-                json={
-                    "model": self.config.model,
-                    "prompt": "",
-                    "stream": False,
-                    "keep_alive": "30m",
-                    "options": {"num_predict": 1},
-                },
-                timeout=max(self.config.timeout_sec, 60.0),
-            )
-            ok = response.status_code == 200
-            debug_log(
-                f"intent judge warmup {'ok' if ok else f'failed HTTP {response.status_code}'} "
-                f"(model={self.config.model})",
-                "voice",
-            )
-            return ok
-        except Exception as e:
-            debug_log(f"intent judge warmup error: {e}", "voice")
-            return False
+        return warm_up_ollama_model(
+            self.config.ollama_base_url,
+            self.config.model,
+            timeout=max(self.config.timeout_sec, 60.0),
+        )
 
     def judge(
         self,

--- a/src/jarvis/listening/intent_judge.py
+++ b/src/jarvis/listening/intent_judge.py
@@ -283,6 +283,38 @@ Examples:
             debug_log(f"intent judge: failed to parse response: {e}", "voice")
             return None
 
+    def warm_up(self) -> bool:
+        """Trigger Ollama to load the model into memory ahead of first use.
+
+        Issues a trivial generation request with ``keep_alive=30m`` so the
+        cold-load cost is paid before the user speaks. Returns True on
+        success. Errors are swallowed — warmup is best-effort.
+        """
+        if not self._available:
+            return False
+        try:
+            response = requests.post(
+                f"{self.config.ollama_base_url}/api/generate",
+                json={
+                    "model": self.config.model,
+                    "prompt": "",
+                    "stream": False,
+                    "keep_alive": "30m",
+                    "options": {"num_predict": 1},
+                },
+                timeout=max(self.config.timeout_sec, 60.0),
+            )
+            ok = response.status_code == 200
+            debug_log(
+                f"intent judge warmup {'ok' if ok else f'failed HTTP {response.status_code}'} "
+                f"(model={self.config.model})",
+                "voice",
+            )
+            return ok
+        except Exception as e:
+            debug_log(f"intent judge warmup error: {e}", "voice")
+            return False
+
     def judge(
         self,
         segments: List[TranscriptSegment],

--- a/src/jarvis/listening/listener.py
+++ b/src/jarvis/listening/listener.py
@@ -1298,16 +1298,88 @@ class VoiceListener(threading.Thread):
         self._whisper_device = resolved_device
 
         if try_device != device and device in ("auto", "cuda"):
-            print("  ⚠️  CUDA not available, using CPU (this may be slower)", flush=True)
-            print("  💡 Tip: Install NVIDIA CUDA toolkit for faster speech recognition", flush=True)
+            print("     ⚠️  CUDA not available, using CPU (this may be slower)", flush=True)
+            print("     💡 Tip: Install NVIDIA CUDA toolkit for faster speech recognition", flush=True)
         if try_compute != compute:
-            print(f"  ⚠️  Using '{try_compute}' compute type ('{compute}' not supported)", flush=True)
+            print(f"     ⚠️  Using '{try_compute}' compute type ('{compute}' not supported)", flush=True)
         if resolved_device == "cpu":
-            print(f"  ⚡ CPU mode: using {cpu_threads} threads with optimised decoding", flush=True)
+            print(f"     ⚡ CPU mode: using {cpu_threads} threads with optimised decoding", flush=True)
 
         suffix = f" ({context})" if context else ""
-        print(f"  ✅ Whisper model '{model_name}' loaded on {resolved_device}{suffix}", flush=True)
+        print(f"     🎤 Whisper '{model_name}' loaded on {resolved_device}{suffix}", flush=True)
         return resolved_device
+
+    def _start_llm_warmup(self) -> Optional[threading.Thread]:
+        """Pre-load the chat model and intent judge model into Ollama memory.
+
+        Runs in a background thread so it overlaps with Whisper initialisation.
+        Results are stashed on ``self._llm_warmup_results`` for the caller to
+        print after Whisper completes, so output stays grouped and in order.
+        Both warmups are best-effort — failures just mean the first user
+        engagement pays the cold-load cost.
+        """
+        chat_model = str(getattr(self.cfg, "ollama_chat_model", "") or "").strip()
+        ollama_base_url = str(getattr(self.cfg, "ollama_base_url", "") or "").strip()
+        judge = self._intent_judge
+
+        self._llm_warmup_results: dict[str, tuple[str, bool]] = {}
+
+        if not chat_model and judge is None:
+            return None
+
+        def _warm_chat_model() -> None:
+            if not chat_model or not ollama_base_url:
+                return
+            try:
+                import requests as _requests
+                resp = _requests.post(
+                    f"{ollama_base_url}/api/generate",
+                    json={
+                        "model": chat_model,
+                        "prompt": "",
+                        "stream": False,
+                        "keep_alive": "30m",
+                        "options": {"num_predict": 1},
+                    },
+                    timeout=120.0,
+                )
+                ok = resp.status_code == 200
+                self._llm_warmup_results["chat"] = (chat_model, ok)
+                debug_log(
+                    f"chat model warmup {'ok' if ok else f'failed HTTP {resp.status_code}'} "
+                    f"(model={chat_model})",
+                    "voice",
+                )
+            except Exception as e:
+                self._llm_warmup_results["chat"] = (chat_model, False)
+                debug_log(f"chat model warmup error: {e}", "voice")
+
+        def _warm_judge() -> None:
+            ok = judge.warm_up()
+            self._llm_warmup_results["judge"] = (judge.config.model, ok)
+
+        def _run_warmups() -> None:
+            threads: list[threading.Thread] = []
+            if chat_model and ollama_base_url:
+                t = threading.Thread(target=_warm_chat_model, daemon=True, name="warmup-chat")
+                t.start()
+                threads.append(t)
+            if judge is not None:
+                t = threading.Thread(target=_warm_judge, daemon=True, name="warmup-judge")
+                t.start()
+                threads.append(t)
+            for t in threads:
+                t.join()
+            debug_log("LLM warmup complete", "voice")
+
+        thread = threading.Thread(target=_run_warmups, daemon=True, name="llm-warmup")
+        thread.start()
+        debug_log(
+            f"LLM warmup started (chat={chat_model or 'n/a'}, "
+            f"judge={judge.config.model if judge else 'n/a'})",
+            "voice",
+        )
+        return thread
 
     def run(self) -> None:
         """Main voice listening loop."""
@@ -1406,6 +1478,13 @@ class VoiceListener(threading.Thread):
                 debug_log(f"microphone permission check error: {e}", "voice")
                 print(f"  ⚠️  Microphone check error: {e}", flush=True)
 
+        # Kick off LLM warmups in parallel with Whisper load so the first
+        # user engagement doesn't pay cold-load cost on either model. All
+        # warmup output (Whisper + LLMs) is indented under this header to
+        # visually group the phase.
+        print("  🔥 Warming up models...", flush=True)
+        self._llm_warmup_thread = self._start_llm_warmup()
+
         # Determine and initialise Whisper backend
         self._whisper_backend = self._determine_whisper_backend()
         model_name = getattr(self.cfg, "whisper_model", "small")
@@ -1430,7 +1509,7 @@ class VoiceListener(threading.Thread):
                 return
 
             self._mlx_model_repo = _get_mlx_model_repo(model_name)
-            print(f"  🔄 Loading MLX Whisper model '{model_name}' (Apple Silicon GPU)...", flush=True)
+            print(f"     🎤 Loading MLX Whisper '{model_name}' (Apple Silicon GPU)...", flush=True)
 
             max_retries = 4
             for attempt in range(max_retries + 1):
@@ -1446,7 +1525,7 @@ class VoiceListener(threading.Thread):
                         )
                         debug_log(f"MLX Whisper model pre-loaded: repo={self._mlx_model_repo}", "voice")
 
-                    print(f"  ✅ MLX Whisper '{model_name}' ready (Apple Silicon GPU acceleration)", flush=True)
+                    print(f"     🎤 MLX Whisper '{model_name}' ready (Apple Silicon GPU)", flush=True)
                     break
                 except Exception as e:
                     error_str = str(e).lower()
@@ -1557,7 +1636,7 @@ class VoiceListener(threading.Thread):
             for try_device, try_compute in configs_to_try:
                 try:
                     cpu_threads = (os.cpu_count() or 4) if try_device in ("cpu", "auto") else 0
-                    print(f"  🔄 Loading Whisper model '{model_name}' (device={try_device}, compute={try_compute})...", flush=True)
+                    print(f"     🎤 Loading Whisper '{model_name}' (device={try_device}, compute={try_compute})...", flush=True)
                     self.model = WhisperModel(
                         model_name, device=try_device, compute_type=try_compute,
                         cpu_threads=cpu_threads,
@@ -1597,7 +1676,7 @@ class VoiceListener(threading.Thread):
                         cache_cleared = _clear_corrupted_whisper_cache(str(e))
                         if cache_cleared:
                             try:
-                                print(f"  🔄 Re-downloading Whisper model '{model_name}'...", flush=True)
+                                print(f"     🎤 Re-downloading Whisper '{model_name}'...", flush=True)
                                 self.model = WhisperModel(
                                     model_name, device=try_device, compute_type=try_compute,
                                     cpu_threads=cpu_threads,
@@ -1670,6 +1749,44 @@ class VoiceListener(threading.Thread):
                 debug_log(f"failed to initialise faster-whisper with any config: {last_error}", "voice")
                 print(f"  ❌ Failed to load Whisper model: {last_error}", flush=True)
                 return
+
+            # Warm up faster-whisper with a silent-audio transcribe so the
+            # first real utterance doesn't pay the cold-decode cost.
+            if np is not None and self.model is not None:
+                try:
+                    warmup_audio = np.zeros(self._samplerate, dtype=np.float32)
+                    segments_iter, _ = self.model.transcribe(warmup_audio, beam_size=1)
+                    for _ in segments_iter:
+                        pass
+                    debug_log("faster-whisper warmup transcription complete", "voice")
+                except Exception as e:
+                    debug_log(f"faster-whisper warmup failed: {e}", "voice")
+
+        # Wait for LLM warmups before announcing "Listening!" so the first
+        # engagement is responsive. Bounded so a slow/down Ollama can't block
+        # us from listening — we'll just pay the cold-load cost on demand.
+        if self._llm_warmup_thread is not None:
+            self._llm_warmup_thread.join(timeout=60.0)
+            still_warming = self._llm_warmup_thread.is_alive()
+            results = getattr(self, "_llm_warmup_results", {})
+
+            chat = results.get("chat")
+            if chat is not None:
+                name, ok = chat
+                icon = "💬" if ok else "⚠️ "
+                status = "ready" if ok else "warmup failed — will load on first use"
+                print(f"     {icon} Chat model '{name}' {status}", flush=True)
+
+            judge = results.get("judge")
+            if judge is not None:
+                name, ok = judge
+                icon = "🧠" if ok else "⚠️ "
+                status = "ready" if ok else "warmup failed — will load on first use"
+                print(f"     {icon} Intent judge '{name}' {status}", flush=True)
+
+            if still_warming:
+                debug_log("LLM warmup still running after 60s — continuing without", "voice")
+                print("     ⏳ Some models still warming — continuing anyway", flush=True)
 
         # Audio parameters
         frame_ms = int(getattr(self.cfg, "vad_frame_ms", 20))

--- a/src/jarvis/listening/listener.py
+++ b/src/jarvis/listening/listener.py
@@ -20,7 +20,7 @@ from .echo_detection import EchoDetector
 from .state_manager import StateManager, ListeningState
 from .wake_detection import is_wake_word_detected, extract_query_after_wake, is_stop_command
 from .transcript_buffer import TranscriptBuffer
-from .intent_judge import IntentJudge, create_intent_judge
+from .intent_judge import IntentJudge, create_intent_judge, warm_up_ollama_model
 from ..debug import debug_log
 
 if TYPE_CHECKING:
@@ -1309,77 +1309,55 @@ class VoiceListener(threading.Thread):
         print(f"     🎤 Whisper '{model_name}' loaded on {resolved_device}{suffix}", flush=True)
         return resolved_device
 
-    def _start_llm_warmup(self) -> Optional[threading.Thread]:
-        """Pre-load the chat model and intent judge model into Ollama memory.
+    def _start_llm_warmup(self) -> list[threading.Thread]:
+        """Pre-load chat and intent judge models into Ollama memory.
 
-        Runs in a background thread so it overlaps with Whisper initialisation.
-        Results are stashed on ``self._llm_warmup_results`` for the caller to
-        print after Whisper completes, so output stays grouped and in order.
-        Both warmups are best-effort — failures just mean the first user
-        engagement pays the cold-load cost.
+        Starts up to two daemon threads concurrently so warmup overlaps
+        with Whisper initialisation. When both models point at the same
+        Ollama model, a single warmup covers both (Ollama loads the
+        weights once; ``keep_alive`` keeps them resident for every caller).
+
+        Results land in ``self._llm_warmup_results`` keyed by role. The
+        caller joins the returned threads with a shared deadline before
+        announcing "Listening!" so the ready state actually means ready.
         """
-        chat_model = str(getattr(self.cfg, "ollama_chat_model", "") or "").strip()
-        ollama_base_url = str(getattr(self.cfg, "ollama_base_url", "") or "").strip()
-        judge = self._intent_judge
-
         self._llm_warmup_results: dict[str, tuple[str, bool]] = {}
 
-        if not chat_model and judge is None:
-            return None
+        chat_model = str(getattr(self.cfg, "ollama_chat_model", "") or "").strip()
+        base_url = str(getattr(self.cfg, "ollama_base_url", "") or "").strip()
+        chat_timeout = max(float(getattr(self.cfg, "llm_tools_timeout_sec", 8.0)), 60.0)
+        judge = self._intent_judge
+        judge_model = judge.config.model if judge is not None else ""
+        shared_model = bool(chat_model) and judge_model == chat_model
 
-        def _warm_chat_model() -> None:
-            if not chat_model or not ollama_base_url:
-                return
-            try:
-                import requests as _requests
-                resp = _requests.post(
-                    f"{ollama_base_url}/api/generate",
-                    json={
-                        "model": chat_model,
-                        "prompt": "",
-                        "stream": False,
-                        "keep_alive": "30m",
-                        "options": {"num_predict": 1},
-                    },
-                    timeout=120.0,
-                )
-                ok = resp.status_code == 200
+        threads: list[threading.Thread] = []
+
+        if chat_model and base_url:
+            def _warm_chat() -> None:
+                ok = warm_up_ollama_model(base_url, chat_model, timeout=chat_timeout)
                 self._llm_warmup_results["chat"] = (chat_model, ok)
-                debug_log(
-                    f"chat model warmup {'ok' if ok else f'failed HTTP {resp.status_code}'} "
-                    f"(model={chat_model})",
-                    "voice",
-                )
-            except Exception as e:
-                self._llm_warmup_results["chat"] = (chat_model, False)
-                debug_log(f"chat model warmup error: {e}", "voice")
+                # When chat and judge share a model, one warmup covers both.
+                if shared_model:
+                    self._llm_warmup_results["judge"] = (chat_model, ok)
 
-        def _warm_judge() -> None:
-            ok = judge.warm_up()
-            self._llm_warmup_results["judge"] = (judge.config.model, ok)
+            threads.append(threading.Thread(target=_warm_chat, daemon=True, name="warmup-chat"))
 
-        def _run_warmups() -> None:
-            threads: list[threading.Thread] = []
-            if chat_model and ollama_base_url:
-                t = threading.Thread(target=_warm_chat_model, daemon=True, name="warmup-chat")
-                t.start()
-                threads.append(t)
-            if judge is not None:
-                t = threading.Thread(target=_warm_judge, daemon=True, name="warmup-judge")
-                t.start()
-                threads.append(t)
-            for t in threads:
-                t.join()
-            debug_log("LLM warmup complete", "voice")
+        if judge is not None and not shared_model:
+            def _warm_judge() -> None:
+                ok = judge.warm_up()
+                self._llm_warmup_results["judge"] = (judge_model, ok)
 
-        thread = threading.Thread(target=_run_warmups, daemon=True, name="llm-warmup")
-        thread.start()
+            threads.append(threading.Thread(target=_warm_judge, daemon=True, name="warmup-judge"))
+
+        for t in threads:
+            t.start()
+
         debug_log(
             f"LLM warmup started (chat={chat_model or 'n/a'}, "
-            f"judge={judge.config.model if judge else 'n/a'})",
+            f"judge={judge_model or 'n/a'}, shared={shared_model})",
             "voice",
         )
-        return thread
+        return threads
 
     def run(self) -> None:
         """Main voice listening loop."""
@@ -1483,7 +1461,8 @@ class VoiceListener(threading.Thread):
         # warmup output (Whisper + LLMs) is indented under this header to
         # visually group the phase.
         print("  🔥 Warming up models...", flush=True)
-        self._llm_warmup_thread = self._start_llm_warmup()
+        self._llm_warmup_started_at = time.time()
+        self._llm_warmup_threads = self._start_llm_warmup()
 
         # Determine and initialise Whisper backend
         self._whisper_backend = self._determine_whisper_backend()
@@ -1763,26 +1742,33 @@ class VoiceListener(threading.Thread):
                     debug_log(f"faster-whisper warmup failed: {e}", "voice")
 
         # Wait for LLM warmups before announcing "Listening!" so the first
-        # engagement is responsive. Bounded so a slow/down Ollama can't block
-        # us from listening — we'll just pay the cold-load cost on demand.
-        if self._llm_warmup_thread is not None:
-            self._llm_warmup_thread.join(timeout=60.0)
-            still_warming = self._llm_warmup_thread.is_alive()
+        # engagement is responsive. A single 60s budget is shared across
+        # all warmup threads so a slow/down Ollama can't block us from
+        # listening — we'll just pay the cold-load cost on demand.
+        warmup_threads = getattr(self, "_llm_warmup_threads", [])
+        if warmup_threads:
+            budget = 60.0
+            deadline = getattr(self, "_llm_warmup_started_at", time.time()) + budget
+            for t in warmup_threads:
+                remaining = max(0.0, deadline - time.time())
+                t.join(timeout=remaining)
+
+            still_warming = any(t.is_alive() for t in warmup_threads)
             results = getattr(self, "_llm_warmup_results", {})
 
-            chat = results.get("chat")
-            if chat is not None:
-                name, ok = chat
-                icon = "💬" if ok else "⚠️ "
+            # Trailing space after ⚠️ intentional: the warning glyph renders
+            # narrower than 🧠/💬, so the pad keeps columns aligned.
+            def _print_status(role_key: str, label: str, ok_icon: str) -> None:
+                entry = results.get(role_key)
+                if entry is None:
+                    return
+                name, ok = entry
+                icon = ok_icon if ok else "⚠️ "
                 status = "ready" if ok else "warmup failed — will load on first use"
-                print(f"     {icon} Chat model '{name}' {status}", flush=True)
+                print(f"     {icon} {label} '{name}' {status}", flush=True)
 
-            judge = results.get("judge")
-            if judge is not None:
-                name, ok = judge
-                icon = "🧠" if ok else "⚠️ "
-                status = "ready" if ok else "warmup failed — will load on first use"
-                print(f"     {icon} Intent judge '{name}' {status}", flush=True)
+            _print_status("chat", "Chat model", "💬")
+            _print_status("judge", "Intent judge", "🧠")
 
             if still_warming:
                 debug_log("LLM warmup still running after 60s — continuing without", "voice")

--- a/src/jarvis/listening/listener.py
+++ b/src/jarvis/listening/listener.py
@@ -1493,10 +1493,13 @@ class VoiceListener(threading.Thread):
             max_retries = 4
             for attempt in range(max_retries + 1):
                 try:
-                    # Pre-load the model by doing a warmup transcription with silent audio
-                    # This triggers the model download before we need it for real transcription
+                    # Pre-load the model by doing a warmup transcription.
+                    # Use low-amplitude noise (not silence) so the decoder actually runs —
+                    # silent audio trips the no-speech short-circuit and leaves the decode
+                    # path cold, so the first real utterance still pays the full cost.
                     if np is not None:
-                        warmup_audio = np.zeros(self._samplerate, dtype=np.float32)  # 1 second of silence
+                        rng = np.random.default_rng(0)
+                        warmup_audio = rng.standard_normal(self._samplerate).astype(np.float32) * 0.01
                         _ = mlx_whisper.transcribe(
                             warmup_audio,
                             path_or_hf_repo=self._mlx_model_repo,
@@ -1729,12 +1732,27 @@ class VoiceListener(threading.Thread):
                 print(f"  ❌ Failed to load Whisper model: {last_error}", flush=True)
                 return
 
-            # Warm up faster-whisper with a silent-audio transcribe so the
-            # first real utterance doesn't pay the cold-decode cost.
+            # Warm up faster-whisper so the first real utterance doesn't pay
+            # the cold-decode cost. Use low-amplitude noise rather than pure
+            # silence — silence trips faster-whisper's no-speech short-circuit
+            # and the decoder never actually runs. Mirror the real transcribe
+            # parameters so beam search, language detection, and the timestamp
+            # path are all exercised here instead of on the user's first word.
             if np is not None and self.model is not None:
                 try:
-                    warmup_audio = np.zeros(self._samplerate, dtype=np.float32)
-                    segments_iter, _ = self.model.transcribe(warmup_audio, beam_size=1)
+                    cpu_mode = self._whisper_device == "cpu"
+                    rng = np.random.default_rng(0)
+                    warmup_audio = rng.standard_normal(self._samplerate).astype(np.float32) * 0.01
+                    try:
+                        segments_iter, _ = self.model.transcribe(
+                            warmup_audio,
+                            language=None,
+                            vad_filter=False,
+                            condition_on_previous_text=not cpu_mode,
+                            without_timestamps=cpu_mode,
+                        )
+                    except TypeError:
+                        segments_iter, _ = self.model.transcribe(warmup_audio, language=None)
                     for _ in segments_iter:
                         pass
                     debug_log("faster-whisper warmup transcription complete", "voice")

--- a/src/jarvis/listening/listening.spec.md
+++ b/src/jarvis/listening/listening.spec.md
@@ -87,6 +87,27 @@ The intent judge receives full context and makes intelligent decisions:
 
 **Model residency (`keep_alive: 30m`):** Each intent-judge request asks Ollama to keep the model resident for 30 minutes after the call. This avoids cold reloads between utterances — without it, Ollama evicts the model after its default 5-minute idle window and the next judge call pays the full reload cost (seconds of extra latency), which is long enough to hit `intent_judge_timeout_sec` and abort. The trade-off is memory: the judge model (default `gemma4:e2b`, ~2 GB) stays resident in RAM/VRAM during active voice sessions. On memory-constrained devices the user can switch to a smaller judge model or override `keep_alive` via a custom Ollama setup.
 
+## Startup & Model Warmup
+
+Before the listener announces "Listening!", it pre-loads every model the first engagement will need. All warmup output is grouped under a single `🔥 Warming up models...` header with indented child status lines, e.g.
+
+```
+  🔥 Warming up models...
+     🎤 Whisper 'small' loaded on cpu
+     💬 Chat model 'llama3.1' ready
+     🧠 Intent judge 'gemma4:e2b' ready
+🎙️  Listening! Try: "How's the weather, Jarvis?"
+```
+
+**What gets warmed:**
+- **Whisper** — loading the model; additionally a silent-audio transcribe so the first real utterance doesn't pay the cold-decode cost. Both the MLX and faster-whisper backends do this.
+- **Chat model** (`cfg.ollama_chat_model`) — a minimal Ollama `/api/generate` request with `keep_alive=30m` so the weights stay resident.
+- **Intent judge model** (`cfg.intent_judge_model`) — same pattern. If it points at the same Ollama model as the chat model, a single warmup covers both roles (Ollama loads the weights once).
+
+**Concurrency:** LLM warmups run in daemon threads started before Whisper loads, so they overlap with Whisper initialisation. After Whisper finishes, the listener joins the warmup threads with a **single 60 s budget** shared across them all. If the budget is exhausted, the listener continues (with a `⏳ Some models still warming — continuing anyway` notice) and the first engagement pays the cold-load cost on demand.
+
+**Best-effort semantics:** Every warmup path swallows its own errors and returns a bool. A failed warmup prints `⚠️ … warmup failed — will load on first use` but never blocks or crashes the listener — voice input is prioritised over startup latency.
+
 ## The Three Listening Modes
 
 ### 1. Wake Word Mode (Default)

--- a/tests/test_intent_judge.py
+++ b/tests/test_intent_judge.py
@@ -423,6 +423,44 @@ class TestCreateIntentJudge:
         assert judge is not None
 
 
+class TestWarmUp:
+    """Tests for IntentJudge.warm_up()."""
+
+    def test_warmup_posts_to_generate_with_keep_alive(self):
+        """Warmup issues a /api/generate request that pins the model in memory."""
+        judge = IntentJudge(IntentJudgeConfig(model="gemma4:e2b"))
+        with patch("jarvis.listening.intent_judge.requests") as mock_requests:
+            mock_requests.post.return_value = MagicMock(status_code=200)
+            ok = judge.warm_up()
+
+        assert ok is True
+        args, kwargs = mock_requests.post.call_args
+        assert args[0].endswith("/api/generate")
+        assert kwargs["json"]["model"] == "gemma4:e2b"
+        assert kwargs["json"]["keep_alive"] == "30m"
+        assert kwargs["json"]["stream"] is False
+
+    def test_warmup_returns_false_on_http_error(self):
+        """Warmup reports failure when Ollama returns a non-200 status."""
+        judge = IntentJudge()
+        with patch("jarvis.listening.intent_judge.requests") as mock_requests:
+            mock_requests.post.return_value = MagicMock(status_code=500)
+            assert judge.warm_up() is False
+
+    def test_warmup_swallows_exceptions(self):
+        """Warmup never raises — transport errors return False."""
+        judge = IntentJudge()
+        with patch("jarvis.listening.intent_judge.requests") as mock_requests:
+            mock_requests.post.side_effect = RuntimeError("boom")
+            assert judge.warm_up() is False
+
+    def test_warmup_skipped_when_unavailable(self):
+        """Warmup is a no-op when requests isn't installed."""
+        judge = IntentJudge()
+        judge._available = False
+        assert judge.warm_up() is False
+
+
 class TestEchoFollowUpPattern:
     """Tests for echo + follow-up pattern handling."""
 

--- a/tests/test_voice_listener.py
+++ b/tests/test_voice_listener.py
@@ -1603,11 +1603,11 @@ class TestLlmWarmup:
         assert listener._llm_warmup_results["judge"] == ("gemma4:e2b", False)
 
 
-class TestWhisperSilentWarmup:
-    """Tests for the faster-whisper silent-audio warmup transcribe."""
+class TestWhisperWarmup:
+    """Tests for the faster-whisper warmup transcribe."""
 
-    def test_silent_warmup_runs_after_model_load(self):
-        """After a successful WhisperModel load, a silent transcribe is invoked."""
+    def test_warmup_runs_after_model_load(self):
+        """After a successful WhisperModel load, a warmup transcribe is invoked."""
         mock_whisper_model = MagicMock()
         mock_whisper_model.transcribe.return_value = (iter([]), MagicMock())
 
@@ -1641,4 +1641,6 @@ class TestWhisperSilentWarmup:
         first_call_args = mock_whisper_model.transcribe.call_args_list[0]
         audio_arg = first_call_args.args[0]
         assert audio_arg.shape[0] == listener._samplerate
-        assert (audio_arg == 0).all(), "warmup should use silent (zero) audio"
+        # Warmup must use non-silent audio so the decoder actually runs —
+        # silence trips faster-whisper's no-speech short-circuit.
+        assert not (audio_arg == 0).all(), "warmup should not use silent audio"

--- a/tests/test_voice_listener.py
+++ b/tests/test_voice_listener.py
@@ -1486,3 +1486,159 @@ class TestWhisperRateLimitRetry:
                             # Should have only tried once — no retry
                             mock_class.assert_called_once()
                             assert listener.model is None
+
+
+def _make_listener_for_warmup(
+    chat_model: str = "llama3.1",
+    judge_model: str | None = "gemma4:e2b",
+    base_url: str = "http://127.0.0.1:11434",
+):
+    """Construct a VoiceListener with enough stubs to exercise warmup only."""
+    with patch("jarvis.listening.listener.FASTER_WHISPER_AVAILABLE", True):
+        with patch("jarvis.listening.listener.MLX_WHISPER_AVAILABLE", False):
+            with patch("jarvis.listening.listener.sd") as mock_sd:
+                mock_sd.query_devices.return_value = [
+                    {"name": "Test Mic", "max_input_channels": 1}
+                ]
+
+                from jarvis.listening.listener import VoiceListener
+                from jarvis.listening.intent_judge import IntentJudge, IntentJudgeConfig
+
+                mock_cfg = _create_mock_config()
+                mock_cfg.ollama_chat_model = chat_model
+                mock_cfg.ollama_base_url = base_url
+                mock_cfg.llm_tools_timeout_sec = 8.0
+                mock_cfg.intent_judge_model = judge_model or ""
+                mock_cfg.intent_judge_timeout_sec = 10.0
+                mock_cfg.intent_judge_thinking_enabled = False
+                mock_cfg.wake_word = "jarvis"
+                mock_cfg.wake_aliases = []
+
+                listener = VoiceListener(MagicMock(), mock_cfg, MagicMock(), MagicMock())
+
+                if judge_model is not None:
+                    listener._intent_judge = IntentJudge(
+                        IntentJudgeConfig(model=judge_model, ollama_base_url=base_url)
+                    )
+                else:
+                    listener._intent_judge = None
+                return listener
+
+
+class TestLlmWarmup:
+    """Tests for VoiceListener._start_llm_warmup orchestration."""
+
+    def test_spawns_threads_for_chat_and_distinct_judge(self):
+        """Two threads when chat and judge point at different models."""
+        listener = _make_listener_for_warmup(
+            chat_model="llama3.1", judge_model="gemma4:e2b"
+        )
+        with patch(
+            "jarvis.listening.listener.warm_up_ollama_model", return_value=True
+        ) as chat_warm, patch(
+            "jarvis.listening.intent_judge.warm_up_ollama_model", return_value=True
+        ) as judge_warm:
+            threads = listener._start_llm_warmup()
+            for t in threads:
+                t.join(timeout=2.0)
+
+        assert len(threads) == 2
+        assert chat_warm.call_args.args[1] == "llama3.1"
+        assert judge_warm.call_args.args[1] == "gemma4:e2b"
+        assert listener._llm_warmup_results["chat"] == ("llama3.1", True)
+        assert listener._llm_warmup_results["judge"] == ("gemma4:e2b", True)
+
+    def test_deduplicates_when_chat_and_judge_share_model(self):
+        """One warmup covers both roles when models match."""
+        listener = _make_listener_for_warmup(
+            chat_model="llama3.1", judge_model="llama3.1"
+        )
+        with patch("jarvis.listening.listener.warm_up_ollama_model", return_value=True) as warm:
+            threads = listener._start_llm_warmup()
+            for t in threads:
+                t.join(timeout=2.0)
+
+        assert len(threads) == 1
+        assert warm.call_count == 1
+        assert listener._llm_warmup_results["chat"] == ("llama3.1", True)
+        assert listener._llm_warmup_results["judge"] == ("llama3.1", True)
+
+    def test_judge_only_when_no_chat_model(self):
+        """Judge still warms when chat model is absent."""
+        listener = _make_listener_for_warmup(chat_model="", judge_model="gemma4:e2b")
+        with patch(
+            "jarvis.listening.intent_judge.warm_up_ollama_model", return_value=True
+        ) as warm:
+            threads = listener._start_llm_warmup()
+            for t in threads:
+                t.join(timeout=2.0)
+
+        assert len(threads) == 1
+        assert warm.call_count == 1
+        assert listener._llm_warmup_results["judge"] == ("gemma4:e2b", True)
+        assert "chat" not in listener._llm_warmup_results
+
+    def test_empty_when_nothing_to_warm(self):
+        """No threads returned when chat and judge are both absent."""
+        listener = _make_listener_for_warmup(chat_model="", judge_model=None)
+        threads = listener._start_llm_warmup()
+        assert threads == []
+        assert listener._llm_warmup_results == {}
+
+    def test_records_failure_from_helper(self):
+        """A False return from the helper shows up in the results dict."""
+        listener = _make_listener_for_warmup(
+            chat_model="llama3.1", judge_model="gemma4:e2b"
+        )
+        with patch(
+            "jarvis.listening.listener.warm_up_ollama_model", return_value=False
+        ), patch(
+            "jarvis.listening.intent_judge.warm_up_ollama_model", return_value=False
+        ):
+            threads = listener._start_llm_warmup()
+            for t in threads:
+                t.join(timeout=2.0)
+
+        assert listener._llm_warmup_results["chat"] == ("llama3.1", False)
+        assert listener._llm_warmup_results["judge"] == ("gemma4:e2b", False)
+
+
+class TestWhisperSilentWarmup:
+    """Tests for the faster-whisper silent-audio warmup transcribe."""
+
+    def test_silent_warmup_runs_after_model_load(self):
+        """After a successful WhisperModel load, a silent transcribe is invoked."""
+        mock_whisper_model = MagicMock()
+        mock_whisper_model.transcribe.return_value = (iter([]), MagicMock())
+
+        with patch("jarvis.listening.listener.sys") as mock_sys:
+            mock_sys.platform = "linux"
+            with patch("jarvis.listening.listener.FASTER_WHISPER_AVAILABLE", True):
+                with patch("jarvis.listening.listener.MLX_WHISPER_AVAILABLE", False):
+                    with patch(
+                        "jarvis.listening.listener.WhisperModel",
+                        return_value=mock_whisper_model,
+                    ):
+                        with patch("jarvis.listening.listener.sd") as mock_sd:
+                            mock_sd.query_devices.return_value = [
+                                {"name": "Test Mic", "max_input_channels": 1}
+                            ]
+                            # Skip actual audio streaming — we only care about init.
+                            mock_sd.InputStream.side_effect = RuntimeError("stop here")
+
+                            from jarvis.listening.listener import VoiceListener
+
+                            mock_cfg = _create_mock_config()
+                            mock_cfg.ollama_chat_model = ""
+                            mock_cfg.ollama_base_url = ""
+                            mock_cfg.intent_judge_model = ""
+                            listener = VoiceListener(
+                                MagicMock(), mock_cfg, MagicMock(), MagicMock()
+                            )
+                            listener.run()
+
+        assert mock_whisper_model.transcribe.called, "warmup transcribe should have fired"
+        first_call_args = mock_whisper_model.transcribe.call_args_list[0]
+        audio_arg = first_call_args.args[0]
+        assert audio_arg.shape[0] == listener._samplerate
+        assert (audio_arg == 0).all(), "warmup should use silent (zero) audio"


### PR DESCRIPTION
## Summary

Pre-load Whisper, the chat model, and the intent judge model during listener startup so the first user engagement doesn't pay cold-load cost.

- LLM warmups (chat + intent judge) run in a background thread that overlaps with the Whisper load
- Added a silent-audio warmup transcribe for faster-whisper (MLX already had one)
- Results are joined with a 60s cap before announcing "🎙️  Listening!" — so the ready state actually means ready
- Ollama warmups use `keep_alive: 30m` to pin the models in memory

## Output grouping

All warmup output is grouped under a single `🔥 Warming up models...` header with 5-space child indentation, following the project's visual hierarchy convention:

\`\`\`
  🔥 Warming up models...
     🎤 Loading Whisper 'small' (device=cpu, compute=int8)...
     ⚡ CPU mode: using 8 threads with optimised decoding
     🎤 Whisper 'small' loaded on cpu
     💬 Chat model 'llama3.1' ready
     🧠 Intent judge 'gemma4:e2b' ready
🎙️  Listening! Try: "How's the weather, Jarvis?"
\`\`\`

## Test plan

- [x] New unit tests for `IntentJudge.warm_up()` covering success, HTTP error, transport error, and the unavailable case
- [x] Existing listening tests still pass (`test_intent_judge.py`, `test_listening_ux_overhaul.py`, `test_hot_window_input.py` — 111 passed)
- [ ] Manual: start the listener and confirm grouped warmup output renders correctly and "Listening!" only appears after models are hot

🤖 Generated with [Claude Code](https://claude.com/claude-code)