### PR TITLE
fix(updater): robust cross-platform install with visible progress and rollback

### DIFF
--- a/src/desktop_app/desktop_app.spec.md
+++ b/src/desktop_app/desktop_app.spec.md
@@ -200,9 +200,9 @@ Updates are only available in bundled mode (PyInstaller builds).
 
 | Platform | Strategy |
 |----------|----------|
-| **macOS** | Uses AppleScript to move current app to trash, move new app in place, and relaunch (synchronous, works because Unix allows moving running apps) |
-| **Windows** | Creates a batch script that waits for the current process (by PID via `tasklist`) to exit, then replaces the executable and relaunches |
-| **Linux** | Creates a shell script that waits for the current process (by PID via `kill -0`) to exit, then replaces the directory and relaunches |
+| **macOS** | Creates a shell script that waits for the current process (by PID via `kill -0`) to exit, moves the old `.app` aside to `Jarvis.app.backup` (one-generation rollback), moves the new bundle in, strips `com.apple.quarantine` so Gatekeeper doesn't re-prompt on unsigned builds, and relaunches via `open`. No Finder/AppleScript automation. Pattern mirrors Squirrel.Mac's `ShipIt` helper. |
+| **Windows** | Creates a batch script that waits for the current process (by PID via `tasklist`) to exit, then runs the Inno Setup installer with `/SILENT` so the installer's own progress window provides visual feedback during install, then relaunches the upgraded exe. Rollback is handled by Inno Setup's own in-session rollback + retained uninstaller data. |
+| **Linux** | Creates a shell script that waits for the current process (by PID via `kill -0`) to exit, moves the old directory to `Jarvis.backup` for rollback, moves the new directory in, and relaunches |
 
 ### Update Flow (Windows/Linux)
 
@@ -231,6 +231,9 @@ sequenceDiagram
 - **Diary is saved before update installation**: The `pre_install_callback` mechanism ensures the diary is saved before the update process begins, so no data is lost
 - **Asset ID tracking**: For develop channel updates (where version stays "latest"), we track the GitHub asset ID to detect new builds
 - **Robust Windows update**: The batch script waits for the actual process to exit (by PID) rather than using a fixed timeout, ensuring the update doesn't fail due to slow shutdown
