### PR TITLE
feat(logs): improve terminal log visual hierarchy

### DIFF
--- a/src/jarvis/daemon.py
+++ b/src/jarvis/daemon.py
@@ -458,8 +458,6 @@ def main() -> None:
     else:
         print("🎙️ Dictation disabled", flush=True)
 
-    print("─" * 50, flush=True)
-
     # Periodic diary update checking
     last_diary_check = time.time()
     diary_check_interval = 60.0

--- a/src/jarvis/listening/listener.py
+++ b/src/jarvis/listening/listener.py
@@ -1972,7 +1972,7 @@ class VoiceListener(threading.Thread):
 
             # Show ready message only after stream is confirmed active
             wake_word = getattr(self.cfg, "wake_word", "jarvis").lower()
-            print(f"🎙️  Listening! Try: \"How's the weather, {wake_word.title()}?\"", flush=True)
+            print(f"\n{'─' * 50}\n🎙️  Listening! Try: \"How's the weather, {wake_word.title()}?\"", flush=True)
 
             # Set face state to IDLE (awake and ready, waiting for wake word)
             try:

--- a/src/jarvis/listening/listener.py
+++ b/src/jarvis/listening/listener.py
@@ -2204,7 +2204,7 @@ class VoiceListener(threading.Thread):
             return
 
         # Log successful transcription
-        print(f"  📝 Heard: \"{text}\"", flush=True)
+        print(f"\n{'─' * 50}\n📝 Heard: \"{text}\"", flush=True)
 
         # Filter out repetitive hallucinations (e.g., "don't don't don't...")
         if self._is_repetitive_hallucination(text):

--- a/src/jarvis/listening/listener.py
+++ b/src/jarvis/listening/listener.py
@@ -263,6 +263,7 @@ class VoiceListener(threading.Thread):
         self.dialogue_memory = dialogue_memory
         self._should_stop = False
         self._dictation_active = False  # Pause flag set by dictation engine
+        self._first_utterance = True  # Suppress turn separator before the very first transcription
 
         # Audio processing components
         self._whisper_backend: Optional[str] = None  # "mlx" or "faster-whisper"
@@ -2203,8 +2204,11 @@ class VoiceListener(threading.Thread):
             self.state_manager.check_hot_window_expiry(self.cfg.voice_debug)
             return
 
-        # Log successful transcription
-        print(f"\n{'─' * 50}\n📝 Heard: \"{text}\"", flush=True)
+        # Log successful transcription — separator omitted on the first utterance since
+        # there is no prior turn to visually separate from.
+        separator = "" if self._first_utterance else f"\n{'─' * 50}"
+        self._first_utterance = False
+        print(f"{separator}\n📝 Heard: \"{text}\"", flush=True)
 
         # Filter out repetitive hallucinations (e.g., "don't don't don't...")
         if self._is_repetitive_hallucination(text):

