### PR TITLE
feat(web_search): show search query in user log line

### DIFF
--- a/src/jarvis/tools/builtin/web_search.py
+++ b/src/jarvis/tools/builtin/web_search.py
@@ -368,7 +368,6 @@ class WebSearchTool(Tool):
 
     def run(self, args: Optional[Dict[str, Any]], context: ToolContext) -> ToolExecutionResult:
         """Execute web search using DuckDuckGo."""
-        context.user_print("🌐 Searching the web…")
         cfg = context.cfg
         try:
             if not getattr(cfg, "web_search_enabled", True):
@@ -383,6 +382,7 @@ class WebSearchTool(Tool):
             if not search_query:
                 return ToolExecutionResult(success=False, reply_text="Please provide a search query for the web search.")
 
+            context.user_print(f"🌐 Searching the web for '{search_query}'…")
             debug_log(f"    🌐 searching for '{search_query}'", "web")
 
             # Overall wall-clock deadline across the full provider chain.


### PR DESCRIPTION
## Summary
- The web search tool's initial user-facing log line now includes the query (e.g. `🌐 Searching the web for 'possessor movie'…`) instead of the generic `🌐 Searching the web…`.
- Moved the print below query validation so it only fires when there's an actual query to show.

## Test plan
- [ ] Trigger a web search via voice or CLI and confirm the query appears in the console output.