### PR TITLE
feat(memory): recency-weight diary enrichment so newer entries supersede older ones

### DIFF
--- a/evals/test_recency_superseding.py
+++ b/evals/test_recency_superseding.py
@@ -21,6 +21,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import List, Optional
+from unittest.mock import patch
 
 import pytest
 
@@ -272,4 +273,105 @@ Question: Based on these entries, what is the current/latest information about: 
             f"Judge identified wrong date as newer. "
             f"Expected {case.new_date}, got {verdict.get('newer_date')}. "
             f"Reasoning: {verdict.get('reasoning')}"
+        )
+
+
+# =============================================================================
+# Tests: End-to-End — reply engine honours newer diary entries
+# =============================================================================
+
+# Models to exercise end-to-end. The small model is expected to be flaky on this
+# task (conflicting facts + recency reasoning), so it's marked xfail rather than
+# skipped — we still want to catch a surprise improvement.
+_E2E_MODELS = [
+    pytest.param("gpt-oss:20b", id="gpt-oss:20b"),
+    pytest.param(
+        "gemma4:e2b",
+        id="gemma4:e2b",
+        marks=pytest.mark.xfail(
+            reason="Small model flakes on recency-superseding — tracked, not blocking",
+            strict=False,
+        ),
+    ),
+]
+
+
+def _query_for_case(case: "SupersedingCase") -> str:
+    """Build a natural-language query that targets the entity in conflict."""
+    desc = case.description.lower()
+    if "office" in desc:
+        return "Which days do I go into the office these days?"
+    if "diet" in desc:
+        return "What does my current diet look like — calories and protein?"
+    return f"What's the latest on: {case.description}?"
+
+
+@pytest.mark.eval
+class TestReplyUsesNewerDiaryEntry:
+    """End-to-end: with conflicting diary entries, the reply should reflect
+    the newer one. Exercises the full reply engine (enrichment retrieval,
+    injection ordering, and preamble framing)."""
+
+    @requires_judge_llm
+    @pytest.mark.parametrize("model", _E2E_MODELS)
+    @pytest.mark.parametrize("case", SUPERSEDING_CASES)
+    def test_reply_reflects_newer_entry(
+        self, case, model, mock_config, eval_db, eval_dialogue_memory
+    ):
+        case = case.values[0] if hasattr(case, 'values') else case
+
+        from jarvis.reply.engine import run_reply_engine
+
+        # Seed diary with older (wrong) then newer (correct) entry.
+        eval_db.upsert_conversation_summary(
+            date_utc=case.old_date,
+            summary=case.old_entry,
+            topics=",".join(case.search_keywords),
+            source_app="test",
+        )
+        eval_db.upsert_conversation_summary(
+            date_utc=case.new_date,
+            summary=case.new_entry,
+            topics=",".join(case.search_keywords),
+            source_app="test",
+        )
+
+        mock_config.ollama_chat_model = model
+        mock_config.memory_enrichment_source = "diary"
+
+        query = _query_for_case(case)
+
+        with patch(
+            'jarvis.reply.engine.get_location_context_with_timezone',
+            return_value=("Location: London, United Kingdom", None),
+        ):
+            reply = run_reply_engine(
+                db=eval_db,
+                cfg=mock_config,
+                tts=None,
+                text=query,
+                dialogue_memory=eval_dialogue_memory,
+            )
+
+        assert reply and reply.strip(), f"[{model}] Reply engine returned empty response"
+
+        reply_lower = reply.lower()
+        has_newer = any(kw.lower() in reply_lower for kw in case.newer_value_keywords)
+        has_only_older = (
+            not has_newer
+            and any(kw.lower() in reply_lower for kw in case.older_value_keywords)
+        )
+
+        print(f"\n  🤖 {model} reply to: {query}")
+        print(f"     {reply[:240]}")
+        print(f"     newer kws {case.newer_value_keywords} present: {has_newer}")
+
+        assert not has_only_older, (
+            f"[{model}] Reply used ONLY older info "
+            f"({case.older_value_keywords}) and ignored newer entry "
+            f"({case.newer_value_keywords}).\nReply: {reply}"
+        )
+        assert has_newer, (
+            f"[{model}] Reply did not reflect newer diary entry "
+            f"({case.newer_value_keywords}).\nReply: {reply}"
         )

