### PR TITLE
fix(desktop_app): absolute import in app.py entry point

### DIFF
--- a/src/desktop_app/app.py
+++ b/src/desktop_app/app.py
@@ -245,7 +245,7 @@ def setup_crash_logging():
 
 def get_crash_paths() -> tuple[Path, Path, Path]:
     """Get paths for crash log, marker, and previous crash log."""
-    from .paths import get_log_dir
+    from desktop_app.paths import get_log_dir
     log_dir = get_log_dir()
 
     crash_log = log_dir / "jarvis_desktop_crash.log"

--- a/tests/test_desktop_app.py
+++ b/tests/test_desktop_app.py
@@ -14,6 +14,38 @@ from pathlib import Path
 from unittest.mock import patch, MagicMock
 
 
+class TestEntryPointImports:
+    """Guardrails for the PyInstaller entry point (src/desktop_app/app.py).
+
+    PyInstaller freezes app.py as __main__ with no parent package, so any
+    relative import (`from .foo import ...`) raises ImportError at launch
+    and the bundled app exits silently. Regression guard for the #242 bug
+    where `from .paths import get_log_dir` inside get_crash_paths() broke
+    every macOS launch.
+    """
+
+    def test_app_py_has_no_relative_imports(self):
+        """app.py is the frozen entry point — must use absolute imports only."""
+        import ast
+        from pathlib import Path
+
+        app_py = Path(__file__).parent.parent / "src" / "desktop_app" / "app.py"
+        tree = ast.parse(app_py.read_text(encoding="utf-8"))
+
+        relative_imports = [
+            f"line {node.lineno}: from {'.' * node.level}{node.module or ''} import ..."
+            for node in ast.walk(tree)
+            if isinstance(node, ast.ImportFrom) and node.level > 0
+        ]
+
+        assert not relative_imports, (
+            "app.py is the PyInstaller entry point and runs as __main__ with "
+            "no package context. Relative imports will raise ImportError at "
+            "launch. Use `from desktop_app.X import ...` instead.\n"
+            "Offenders:\n  " + "\n  ".join(relative_imports)
+        )
+
+
 class TestGetCrashPaths:
     """Tests for get_crash_paths() function."""
 


### PR DESCRIPTION
## Summary

- PR #242 introduced `from .paths import get_log_dir` inside `get_crash_paths()` in [src/desktop_app/app.py](src/desktop_app/app.py). Since PyInstaller freezes `app.py` as `__main__` with no package context, the relative import raised `ImportError` on every macOS launch — before `setup_crash_logging()` could even redirect stderr. The bundled app exited silently.
- The failure was masked by the pre-#244 broken zip (Gatekeeper's generic "can't be opened" message kicked in first). Once #244 landed and the bundle was structurally extractable, the real traceback surfaced when users launched from Terminal:
  ```
  File "app.py", line 248, in get_crash_paths
  ImportError: attempted relative import with no known parent package
  ```
- Fixed by switching to `from desktop_app.paths import get_log_dir`, matching every other import in `app.py`. Added an AST-based guard test that scans `app.py` for any `from .X import` — existing tests passed because pytest imports `app.py` through the `desktop_app` package, exactly the case PyInstaller does not reproduce.

Closes the launch regression surfaced in #244's release and restores macOS launch for users who have already auto-updated.

## Test plan

- [x] `pytest tests/test_desktop_app.py::TestEntryPointImports` passes
- [x] Verified the new guard test fails when the relative import is reintroduced
- [ ] Manual: launch a freshly-built macOS bundle and confirm the app starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)