+- **Visible Windows install progress**: The Inno Setup installer runs with `/SILENT` (not `/VERYSILENT`) so its own progress window is visible while the install runs — bridging the gap between the download dialog closing and the new app launching, which would otherwise look like a hang
+- **Quarantine stripping (macOS)**: The shell script runs `xattr -dr com.apple.quarantine` on the newly-installed bundle. Builds are unsigned (ad-hoc signing breaks Qt WebEngine's symlinks — see `release.yml`), so without this step Gatekeeper may re-trigger the "unidentified developer" prompt on every update
+- **One-generation rollback (macOS, Linux)**: The previous `.app` / directory is moved aside to `<name>.backup` rather than deleted outright, so a user can restore the prior version manually if the new one fails to launch. The backup from the previous update is cleared before creating a new one, so at most one backup exists on disk at a time. This is a simplified version of Squirrel's versioned-folder rollback — enough safety for a single-bundle install, without the architectural overhead
 
 ## Memory Viewer
 

--- a/src/desktop_app/updater.py
+++ b/src/desktop_app/updater.py
@@ -338,17 +338,17 @@ def is_frozen() -> bool:
 def install_update_macos(download_path: Path) -> bool:
     """Install update on macOS.
 
-    Strategy:
-    1. Extract zip to temp location
-    2. Move current app to trash
-    3. Move new app to original location
-    4. Launch new app
-    5. Exit current app
+    Strategy mirrors Linux: write a shell script that waits for the current
+    process to exit, replaces the .app bundle with `rm -rf` + `mv`, relaunches
+    via `open`, and cleans up temp. Using plain Unix file operations avoids
+    the Finder/AppleScript automation prompts that were failing mid-install
+    and leaving users with a trashed app and no replacement.
     """
     import zipfile
 
     app_path = get_app_path()
     temp_dir = Path(tempfile.mkdtemp())
+    current_pid = os.getpid()
 
     try:
         with zipfile.ZipFile(download_path, "r") as zf:
@@ -359,29 +359,43 @@ def install_update_macos(download_path: Path) -> bool:
         if not new_app_path.exists():
             raise FileNotFoundError("Jarvis.app not found in download")
 
-        # Use AppleScript to move to trash and replace
-        # Escape paths to prevent injection if paths contain quotes
-        escaped_app = _escape_applescript_path(app_path)
-        escaped_new_app = _escape_applescript_path(new_app_path)
-        escaped_parent = _escape_applescript_path(app_path.parent)
-        script = f'''
-        tell application "Finder"
-            move POSIX file "{escaped_app}" to trash
-            move POSIX file "{escaped_new_app}" to folder "{escaped_parent}"
-        end tell
-        '''
-        subprocess.run(["osascript", "-e", script], check=True)
+        escaped_app = _escape_shell_path(app_path)
+        escaped_backup = _escape_shell_path(app_path.with_suffix(app_path.suffix + ".backup"))
+        escaped_new_app = _escape_shell_path(new_app_path)
+        escaped_temp = _escape_shell_path(temp_dir)
 
-        # Launch new app
-        subprocess.Popen(["open", str(app_path.parent / "Jarvis.app")])
+        # The quarantine strip is essential for unsigned builds: without it,
+        # Gatekeeper may re-prompt with "unidentified developer" on every
+        # update. Keeping the previous bundle as .backup provides a one-step
+        # rollback if the new version fails to launch.
+        script_path = temp_dir / "update.sh"
+        script_content = f'''#!/bin/bash
+echo "Updating Jarvis..."
+echo "Waiting for process {current_pid} to exit..."
+while kill -0 {current_pid} 2>/dev/null; do
+    sleep 1
+done
+echo "Process exited, applying update..."
+rm -rf {escaped_backup}
+if [ -e {escaped_app} ]; then
+    mv {escaped_app} {escaped_backup}
+fi
+mv {escaped_new_app} {escaped_app}
+xattr -dr com.apple.quarantine {escaped_app} 2>/dev/null || true
+open {escaped_app}
+rm -rf {escaped_temp}
+'''
+        script_path.write_text(script_content)
+        script_path.chmod(0o755)
+
+        subprocess.Popen([str(script_path)], start_new_session=True)
 
         return True
 
     except Exception as e:
         debug_log(f"macOS update failed: {e}", "updater")
-        return False
-    finally:
         shutil.rmtree(temp_dir, ignore_errors=True)
+        return False
 
 
 def install_update_windows(download_path: Path) -> bool:
@@ -417,11 +431,13 @@ def install_update_windows(download_path: Path) -> bool:
 
         batch_script = temp_dir / "update.bat"
         # Wait for the current process to exit by checking if PID still exists.
-        # This is more reliable than a fixed timeout since the app may take time
-        # to shut down (e.g., saving diary entries).
         # tasklist returns errorlevel 0 if process found, 1 if not found.
-        # After the silent installer finishes the installer's own [Run] launch
-        # step is skipped (skipifsilent), so we relaunch the upgraded exe here.
+        # We use /SILENT (not /VERYSILENT) so Inno Setup shows its own progress
+        # window during install — otherwise the user sees nothing between the
+        # download dialog closing and the new app launching, which can take
+        # long enough to feel like a hang. The installer's own [Run] launch
+        # step is still skipped under /SILENT (skipifsilent), so we relaunch
+        # the upgraded exe ourselves.
         batch_content = f'''@echo off
 echo Updating Jarvis...
 echo Waiting for process {current_pid} to exit...
@@ -432,7 +448,7 @@ if not errorlevel 1 (
     goto wait_loop
 )
 echo Process exited, running installer...
-"{escaped_new_exe}" /VERYSILENT /SUPPRESSMSGBOXES /NORESTART
+"{escaped_new_exe}" /SILENT /SUPPRESSMSGBOXES /NORESTART
 echo Launching updated Jarvis...
 start "" "{escaped_installed_exe}"
 rmdir /s /q "{escaped_temp}"
@@ -482,14 +498,14 @@ def install_update_linux(download_path: Path) -> bool:
 
         # Escape paths using single quotes to prevent shell injection
         escaped_app_dir = _escape_shell_path(app_dir)
+        escaped_backup = _escape_shell_path(app_dir.with_name(app_dir.name + ".backup"))
         escaped_new_app = _escape_shell_path(new_app_dir)
         escaped_temp = _escape_shell_path(temp_dir)
         escaped_jarvis = _escape_shell_path(app_dir / "Jarvis")
 
         script_path = temp_dir / "update.sh"
-        # Wait for the current process to exit by checking if PID still exists.
-        # This is more reliable than a fixed timeout since the app may take time
-        # to shut down (e.g., saving diary entries).
+        # Keeping the previous directory as .backup gives the user a one-step
+        # rollback if the new version fails to launch.
         script_content = f'''#!/bin/bash
 echo "Updating Jarvis..."
 echo "Waiting for process {current_pid} to exit..."
@@ -497,7 +513,10 @@ while kill -0 {current_pid} 2>/dev/null; do
     sleep 1
 done
 echo "Process exited, applying update..."
-rm -rf {escaped_app_dir}
+rm -rf {escaped_backup}
+if [ -e {escaped_app_dir} ]; then
+    mv {escaped_app_dir} {escaped_backup}
+fi
 mv {escaped_new_app} {escaped_app_dir}
 {escaped_jarvis} &
 rm -rf {escaped_temp}

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -466,8 +466,12 @@ class TestInstallUpdateWindows:
             assert "tasklist" in batch_content
             assert "Process exited" in batch_content
 
-            # Verify the installer is run silently (not the old move/replace approach)
-            assert "/VERYSILENT" in batch_content
+            # Verify the installer is run silently (not the old move/replace approach).
+            # We use /SILENT rather than /VERYSILENT so Inno Setup shows its own
+            # progress window during install — otherwise the user sees nothing
+            # between the download dialog closing and the new app launching.
+            assert "/SILENT" in batch_content
+            assert "/VERYSILENT" not in batch_content
             assert "/SUPPRESSMSGBOXES" in batch_content
             assert "move /y" not in batch_content
 
@@ -516,11 +520,95 @@ class TestInstallUpdateWindows:
 
         # The launch must come after the installer line so the new binary is
         # in place when it runs.
-        installer_idx = batch_content.find("/VERYSILENT")
+        installer_idx = batch_content.find("/SILENT")
         launch_idx = batch_content.find(f'start "" "{mock_app_path}"')
         assert installer_idx != -1, "installer line missing"
         assert launch_idx != -1, "start line for upgraded exe missing"
         assert launch_idx > installer_idx, "launch must follow install"
+
+
+class TestInstallUpdateMacos:
+    """Tests for macOS update installation."""
+
+    @pytest.mark.unit
+    def test_shell_script_waits_for_pid_and_relaunches(self, tmp_path):
+        """macOS installer must wait for the current PID to exit, replace the
+        bundle with plain file ops (no Finder automation), and relaunch.
+
+        The previous AppleScript/Finder approach was failing mid-install on
+        some machines — it would trash the old app, prompt for file-editing
+        permission, then error out, leaving the user with no app. The shell
+        script approach matches Linux and avoids Finder entirely.
+        """
+        import os
+        import zipfile
+        from unittest.mock import patch, MagicMock
+
+        zip_path = tmp_path / "update.zip"
+        app_source = tmp_path / "zip_content" / "Jarvis.app"
+        app_source.mkdir(parents=True)
+        (app_source / "Contents").mkdir()
+        (app_source / "Contents" / "Info.plist").write_bytes(b"mock plist")
+
+        with zipfile.ZipFile(zip_path, "w") as zf:
+            for f in app_source.rglob("*"):
+                if f.is_file():
+                    zf.write(f, arcname=str(f.relative_to(tmp_path / "zip_content")))
+
+        mock_app_path = tmp_path / "Applications" / "Jarvis.app"
+        mock_app_path.mkdir(parents=True)
+        (mock_app_path / "existing").write_bytes(b"old bundle")
+
+        from desktop_app.updater import install_update_macos
+
+        script_content_captured = []
+
+        def capture_popen(args, **kwargs):
+            if len(args) == 1 and args[0].endswith("update.sh"):
+                script_path = Path(args[0])
+                if script_path.exists():
+                    script_content_captured.append(script_path.read_text())
+            return MagicMock()
+
+        with patch("desktop_app.updater.get_app_path", return_value=mock_app_path):
+            with patch("desktop_app.updater.subprocess.Popen", side_effect=capture_popen):
+                result = install_update_macos(zip_path)
+
+        assert result is True
+        assert len(script_content_captured) == 1
+        script_content = script_content_captured[0]
+
+        current_pid = os.getpid()
+        assert f"kill -0 {current_pid}" in script_content
+        assert "sleep 1" in script_content
+        # No Finder automation
+        assert "osascript" not in script_content
+        assert "Finder" not in script_content
+        # Bundle is replaced and relaunched
+        assert "mv " in script_content
+        assert "open " in script_content
+
+        # Previous bundle is preserved as a .backup for rollback, not deleted.
+        # This is important: if the new version fails to launch, the user can
+        # restore the backup manually.
+        backup_path = str(mock_app_path) + ".backup"
+        assert backup_path in script_content
+        assert f"mv '{mock_app_path}' '{backup_path}'" in script_content
+        # The old .backup from the previous update is cleared first.
+        assert f"rm -rf '{backup_path}'" in script_content
+
+        # Quarantine xattr is stripped so Gatekeeper doesn't re-prompt on every
+        # update for unsigned builds.
+        assert "xattr -dr com.apple.quarantine" in script_content
+
+        clear_backup_idx = script_content.find(f"rm -rf '{backup_path}'")
+        move_to_backup_idx = script_content.find(f"mv '{mock_app_path}' '{backup_path}'")
+        install_idx = script_content.find(f"mv '") # first mv is to backup, find install
+        xattr_idx = script_content.find("xattr -dr com.apple.quarantine")
+        open_idx = script_content.find("open ")
+        assert clear_backup_idx < move_to_backup_idx, "must clear old backup before creating new one"
+        assert move_to_backup_idx < xattr_idx, "backup happens before xattr strip"
+        assert xattr_idx < open_idx, "xattr strip must precede launch"
 
 
 class TestInstallUpdateLinux:
@@ -575,6 +663,11 @@ class TestInstallUpdateLinux:
                 assert "while" in script_content
                 assert "sleep 1" in script_content
                 assert "Process exited" in script_content
+
+                # Previous directory is kept as .backup for rollback.
+                backup_path = str(mock_app_dir) + ".backup"
+                assert backup_path in script_content
+                assert f"mv '{mock_app_dir}' '{backup_path}'" in script_content
 
 
 class TestPathEscaping:


### PR DESCRIPTION
## Summary

Fixes two reported update-flow bugs and hardens the installer against future failure modes:

- **macOS: \"Installation failed\" after the old app is trashed.** The previous AppleScript/Finder approach could move the current app to trash, prompt for file-editing permission, then fail mid-script — leaving users with no app at all. Replaced with a shell script that waits for the parent PID, swaps the bundle with `rm -rf` + `mv`, and relaunches via `open`. No Finder automation. Pattern mirrors Squirrel.Mac's `ShipIt` helper.
- **Windows: long blank gap between download finishing and the new version launching.** Inno Setup was running with `/VERYSILENT`, which shows nothing. Switched to `/SILENT` so the installer's own progress window is visible during install. On slower disks the old behaviour looked like a hang.

## Additional hardening (based on reviewing Sparkle / Squirrel.Mac / Squirrel.Windows)

- **Quarantine strip (macOS)**: `xattr -dr com.apple.quarantine` on the new bundle. Specifically matters for us because our builds are intentionally unsigned (ad-hoc `codesign --force --deep` breaks Qt WebEngine symlinks — see `release.yml`). Without the strip, Gatekeeper could re-trigger \"unidentified developer\" on every update.
- **One-generation rollback (macOS + Linux)**: the old bundle/directory is moved to `<name>.backup` instead of deleted. The prior backup is cleared first, so at most one backup exists on disk at a time. If a new version fails to launch, the user can restore the previous one manually. Simpler than Squirrel's versioned-folder architecture but covers the main risk.
- **Windows rollback** continues to rely on Inno Setup's in-session rollback and retained uninstaller data (a full Squirrel.Windows-style rewrite was out of scope).

## What changed

- `src/desktop_app/updater.py` — rewrote `install_update_macos` (shell script, no Finder), switched Windows installer to `/SILENT`, added rollback to macOS and Linux shell scripts, added xattr strip on macOS.
- `tests/test_updater.py` — added a `TestInstallUpdateMacos` class mirroring the Linux test, updated Windows tests for `/SILENT`, extended Linux test to check the new backup behaviour.
- `src/desktop_app/desktop_app.spec.md` — updated the platform-strategy table and the \"Important Notes\" section.

## Test plan

- [x] `pytest tests/test_updater.py` — all 36 tests pass
- [ ] Manual: trigger an update on macOS, verify the new bundle launches without a Gatekeeper prompt and that `Jarvis.app.backup` exists afterwards
- [ ] Manual: trigger an update on Windows, verify the Inno Setup progress window is visible during install and the new version launches
- [ ] Manual: verify the backup from the previous update is cleared (not accumulated) on the next update

🤖 Generated with [Claude Code](https://claude.com/claude-code)