--- a/src/jarvis/memory/conversation.py
+++ b/src/jarvis/memory/conversation.py
@@ -513,8 +513,11 @@ def search_conversation_memory_by_keywords(
                 date_str = result_text[1:11] if result_text.startswith('[') and len(result_text) > 11 else ''
                 scored_results.append((float(score) if score else 0.0, date_str, result_text))
 
-        # Sort by relevance score DESC, then date DESC (newer wins ties)
-        scored_results.sort(key=lambda x: (x[0], x[1]), reverse=True)
+        # Sort newest-first so recency-superseding works at the injection site:
+        # when two entries disagree, the model sees the newer one first and the
+        # preamble in the reply engine tells it to treat the newer entry as the
+        # user's current understanding. Fall back to relevance score as tiebreak.
+        scored_results.sort(key=lambda x: (x[1], x[0]), reverse=True)
         contexts = [text for _, _, text in scored_results]
 
         debug_log(f"      ✅ found {len(contexts)} keyword search results", "memory")

--- a/src/jarvis/reply/engine.py
+++ b/src/jarvis/reply/engine.py
@@ -362,7 +362,12 @@ def run_reply_engine(db: "Database", cfg, tts: Optional[Any],
             )
 
         if conversation_context:
-            guidance.append("\nRelevant conversation history:\n" + conversation_context)
+            guidance.append(
+                "\nRelevant conversation history (newest first, dated as "
+                "[YYYY-MM-DD]). When entries disagree, treat the most recent "
+                "entry as the user's current understanding and preferences — "
+                "it supersedes older entries:\n" + conversation_context
+            )
 
         if graph_context:
             guidance.append("\n" + graph_context)

--- a/src/jarvis/reply/reply.spec.md
+++ b/src/jarvis/reply/reply.spec.md
@@ -49,7 +49,7 @@ Design principles enforced by the engine:
    - Start with the unified `SYSTEM_PROMPT`.
    - Append ASR note: inputs come from speech transcription and may include errors; prefer user intent and ask brief clarifying questions when uncertain.
    - Append the tool-use protocol (allowed response formats and MCP invocation format if configured).
-   - Append `Relevant conversation history:` when enrichment produced context.
+   - Append `Relevant conversation history:` when enrichment produced context. Entries are ordered newest-first (with `[YYYY-MM-DD]` prefixes preserved) and the preamble instructs the model that when entries disagree, the most recent entry reflects the user's current understanding and supersedes older entries. This prevents stale diary facts from overriding more recent corrections.
    - Append `Tools:` with the dynamically generated tool descriptions (including configured MCP servers, if any) and guidance for preferring real data over shell commands.
 
 6. Agentic Messages Loop with Dynamic Context


### PR DESCRIPTION
## Summary

When two diary entries disagree, the reply should reflect the newer one — it represents the user's current understanding. Previously, multiple days' summaries were injected with equal weight and an older (wrong) entry could win over a newer correction.

- Sort diary search results newest-first (date DESC, relevance score as tiebreaker) so the injection site sees recent entries first.
- Reframe the enrichment preamble to tell the model entries are newest-first and that the most recent entry supersedes older ones when they disagree.
- Update `reply.spec.md` to document the recency-superseding contract.
- Add end-to-end eval `TestReplyUsesNewerDiaryEntry` covering `gpt-oss:20b` and `gemma4:e2b` (xfail, non-strict) — seeds a wrong diary entry, then a newer corrected one, and asserts the reply reflects the newer info.

Sibling to #232 which reframed enrichment as reference-only — this adds recency-weighting without suppressing instructions.

## Test plan

- [x] `pytest evals/test_recency_superseding.py::TestDiaryRecencyOrder` — sort change keeps existing ordering guarantees
- [x] `pytest evals/test_recency_superseding.py::TestGraphRecencySuperseding` — graph superseding unchanged
- [x] `pytest tests/test_diary_enrichment_flow.py` — diary → enrichment pipeline still works
- [ ] Live end-to-end eval with `gpt-oss:20b` (requires local Ollama): `pytest evals/test_recency_superseding.py::TestReplyUsesNewerDiaryEntry`
- [ ] Manual check: chat about something (e.g. office days), correct it in a later session, verify Jarvis reflects the correction

🤖 Generated with [Claude Code](https://claude.com/claude-code)