--- a/src/jarvis/reply/engine.py
+++ b/src/jarvis/reply/engine.py
@@ -220,7 +220,7 @@ def run_reply_engine(db: "Database", cfg, tts: Optional[Any],
                 for entry in context_results[:3]:
                     # Show a short preview of each diary entry (first 80 chars)
                     preview = entry.strip().replace("\n", " ")[:80]
-                    print(f"     {preview}", flush=True)
+                    print(f"     · {preview}", flush=True)
                 debug_log(f"diary enrichment: {len(context_results)} results", "memory")
         except Exception as e:
             debug_log(f"diary enrichment failed: {e}", "memory")
@@ -281,9 +281,9 @@ def run_reply_engine(db: "Database", cfg, tts: Optional[Any],
                     print(f"  🧠 Knowledge: {len(graph_parts)} nodes — {names_str}", flush=True)
                     for name, reason in node_annotations[:4]:
                         if reason:
-                            print(f"     {name} → {reason}", flush=True)
+                            print(f"     · {name} → {reason}", flush=True)
                         else:
-                            print(f"     {name}", flush=True)
+                            print(f"     · {name}", flush=True)
             except Exception as e:
                 debug_log(f"graph enrichment failed: {e}", "memory")
 
@@ -833,7 +833,8 @@ def run_reply_engine(db: "Database", cfg, tts: Optional[Any],
 
         # Print error message
         try:
-            print(f"\n⚠️ Jarvis\n{reply}\n", flush=True)
+            indented_reply = "\n  ".join(reply.splitlines())
+            print(f"\n⚠️ Jarvis\n  {indented_reply}\n", flush=True)
         except Exception:
             pass
 
@@ -853,12 +854,13 @@ def run_reply_engine(db: "Database", cfg, tts: Optional[Any],
     if safe_reply:
         # Print reply with appropriate header
         try:
+            indented_safe_reply = "\n  ".join(safe_reply.splitlines())
             if not getattr(cfg, "voice_debug", False):
-                print(f"\n🤖 Jarvis\n" + safe_reply + "\n", flush=True)
+                print(f"\n🤖 Jarvis\n  {indented_safe_reply}\n", flush=True)
             else:
-                print(f"\n[jarvis]\n" + safe_reply + "\n", flush=True)
+                print(f"\n[jarvis]\n  {indented_safe_reply}\n", flush=True)
         except Exception:
-            print(f"\n[jarvis]\n" + safe_reply + "\n", flush=True)
+            print(f"\n[jarvis]\n  " + "\n  ".join(safe_reply.splitlines()) + "\n", flush=True)
 
         # TTS output - callbacks handled by calling code
         if tts is not None and tts.enabled:

--- a/src/jarvis/reply/engine.py
+++ b/src/jarvis/reply/engine.py
@@ -28,6 +28,11 @@ if TYPE_CHECKING:
 
 # ── Helpers ─────────────────────────────────────────────────────────────────
 
+
+def _indent_text(text: str, prefix: str = "  ") -> str:
+    return f"\n{prefix}".join(text.splitlines())
+
+
 # Stop words excluded from question→node matching (common words that inflate false matches).
 # The list is English-biased — the extractor prompt currently produces English questions. For
 # non-English questions nothing would be filtered here, which is a graceful degradation (noisier
@@ -833,10 +838,9 @@ def run_reply_engine(db: "Database", cfg, tts: Optional[Any],
 
         # Print error message
         try:
-            indented_reply = "\n  ".join(reply.splitlines())
-            print(f"\n⚠️ Jarvis\n  {indented_reply}\n", flush=True)
-        except Exception:
-            pass
+            print(f"\n⚠️ Jarvis\n  {_indent_text(reply)}\n", flush=True)
+        except Exception as e:
+            debug_log(f"error reply formatting failed: {e}", "planning")
 
         # Still add to dialogue memory so context is preserved
         if dialogue_memory is not None:
@@ -854,13 +858,12 @@ def run_reply_engine(db: "Database", cfg, tts: Optional[Any],
     if safe_reply:
         # Print reply with appropriate header
         try:
-            indented_safe_reply = "\n  ".join(safe_reply.splitlines())
             if not getattr(cfg, "voice_debug", False):
-                print(f"\n🤖 Jarvis\n  {indented_safe_reply}\n", flush=True)
+                print(f"\n🤖 Jarvis\n  {_indent_text(safe_reply)}\n", flush=True)
             else:
-                print(f"\n[jarvis]\n  {indented_safe_reply}\n", flush=True)
-        except Exception:
-            print(f"\n[jarvis]\n  " + "\n  ".join(safe_reply.splitlines()) + "\n", flush=True)
+                print(f"\n[jarvis]\n  {_indent_text(safe_reply)}\n", flush=True)
+        except Exception as e:
+            debug_log(f"reply formatting failed: {e}", "planning")
 
         # TTS output - callbacks handled by calling code
         if tts is not None and tts.enabled:


### PR DESCRIPTION
## Summary

- Adds a \`──────────────────────────────────────────────────\` separator before each \`📝 Heard:\` line, clearly delineating conversation turns
- Promotes \`📝 Heard:\` to top-level (removes the 2-space indent) so it acts as the visual anchor for a turn, with all processing detail indented beneath it
- Adds \`·\` bullet prefix to diary entries and knowledge nodes, making them easier to scan as list items
- Indents the Jarvis response body by 2 spaces under the \`🤖 Jarvis\` header via a shared \`_indent_text()\` helper
- Replaces bare \`except Exception: pass\` with \`debug_log\` so stdout encoding failures stay visible

**Before:**
\`\`\`
📝 Heard: "tell me something about myself."
🧠 Intent (wake word): directed → "tell me something"
✨ Working on it: tell me something
  📖 Diary: recalled 2 entries
     [2025-08-19] SUMMARY: ...
  🧠 Knowledge: 2 nodes — Local & Events

🤖 Jarvis
You mentioned an interest...
\`\`\`

**After:**
\`\`\`
──────────────────────────────────────────────────
📝 Heard: "tell me something about myself."
  🧠 Intent (wake word): directed → "tell me something"

✨ Working on it: tell me something
  📖 Diary: recalled 2 entries
     · [2025-08-19] SUMMARY: ...
  🧠 Knowledge: 2 nodes — Local & Events
     · Local & Events

🤖 Jarvis
  You mentioned an interest...
\`\`\`

## Test plan

- [ ] Run Jarvis, speak a query — confirm separator appears before each Heard line
- [ ] Confirm diary entries and knowledge nodes show \`·\` prefix
- [ ] Confirm Jarvis response body is indented 2 spaces
- [ ] Confirm multi-line responses indent all lines correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)