### PR TITLE
test(dictation): stop clipboard test from pasting into real apps

### DIFF
--- a/tests/test_dictation.py
+++ b/tests/test_dictation.py
@@ -546,10 +546,14 @@ class TestClipboard:
         _clipboard_paste("hello")
         mock_clip_win.assert_called_once_with("hello")
 
+    @patch("src.jarvis.dictation.dictation_engine._paste_cgevent", return_value=True)
+    @patch("src.jarvis.dictation.dictation_engine._check_macos_accessibility", return_value=True)
     @patch("src.jarvis.dictation.dictation_engine.platform")
     @patch("src.jarvis.dictation.dictation_engine._clipboard_macos")
     @patch("src.jarvis.dictation.dictation_engine.pynput_keyboard")
-    def test_clipboard_paste_macos(self, mock_kb, mock_clip_mac, mock_platform):
+    def test_clipboard_paste_macos(
+        self, mock_kb, mock_clip_mac, mock_platform, mock_ax, mock_cge
+    ):
         from src.jarvis.dictation.dictation_engine import _clipboard_paste
         mock_platform.system.return_value = "Darwin"
         mock_ctrl = MagicMock()
@@ -558,6 +562,10 @@ class TestClipboard:
 
         _clipboard_paste("hello mac")
         mock_clip_mac.assert_called_once_with("hello mac")
+        # Guard: the real CGEvent paste and Accessibility check must never
+        # fire during tests — they would emit a real Cmd+V into whatever
+        # window has focus and pop open System Settings.
+        mock_cge.assert_called_once()
 
     def test_clipboard_paste_empty_string_is_noop(self):
         from src.jarvis.dictation.dictation_engine import _clipboard_paste


### PR DESCRIPTION
## Summary

- `test_clipboard_paste_macos` forced `platform.system()` to `\"Darwin\"` and ran the real `_clipboard_paste`, but only mocked `_clipboard_macos` and `pynput_keyboard` — **not** `_paste_cgevent` or `_check_macos_accessibility`.
- On every full test run on a real macOS host this posted a real **Cmd+V** via the CoreGraphics HID event tap (pasting whatever was on the clipboard into the focused window) and, whenever the Python process wasn't Accessibility-trusted, popped open **System Settings → Privacy & Security → Accessibility**.
- Fix: patch both helpers in the test and assert the CGEvent path is the one exercised, so any future regression of this shape fails loudly instead of typing into the user's apps.

## Why it matters

Reported symptom: running the full test suite caused the clipboard to keep pasting, and a system window (the Accessibility pane) appeared on its own even with no Jarvis daemon running. The test itself was the driver.

## Test plan

- [x] `pytest tests/test_dictation.py::TestClipboard -x` passes
- [ ] Full `pytest` run on macOS no longer triggers real Cmd+V or opens System Settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)