### PR TITLE
docs: codify issue-triage and PR-review workflow guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,11 +32,17 @@ Use [Conventional Commits](https://www.conventionalcommits.org/) for all commit 
 
 When pushing commits to a PR, always update the PR title and body to cover the entire changeset.
 
+After creating a PR, run the `/review-pr` skill on it before considering the task complete.
+
 Squash-merged commits on `develop` should only carry the PR number in the title (e.g. `(#171)`), never the originating issue number. Issue references belong in the commit body as `Closes #NNN` so that they auto-close when the commit reaches `main` on release.
 
 ## Issue Triage
 
 Never close an issue because its fix landed on `develop`. GitHub auto-closes issues when the `Closes #NNN` commit reaches `main` during a release, so a manual close on a develop-only fix is premature and drops the auto-close signal. The only legitimate manual closures are: duplicates (reference the canonical issue), insufficient info, user-environment issues, or not-a-bug.
+
+Before assuming you understand a reported issue, re-read the report and check whether key usage details are actually stated. If something is ambiguous (e.g. were they using the wake word? which model? which OS?), ask clarifying questions or offer guidance on correct usage rather than jumping to a diagnosis. Keep issues open until at least 2 weeks of reporter inactivity after a clarifying question or suggested fix — don't close them for silence before then.
+
+If you discover a past comment you made that was premature, wrong, or missed the point, edit or delete the original comment rather than leaving it and posting a follow-up correction. A clean thread is easier for reporters to follow than a trail of self-corrections.
 
 ## Releases
 


### PR DESCRIPTION
## Summary

Adds three practices to `CLAUDE.md` so future sessions pick them up automatically:

- **Issue triage — understand before diagnosing.** Re-read the report, ask clarifying questions (wake word? model? OS?) or offer usage guidance instead of jumping to a diagnosis. Keep issues open until at least 2 weeks of reporter inactivity after a clarifying question or suggested fix.
- **Fix past comments in place.** If an earlier comment was premature or wrong, edit/delete the original rather than posting a follow-up correction — cleaner threads for reporters.
- **Always `/review-pr` after opening a PR.** Added to the Git Workflow section.

## Why

Recent batch of issue closures went out same-day, some terse ("There is no information here"), without first asking what the reporter was doing or whether they were using the wake word. Reopened and edited-in-place during this session: #162, #205, #190, #196, #139.

## Test plan

- [x] `CLAUDE.md` renders as intended — diff is additive, three short paragraphs slotted into existing sections.
- [ ] Follow-up behaviour will be verified the next time an issue is triaged or a PR is opened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)