### PR TITLE
perf: LLM contexts graph, small-model demotions, perf timing harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .venv/
 __pycache__/
 .pytest_cache/
+tests/performance/reports/
 .mamba_env/
 .micromamba/
 .claude/*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,8 @@ Any code change must either adhere to our spec files perfectly or you should ask
 | `src/jarvis/memory/graph.spec.md` | Node graph memory (v2), self-organising tree, UI explorer | Dynamic structure; access-aware; auto-split/merge (future) |
 | `src/jarvis/memory/summariser.spec.md` | Diary summariser prompt contract and hygiene rules (deflection, attribution, topic separation) | Summariser is the source; corrupted summaries poison every downstream consumer |
 
+The LLM contexts graph at `docs/llm_contexts.md` maps every LLM call in the app (model, gating, inputs, outputs, limits, flow). Keep it up-to-date at all times: any change that adds, removes, or alters an LLM context (model resolution, timeout, cap, prompt source, gating flag, data-flow edge) must update `docs/llm_contexts.md` in the same PR.
+
 Avoid hardcoded language patterns as this assistant needs to support an arbitrary amount of different languages.
 
 Tools define when/how to be used and return raw data without LLM processing. The unified system prompt in `src/jarvis/system_prompt.py` handles response formatting and personality through the daemon's LLM loop.

--- a/docs/llm_contexts.md
+++ b/docs/llm_contexts.md
@@ -1,0 +1,225 @@
+# LLM Contexts Map
+
+Every distinct LLM call in Jarvis, what feeds it, what consumes it, and how it is gated. This is the reference for optimising the app's main bottleneck (LLM latency). Keep it in sync with the code — see the note at the bottom.
+
+---
+
+## 1. Main Reply Loop (agentic messages loop)
+
+- **File**: [src/jarvis/reply/engine.py](src/jarvis/reply/engine.py) — `reply()` and the loop at ~lines 1370-1650; native tool-call path in `chat_with_messages()` (~1424, 1455).
+- **Trigger**: every user message. Runs up to `agentic_max_turns` (default 8) iterations per reply.
+- **Model / gating**: `cfg.ollama_chat_model` (the big model). Not optional. No size branching on the loop itself — size branching affects the digests/evaluator around it.
+- **Inputs**:
+  - Redacted user query
+  - Recent dialogue (last 5 minutes)
+  - Unified system prompt from [src/jarvis/system_prompt.py](src/jarvis/system_prompt.py) + ASR note + tool-protocol guidance
+  - Digested memory enrichment (optional, see #5)
+  - Time + location context (re-injected each turn)
+  - Tool schema: native via `generate_tools_json_schema()` ([src/jarvis/tools/registry.py](src/jarvis/tools/registry.py)) or text fallback via `_text_tool_call_guidance()` ([engine.py:68](src/jarvis/reply/engine.py:68))
+  - Tool results from prior turns (raw or digested — see #6)
+- **Output**: OpenAI-style `{content, tool_calls, thinking}`. Consumed by the evaluator (#3), tool orchestrator, and TTS pipeline.
+- **Limits**: no explicit `max_tokens` — Ollama defaults. Timeout `llm_chat_timeout_sec` (45s). Auto-fallback from native to text tool-calls on HTTP 400 (`ToolsNotSupportedError`), sticky for the session.
+
+## 2. Intent Judge
+
+- **File**: [src/jarvis/listening/intent_judge.py](src/jarvis/listening/intent_judge.py) — `IntentJudge.evaluate()`.
+- **Trigger**: on a speech segment *only if* there is an engagement signal (wake word detected, hot-window active, or TTS playing). Pure ambient speech skips it.
+- **Model / gating**: `cfg.intent_judge_model` (default `gemma4:e2b`, ~2B). Falls back to text-based wake detection if Ollama is unavailable.
+- **Inputs**:
+  - Rolling transcript buffer (last 120s, with timestamps)
+  - Wake-word timestamp (if any), normalised aliases
+  - Last TTS text + finish time (echo rejection)
+  - State flags (wake_word_mode, hot_window_mode, during_tts)
+- **System prompt**: `SYSTEM_PROMPT_TEMPLATE` at [intent_judge.py:135](src/jarvis/listening/intent_judge.py:135). Teaches query extraction, echo detection, stop commands, pronoun/topic disambiguation, imperative re-addressing, declaratives to the wake word.
+- **Output**: strict JSON `IntentJudgment{directed, query, stop, confidence, reasoning}` ([intent_judge.py:94](src/jarvis/listening/intent_judge.py:94)). Consumed by the listening state machine which dispatches to the reply engine.
+- **Limits**: `intent_judge_timeout_sec` (15s).
+
+## 3. Evaluator (post-turn decision)
+
+- **File**: [src/jarvis/reply/evaluator.py](src/jarvis/reply/evaluator.py) — `evaluate_turn()`.
+- **Trigger**: after every agentic-loop turn that produced prose. Skipped on tool-call-only or malformed turns.
+- **Model / gating**: resolution chain `evaluator_model → intent_judge_model → ollama_chat_model`. Gated by `cfg.evaluator_enabled`: `None` → auto-ON for SMALL, auto-OFF for LARGE.
+- **Inputs**: redacted user query, assistant prose this turn, toolbox (name + one-liner), turns used, invoked-tools history (name + args/result summary).
+- **System prompt**: `_EVALUATOR_SYSTEM_PROMPT` at [evaluator.py:43](src/jarvis/reply/evaluator.py:43). Teaches terminal vs continue, tool-coverage, multi-part query counting, garbled-turn salvage, structured `tool_call` emission.
+- **Output**: strict JSON `EvaluatorResult{terminal, nudge, reason, tool_call}` ([evaluator.py:29](src/jarvis/reply/evaluator.py:29)). Consumed by the loop at ~engine.py:1580.
+- **Limits**: `llm_digest_timeout_sec` (8s, shared). Nudge cap `evaluator_nudge_max` (2). Fail-open → `terminal=True`.
+
+## 4. Memory Enrichment Extractor
+
+- **File**: [src/jarvis/reply/enrichment.py](src/jarvis/reply/enrichment.py) — `extract_search_params_for_memory()` (~line 71).
+- **Trigger**: once per reply before the loop.
+- **Model / gating**: resolved via `_resolve_tool_router_model(cfg)` — `tool_router_model → intent_judge_model → ollama_chat_model`. Small classification task; rides the same small/warm model as the router. Not optional; silent empty-dict on failure.
+- **Inputs**: user query, optional context hint (live-context compact summary), UTC now.
+- **System prompt**: inline at [enrichment.py:35-63](src/jarvis/reply/enrichment.py:35).
+- **Output**: `{keywords, from?, to?, questions?}`. Consumed by memory search at ~engine.py:1359.
+- **Limits**: up to 2 retries; timeout from `llm_tools_timeout_sec`.
+
+## 5. Memory Digest (optional, SMALL models)
+
+- **File**: [src/jarvis/reply/enrichment.py](src/jarvis/reply/enrichment.py) — `digest_memory_for_query()` + `_distil_batch()`.
+- **Trigger**: once per reply when enrichment returns hits AND `memory_digest_enabled` (auto-ON for SMALL ≤7B, OFF for LARGE). Skipped if raw < `_DIGEST_MIN_CHARS` (400). Batched if raw > `_DIGEST_BATCH_MAX_CHARS` (2000).
+- **Model / gating**: `ollama_chat_model`. Gated by `memory_digest_enabled`.
+- **Inputs**: user query, raw diary entries, raw graph nodes.
+- **System prompt**: `_DIGEST_SYSTEM_PROMPT` at [enrichment.py:122](src/jarvis/reply/enrichment.py:122). Teaches relevance filtering, preference-signal detection, attribution preservation, `NONE` sentinel, identity queries.
+- **Output**: ≤400 chars text per batch (`_DIGEST_MAX_CHARS`) injected as reference-only memory context into the main loop's system message. Empty on failure.
+- **Limits**: `llm_digest_timeout_sec` (8s, shared).
+
+## 6. Tool-Result Digest (optional, SMALL models)
+
+- **File**: [src/jarvis/reply/enrichment.py](src/jarvis/reply/enrichment.py) — `digest_tool_result_for_query()` + `_distil_tool_batch()`.
+- **Trigger**: after each tool result in the loop, if `tool_result_digest_enabled` (auto-ON for SMALL, OFF for LARGE). Skipped if raw < 400 chars (`_TOOL_DIGEST_MIN_CHARS`); batched if > 2500 (`_TOOL_DIGEST_BATCH_MAX_CHARS`).
+- **Model / gating**: `ollama_chat_model`. Gated by `tool_result_digest_enabled`.
+- **Inputs**: user query, tool name, raw tool result (e.g. webSearch payload inside UNTRUSTED WEB EXTRACT fence).
+- **System prompt**: `_TOOL_DIGEST_SYSTEM_PROMPT`. Teaches attributed fact extraction, `NONE` sentinel, no inference.
+- **Output**: ≤600 chars per batch (`_TOOL_DIGEST_MAX_CHARS`) replacing the raw payload in the messages stream. Falls back to raw on `NONE`.
+- **Limits**: `llm_digest_timeout_sec` (8s, shared).
+
+## 7. Max-Turn Loop Digest
+
+- **File**: [src/jarvis/reply/enrichment.py](src/jarvis/reply/enrichment.py) — `digest_loop_for_max_turns()` (~line 847).
+- **Trigger**: when the loop exhausts `agentic_max_turns` without a terminal evaluator decision.
+- **Model / gating**: `_resolve_loop_digest_model(cfg)` — prefers `intent_judge_model`, falls back to `ollama_chat_model`.
+- **Inputs**: user query + loop activity (tool calls, results summaries, any prose).
+- **System prompt**: `_LOOP_DIGEST_SYSTEM_PROMPT` — caveat-prefixed, user-language, concise.
+- **Output**: caveat-prefixed final reply. Fails open to the last raw candidate.
+- **Limits**: `llm_digest_timeout_sec` (8s, shared).
+
+## 8. Tool Router (pre-loop tool selection)
+
+- **File**: [src/jarvis/tools/selection.py](src/jarvis/tools/selection.py) — `select_tools_with_llm()` (~line 331).
+- **Trigger**: once per reply before the loop, if `tool_selection_strategy == "llm"` (default). Other strategies: `all`, `keyword`, `embedding`.
+- **Model / gating**: `_resolve_tool_router_model(cfg)` chain — `tool_router_model → intent_judge_model → ollama_chat_model`.
+- **Inputs**: user query, tool catalogue (builtin + MCP with descriptions), optional narrow-down hint.
+- **System prompt**: inline (~lines 260-315). Teaches pick up-to-5 tools or `none`.
+- **Output**: comma-separated tool names or `none`. Capped at `_LLM_MAX_SELECTED` (5). Always-included tools (`stop`, `toolSearchTool`) are unioned in regardless.
+- **Limits**: `llm_timeout_sec`. On failure → all tools.
+
+## 9. Tool Searcher (mid-loop escape hatch)
+
+- **File**: [src/jarvis/tools/builtin/tool_search.py](src/jarvis/tools/builtin/tool_search.py) — `toolSearchTool`.
+- **Trigger**: when the model explicitly invokes `toolSearchTool` during the loop. Capped at `tool_search_max_calls` (3) per reply.
+- **Model**: reuses the tool router (#8) — no separate LLM call here.
+- **Inputs**: self-contained query from the model.
+- **Output**: newline-separated tool names + one-liners, merged into the allow-list for the next turn.
+
+## 10. Conversation Summariser
+
+- **File**: [src/jarvis/memory/conversation.py](src/jarvis/memory/conversation.py) — `generate_conversation_summary()` (~lines 350/355).
+- **Trigger**: background, periodic — when unsaved dialogue reaches `dialogue_memory_timeout`. One per day per `source_app`.
+- **Model / gating**: `ollama_chat_model`. Respects `llm_thinking_enabled`. Uses streaming when a token callback is provided, else direct.
+- **Inputs**: recent conversation chunks + prior same-day summary (for incremental update).
+- **System prompt**: inline (~lines 310-320). Hygiene rules per [src/jarvis/memory/summariser.spec.md](src/jarvis/memory/summariser.spec.md): no deflection narration, attribution preservation, topic separation. ≤200 words + 3-5 topic keywords.
+- **Output**: `(summary_text, topics_text)` → `conversation_summaries` table, embedded for vector search, feeds enrichment (#4) and graph extraction (#11).
+- **Limits**: `timeout_sec` (30s default).
+
+## 11. Knowledge Graph Fact Extraction
+
+- **File**: [src/jarvis/memory/graph_ops.py](src/jarvis/memory/graph_ops.py) — `_llm_extract_facts()` (~line 98).
+- **Trigger**: after each daily summary (#10). Background.
+- **Model**: `ollama_chat_model`.
+- **Inputs**: summary text + optional date.
+- **Output**: JSON array of novel fact strings → memory graph nodes.
+- **Limits**: `timeout_sec`. Failures → empty list.
+
+## 12. Knowledge Graph Best-Child Picker
+
+- **File**: [src/jarvis/memory/graph_ops.py](src/jarvis/memory/graph_ops.py) — `_llm_pick_best_child()` (~line 167).
+- **Trigger**: during graph insertion, per fact, to place it under the best existing category. Background.
+- **Model**: uses `picker_model` when passed through from `update_graph_from_dialogue` (daemon resolves it via `_resolve_tool_router_model(cfg)` → small model when available). Falls back to `ollama_chat_model` when no small model is configured.
+- **Inputs**: fact text + numbered list of candidate child nodes (name + description).
+- **System prompt**: inline (~lines 156-161) — answer with number or `NONE`.
+- **Output**: child node id or `None` (fact still inserted, just not under an optimal parent).
+
+## 13. Tool-specific LLM calls
+
+- **Weather** ([src/jarvis/tools/builtin/weather.py](src/jarvis/tools/builtin/weather.py), ~line 60) — `ollama_chat_model`, parses location/time/unit from the query.
+- **Nutrition log_meal** ([src/jarvis/tools/builtin/nutrition/log_meal.py](src/jarvis/tools/builtin/nutrition/log_meal.py), lines 48 & 136) — `ollama_chat_model`, extracts nutrients, confirms logging.
+
+---
+
+## Frequency / Size Summary
+
+| # | Context | Per reply | Optional? | Model tier |
+|---|---------|-----------|-----------|------------|
+| 1 | Main chat loop | 1-8 | No | LARGE |
+| 2 | Intent judge | 1 (voice only) | fallback available | SMALL |
+| 3 | Evaluator | 1-7 | auto by size | SMALL |
+| 4 | Memory enrichment extract | 1 | No | SMALL (via router chain) |
+| 5 | Memory digest | 0-N | auto by size | SMALL (uses chat model) |
+| 6 | Tool-result digest | 0-N | auto by size | SMALL (uses chat model) |
+| 7 | Max-turn digest | 0-1 | No | SMALL |
+| 8 | Tool router | 1 | yes (strategy) | SMALL |
+| 9 | Tool searcher | 0-3 | model-initiated | SMALL (reuses #8) |
+| 10 | Summariser | ~1/session | No (background) | LARGE |
+| 11 | Graph extraction | ~1/session | No (background) | LARGE |
+| 12 | Graph best-child | 0-N | No (background) | SMALL (via router chain) |
+| 13 | Tool-specific | per-tool | n/a | LARGE |
+
+## Size-aware auto switches
+
+Driven by `detect_model_size(model_name) → SMALL (≤7B) | LARGE (8B+)`:
+
+| Feature | SMALL | LARGE |
+|---------|-------|-------|
+| Memory digest | ON | OFF |
+| Tool-result digest | ON | OFF |
+| Evaluator | ON | OFF |
+
+## Config keys
+
+- Models: `ollama_chat_model`, `intent_judge_model`, `evaluator_model`, `tool_router_model`
+- Flags: `evaluator_enabled`, `memory_digest_enabled`, `tool_result_digest_enabled`, `llm_thinking_enabled`, `intent_judge_thinking_enabled`, `tool_selection_strategy`
+- Timeouts: `llm_chat_timeout_sec` (45s), `llm_digest_timeout_sec` (8s, shared across #3/#5/#6/#7), `llm_tools_timeout_sec`, `intent_judge_timeout_sec` (15s)
+- Caps: `agentic_max_turns` (8), `evaluator_nudge_max` (2), `tool_search_max_calls` (3), `_LLM_MAX_SELECTED` (5), `_DIGEST_MAX_CHARS` (400), `_TOOL_DIGEST_MAX_CHARS` (600)
+
+## Flow
+
+```
+user input
+  └─▶ [2] Intent Judge            (voice only, SMALL)
+        └─▶ [4] Enrichment extract
+              └─▶ [5] Memory digest  (optional, SMALL path)
+                    └─▶ [8] Tool router
+                          └─▶ AGENTIC LOOP  (≤ agentic_max_turns)
+                                ├─ [1] Main chat turn
+                                ├─ tool execution
+                                │    └─ [6] Tool-result digest (optional)
+                                │    └─ [9] Tool searcher (model-initiated)
+                                └─ [3] Evaluator (after prose turns)
+                                      └─ nudge OR direct tool_call OR terminal
+                                └─ if max turns → [7] Max-turn digest
+                          └─▶ TTS / output
+                          └─▶ background: [10] summariser → [11] graph extract → [12] best-child
+```
+
+## Optimisation ideas (seed list)
+
+1. Batch multi-chunk memory digests (#5) into a single call with explicit markers.
+2. Parallelise multiple tool-result digests (#6) when several results land at once.
+3. Cache evaluator (#3) by `(query, content)` hash.
+4. Pre-warm the intent-judge model before TTS finishes.
+5. Cache tool-router (#8) output by query hash.
+6. Give each digest its own timeout budget rather than sharing `llm_digest_timeout_sec` (today a slow memory digest can starve the evaluator).
+7. Consider single-model deployments: router+evaluator prefer `intent_judge_model`; loading a second model hurts cold-start latency on small hardware.
+8. Narrow `llm_thinking_enabled` to evaluator/router only, not every context.
+9. Reduce `intent_judge_timeout_sec` (15s) or race it against text-based wake detection to avoid blocking the audio loop.
+
+---
+
+## Measuring
+
+`tests/performance/test_pipeline_timings.py` times each context in this graph against a live Ollama. Run:
+
+```
+pytest tests/performance/ -v -m performance -s
+```
+
+It records per-context p50/p95 latencies using a monkey-patch recorder that infers the context from the caller's `__qualname__` (see `_CALLER_TO_CONTEXT` in `tests/performance/timing_recorder.py`). Dumps a JSON report to `tests/performance/reports/`. A micro-benchmark with a tiny fixed prompt runs alongside to give a per-call floor — if that floor moves, every context's total moves with it, so hardware/model drift is visible immediately.
+
+Baseline on a local gemma4:e2b (as of 2026-04-22, 3 queries × 3 runs): main chat turn p50 ~4.5s, evaluator p50 ~3.8s (≈80% of a main turn), enrichment extract p50 ~0.9s (small-model chain), micro-prompt floor ~0.15s. Sample sizes: main 25 calls, evaluator 15, enrichment 9. Use these as rough reference points — the assertions in the test are relative-shape (evaluator ≤ 1.5× main chat turn, router ≤ 1.5× main chat turn), not absolute.
+
+When you add or change a context, update `_CALLER_TO_CONTEXT` so it shows up in the report instead of landing in the `other:` bucket.
+
+## Keep this doc in sync
+
+This graph is the reference for LLM-latency optimisation. Treat it as authoritative: whenever code changes affect an LLM call — a new context, a removed one, a changed model/timeout/cap/gating/prompt source, or a new data-flow edge — update this file in the same PR. If the update would be more than a one-line tweak, reflect it in the relevant `*.spec.md` too.

--- a/docs/llm_contexts.md
+++ b/docs/llm_contexts.md
@@ -48,7 +48,7 @@ Every distinct LLM call in Jarvis, what feeds it, what consumes it, and how it i
 
 - **File**: [src/jarvis/reply/enrichment.py](src/jarvis/reply/enrichment.py) — `extract_search_params_for_memory()` (~line 71).
 - **Trigger**: once per reply before the loop.
-- **Model / gating**: resolved via `_resolve_tool_router_model(cfg)` — `tool_router_model → intent_judge_model → ollama_chat_model`. Small classification task; rides the same small/warm model as the router. Not optional; silent empty-dict on failure.
+- **Model / gating**: resolved via `resolve_tool_router_model(cfg)` — `tool_router_model → intent_judge_model → ollama_chat_model`. Small classification task; rides the same small/warm model as the router. Not optional; silent empty-dict on failure.
 - **Inputs**: user query, optional context hint (live-context compact summary), UTC now.
 - **System prompt**: inline at [enrichment.py:35-63](src/jarvis/reply/enrichment.py:35).
 - **Output**: `{keywords, from?, to?, questions?}`. Consumed by memory search at ~engine.py:1359.
@@ -88,7 +88,7 @@ Every distinct LLM call in Jarvis, what feeds it, what consumes it, and how it i
 
 - **File**: [src/jarvis/tools/selection.py](src/jarvis/tools/selection.py) — `select_tools_with_llm()` (~line 331).
 - **Trigger**: once per reply before the loop, if `tool_selection_strategy == "llm"` (default). Other strategies: `all`, `keyword`, `embedding`.
-- **Model / gating**: `_resolve_tool_router_model(cfg)` chain — `tool_router_model → intent_judge_model → ollama_chat_model`.
+- **Model / gating**: `resolve_tool_router_model(cfg)` chain — `tool_router_model → intent_judge_model → ollama_chat_model`.
 - **Inputs**: user query, tool catalogue (builtin + MCP with descriptions), optional narrow-down hint.
 - **System prompt**: inline (~lines 260-315). Teaches pick up-to-5 tools or `none`.
 - **Output**: comma-separated tool names or `none`. Capped at `_LLM_MAX_SELECTED` (5). Always-included tools (`stop`, `toolSearchTool`) are unioned in regardless.
@@ -125,7 +125,7 @@ Every distinct LLM call in Jarvis, what feeds it, what consumes it, and how it i
 
 - **File**: [src/jarvis/memory/graph_ops.py](src/jarvis/memory/graph_ops.py) — `_llm_pick_best_child()` (~line 167).
 - **Trigger**: during graph insertion, per fact, to place it under the best existing category. Background.
-- **Model**: uses `picker_model` when passed through from `update_graph_from_dialogue` (daemon resolves it via `_resolve_tool_router_model(cfg)` → small model when available). Falls back to `ollama_chat_model` when no small model is configured.
+- **Model**: uses `picker_model` when passed through from `update_graph_from_dialogue` (daemon resolves it via `resolve_tool_router_model(cfg)` → small model when available). Falls back to `ollama_chat_model` when no small model is configured.
 - **Inputs**: fact text + numbered list of candidate child nodes (name + description).
 - **System prompt**: inline (~lines 156-161) — answer with number or `NONE`.
 - **Output**: child node id or `None` (fact still inserted, just not under an optimal parent).

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,7 +4,10 @@ markers =
     integration: Tests requiring complex setup/external services - run in git hooks only
     e2e: End-to-end workflow tests with real configurations - run in git hooks only
     eval: Quality evaluations testing LLM response quality - run manually only
+    performance: Timing harness against a live Ollama - run manually only (needs Ollama reachable)
 
 testpaths = tests
 # Evals are excluded by default, run them explicitly with: pytest evals/ -v
+# Performance tests are excluded by default, run them explicitly with: pytest tests/performance/ -v -m performance
+addopts = -m "not performance"
 

--- a/src/desktop_app/memory_viewer.py
+++ b/src/desktop_app/memory_viewer.py
@@ -482,12 +482,17 @@ def graph_import_diary() -> Response:
     from jarvis.config import load_settings
     from jarvis.memory.db import Database
     from jarvis.memory.graph_ops import update_graph_from_dialogue
+    from jarvis.reply.engine import resolve_tool_router_model
 
     def generate():
         try:
             settings = load_settings()
             db_path = _get_db_path()
             db = Database(db_path, sqlite_vss_path=None)
+            # Run the best-child picker on the small router-chain model so
+            # historical import doesn't page in the big chat model for every
+            # placement decision.
+            picker_model = resolve_tool_router_model(settings)
 
             summaries = db.get_all_conversation_summaries()
             total = len(summaries)
@@ -517,6 +522,7 @@ def graph_import_diary() -> Response:
                         timeout_sec=settings.llm_chat_timeout_sec,
                         thinking=getattr(settings, 'llm_thinking_enabled', False),
                         date_utc=date_utc,
+                        picker_model=picker_model,
                     )
                     facts_stored = len(stored_facts)
                     total_facts += facts_stored

--- a/src/jarvis/daemon.py
+++ b/src/jarvis/daemon.py
@@ -242,6 +242,12 @@ def _check_and_update_diary(
             # Only use token handler if we have callbacks or IPC enabled
             on_token = on_token_handler if (use_callbacks or use_ipc) else None
 
+            # Graph best-child picker is a one-digit classification — reuse the
+            # tool-router model chain so placement runs on a small model instead
+            # of paging in the big chat model for every fact.
+            from .reply.engine import _resolve_tool_router_model
+            graph_picker_model = _resolve_tool_router_model(cfg)
+
             summary_id = update_diary_from_dialogue_memory(
                 db=db,
                 dialogue_memory=_global_dialogue_memory,
@@ -254,6 +260,7 @@ def _check_and_update_diary(
                 force=force,
                 on_token=on_token,
                 thinking=getattr(cfg, 'llm_thinking_enabled', False),
+                graph_picker_model=graph_picker_model,
             )
 
             # Flush any remaining tokens in IPC mode

--- a/src/jarvis/daemon.py
+++ b/src/jarvis/daemon.py
@@ -245,8 +245,8 @@ def _check_and_update_diary(
             # Graph best-child picker is a one-digit classification — reuse the
             # tool-router model chain so placement runs on a small model instead
             # of paging in the big chat model for every fact.
-            from .reply.engine import _resolve_tool_router_model
-            graph_picker_model = _resolve_tool_router_model(cfg)
+            from .reply.engine import resolve_tool_router_model
+            graph_picker_model = resolve_tool_router_model(cfg)
 
             summary_id = update_diary_from_dialogue_memory(
                 db=db,

--- a/src/jarvis/listening/listener.py
+++ b/src/jarvis/listening/listener.py
@@ -1429,8 +1429,8 @@ class VoiceListener(threading.Thread):
         # Use the same resolution helper the reply engine uses so warmup
         # targets the model the engine will actually call. Keeping a single
         # source of truth prevents drift between warmup and runtime.
-        from ..reply.engine import _resolve_tool_router_model
-        router_model_effective = _resolve_tool_router_model(self.cfg)
+        from ..reply.engine import resolve_tool_router_model
+        router_model_effective = resolve_tool_router_model(self.cfg)
         router_model = router_model_effective if strategy == "llm" else ""
         shared_router = bool(router_model) and router_model in {chat_model, judge_model}
 

--- a/src/jarvis/memory/conversation.py
+++ b/src/jarvis/memory/conversation.py
@@ -752,6 +752,7 @@ def update_diary_from_dialogue_memory(
     force: bool = False,
     on_token: Optional[Callable[[str], None]] = None,
     thinking: bool = False,
+    graph_picker_model: Optional[str] = None,
 ) -> Optional[int]:
     """
     Update the diary with pending interactions from dialogue memory.
@@ -836,6 +837,7 @@ def update_diary_from_dialogue_memory(
                         timeout_sec=graph_timeout,
                         thinking=thinking,
                         date_utc=today,
+                        picker_model=graph_picker_model,
                     )
                     if stored:
                         print(f"  🧠 Knowledge graph: learned {len(stored)} new facts", flush=True)

--- a/src/jarvis/memory/graph.spec.md
+++ b/src/jarvis/memory/graph.spec.md
@@ -121,6 +121,7 @@ Piggybacks on the existing diary update flow in `conversation.py`:
    - **Recent nodes** — checked first; follows conversational momentum
    - **Top nodes** — checked second; matches frequently accessed knowledge domains
    - **Root traversal** — greedy top-down descent; LLM picks the best child at each level, or stops at the current node if none fit
+   - **Picker model**: `update_graph_from_dialogue` / `find_best_node` / `_llm_pick_best_child` accept an optional `picker_model` override. Callers (daemon, memory viewer's diary-import endpoint) resolve it via `resolve_tool_router_model(cfg)` so the best-child classification runs on the small warm router model instead of the big chat model. When `picker_model` is `None` the picker falls back to `ollama_chat_model`.
 4. **Append**: The fact is appended to the chosen node's data
 5. **Split**: If the node now exceeds `SPLIT_THRESHOLD`, auto-split is triggered
 

--- a/src/jarvis/memory/graph_ops.py
+++ b/src/jarvis/memory/graph_ops.py
@@ -140,6 +140,7 @@ def _llm_pick_best_child(
     ollama_chat_model: str,
     timeout_sec: float = 15.0,
     thinking: bool = False,
+    picker_model: Optional[str] = None,
 ) -> Optional[str]:
     """Ask the LLM which child node best fits a memory fragment.
 
@@ -164,9 +165,13 @@ def _llm_pick_best_child(
         f"Categories:\n{options_text}"
     )
 
+    # Picker is a one-digit classification — reuse the small picker_model
+    # when the caller provides one (resolved from intent_judge_model → chat_model).
+    # Falls back to the chat model when no small model is configured.
+    effective_model = picker_model or ollama_chat_model
     response = call_llm_direct(
         base_url=ollama_base_url,
-        chat_model=ollama_chat_model,
+        chat_model=effective_model,
         system_prompt=system_prompt,
         user_content=user_content,
         timeout_sec=timeout_sec,
@@ -197,6 +202,7 @@ def find_best_node(
     ollama_chat_model: str,
     timeout_sec: float = 15.0,
     thinking: bool = False,
+    picker_model: Optional[str] = None,
 ) -> str:
     """Find the best node to store a memory fragment using three entry points.
 
@@ -215,7 +221,7 @@ def find_best_node(
         debug_log(f"graph traversal: trying {len(recent)} recent nodes: {[n.name for n in recent]}", "memory")
         best = _llm_pick_best_child(
             fragment, recent, ollama_base_url, ollama_chat_model,
-            timeout_sec=timeout_sec, thinking=thinking,
+            timeout_sec=timeout_sec, thinking=thinking, picker_model=picker_model,
         )
         if best is not None:
             matched = store.get_node(best)
@@ -230,7 +236,7 @@ def find_best_node(
         debug_log(f"graph traversal: trying {len(top)} top nodes: {[n.name for n in top]}", "memory")
         best = _llm_pick_best_child(
             fragment, top, ollama_base_url, ollama_chat_model,
-            timeout_sec=timeout_sec, thinking=thinking,
+            timeout_sec=timeout_sec, thinking=thinking, picker_model=picker_model,
         )
         if best is not None:
             matched = store.get_node(best)
@@ -251,7 +257,7 @@ def find_best_node(
         debug_log(f"graph traversal: depth {depth}, choosing from {[c.name for c in children]}", "memory")
         best = _llm_pick_best_child(
             fragment, children, ollama_base_url, ollama_chat_model,
-            timeout_sec=timeout_sec, thinking=thinking,
+            timeout_sec=timeout_sec, thinking=thinking, picker_model=picker_model,
         )
         if best is None:
             debug_log(f"graph traversal: no children fit at depth {depth}, stopping", "memory")
@@ -392,6 +398,7 @@ def update_graph_from_dialogue(
     timeout_sec: float = 30.0,
     thinking: bool = False,
     date_utc: Optional[str] = None,
+    picker_model: Optional[str] = None,
 ) -> "list[tuple[str, str]]":
     """End-to-end: extract memories from a summary, place each in the best
     node, and trigger auto-split if needed.
@@ -432,6 +439,7 @@ def update_graph_from_dialogue(
                 ollama_chat_model=ollama_chat_model,
                 timeout_sec=15.0,
                 thinking=thinking,
+                picker_model=picker_model,
             )
 
             # Step 3: Append the fact to the chosen node

--- a/src/jarvis/reply/engine.py
+++ b/src/jarvis/reply/engine.py
@@ -42,7 +42,7 @@ def _indent_text(text: str, prefix: str = "  ") -> str:
     return f"\n{prefix}".join(text.splitlines())
 
 
-def _resolve_tool_router_model(cfg) -> str:
+def resolve_tool_router_model(cfg) -> str:
     """Pick the LLM model for tool routing.
 
     Resolution order: explicit `tool_router_model` → `intent_judge_model` →
@@ -639,7 +639,7 @@ def run_reply_engine(db: "Database", cfg, tts: Optional[Any],
     # this resolves to the chat model, so nothing changes there.
     try:
         search_params = extract_search_params_for_memory(
-            redacted, cfg.ollama_base_url, _resolve_tool_router_model(cfg),
+            redacted, cfg.ollama_base_url, resolve_tool_router_model(cfg),
             timeout_sec=float(getattr(cfg, 'llm_tools_timeout_sec', 8.0)),
             thinking=getattr(cfg, 'llm_thinking_enabled', False),
             context_hint=context_hint,
@@ -820,7 +820,7 @@ def run_reply_engine(db: "Database", cfg, tts: Optional[Any],
         mcp_tools=mcp_tools,
         strategy=strategy,
         llm_base_url=cfg.ollama_base_url,
-        llm_model=_resolve_tool_router_model(cfg),
+        llm_model=resolve_tool_router_model(cfg),
         llm_timeout_sec=float(getattr(cfg, "llm_tools_timeout_sec", 8.0)),
         embed_model=getattr(cfg, "ollama_embed_model", "nomic-embed-text"),
         embed_timeout_sec=float(getattr(cfg, "llm_embed_timeout_sec", 10.0)),

--- a/src/jarvis/reply/engine.py
+++ b/src/jarvis/reply/engine.py
@@ -632,10 +632,14 @@ def run_reply_engine(db: "Database", cfg, tts: Optional[Any],
 
     context_hint = _build_enrichment_context_hint(cfg, recent_messages)
 
-    # Extract keywords and implicit questions (needed by both diary and graph enrichment)
+    # Extract keywords and implicit questions (needed by both diary and graph enrichment).
+    # Keyword/time extraction is a small classification job — reuse the tool-router
+    # model chain (intent_judge_model → chat_model) so we don't page in the big
+    # chat model just to emit a 5-item JSON blob. On small single-model setups
+    # this resolves to the chat model, so nothing changes there.
     try:
         search_params = extract_search_params_for_memory(
-            redacted, cfg.ollama_base_url, cfg.ollama_chat_model,
+            redacted, cfg.ollama_base_url, _resolve_tool_router_model(cfg),
             timeout_sec=float(getattr(cfg, 'llm_tools_timeout_sec', 8.0)),
             thinking=getattr(cfg, 'llm_thinking_enabled', False),
             context_hint=context_hint,

--- a/src/jarvis/reply/reply.spec.md
+++ b/src/jarvis/reply/reply.spec.md
@@ -32,7 +32,8 @@ Design principles enforced by the engine:
    - Include short-term dialogue memory (last 5 minutes) as prior messages.
 
 4. Conversation Memory Enrichment (optional)
-   - Extract search parameters via `extract_search_params_for_memory(query, base_url, chat_model, ..., context_hint=...)`.
+   - Extract search parameters via `extract_search_params_for_memory(query, base_url, router_model, ..., context_hint=...)`.
+     - Runs on the tool-router model chain (`resolve_tool_router_model(cfg)` → `tool_router_model → intent_judge_model → ollama_chat_model`), not the big chat model. The extractor is a small classification-shaped task and rides the already-warm router/judge model instead of paging in the chat weights.
      - Output fields: `keywords: List[str]`, optional `from`, optional `to`, optional `questions: List[str]`.
      - `context_hint` carries a compact summary of what is already live in the assistant's context (current time, location, short-term dialogue). The extractor uses it to skip implicit personal questions whose answers are already visible — those facts do not need to be pulled from long-term memory.
    - If `keywords` present, call `search_conversation_memory_by_keywords(db, keywords, from_time, to_time, ...)` to retrieve relevant snippets (bounded by configured max results).

--- a/tests/performance/README.md
+++ b/tests/performance/README.md
@@ -1,0 +1,43 @@
+# Performance tests
+
+Per-context timings for the reply pipeline. Excluded from the default pytest run
+(see `pytest.ini`'s `addopts = -m "not performance"`).
+
+## Running
+
+```bash
+pytest tests/performance/ -v -m performance -s
+```
+
+The `-s` flag lets the report table print to stdout. Tests auto-skip when Ollama
+is unreachable, so the harness is safe to leave in the repo.
+
+## Env vars
+
+| Var | Default | Description |
+|-----|---------|-------------|
+| `JARVIS_PERF_OLLAMA_URL` | `http://localhost:11434` | Ollama endpoint |
+| `JARVIS_PERF_MODEL` | `gemma4:e2b` | Model pulled in Ollama for the run |
+| `JARVIS_PERF_RUNS` | `3` | Runs per query (bump for tighter p95) |
+| `JARVIS_PERF_REPORT_DIR` | `tests/performance/reports/` | JSON report output |
+
+`PERF_RUNS=3` is a fast-iteration default. For stable p95 numbers when
+benchmarking a change, use `JARVIS_PERF_RUNS=10` or higher.
+
+## What it measures
+
+- **`test_micro_benchmark_tiny_prompt`** — one warmup + N tiny round-trips.
+  Hardware baseline: the floor for every context's per-call cost.
+- **`test_pipeline_timings_by_context`** — three representative queries × N runs
+  of `run_reply_engine`, with per-context timings bucketed via stack-frame
+  inspection in [`timing_recorder.py`](timing_recorder.py).
+
+Shape invariants (not absolute numbers):
+- Evaluator p50 ≤ main chat turn p50 × 1.5.
+- Tool router p50 ≤ main chat turn p50 × 1.5.
+- Enrichment extractor shares the router model chain.
+
+Unmapped callers print as `other:<qualname>` — that's a signal to update the
+`_CALLER_TO_CONTEXT` map in `timing_recorder.py` alongside `docs/llm_contexts.md`.
+
+Reports are written to `reports/` and git-ignored.

--- a/tests/performance/test_pipeline_timings.py
+++ b/tests/performance/test_pipeline_timings.py
@@ -1,0 +1,236 @@
+"""⏱️ Performance: time each LLM context in the reply pipeline.
+
+Runs ``run_reply_engine`` N times against a live Ollama with a fixed tiny
+prompt, records per-context timings via the monkey-patching recorder, and
+asserts a few relative-shape invariants so the test fails when the pipeline
+shape drifts (e.g. the evaluator becomes more expensive than the main turn).
+
+Also includes a micro-benchmark that calls each configured model with a
+tiny fixed prompt, giving a hardware baseline to diff against.
+
+Run manually:
+    pytest tests/performance/ -v -m performance -s
+
+Requires:
+    - Ollama reachable at http://localhost:11434
+    - ``gemma4:e2b`` pulled (or override via env var)
+
+The test is skipped automatically if Ollama is unreachable, so it's safe to
+leave in the repo. Use ``-s`` to see the report table.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+
+import pytest
+import requests
+
+from tests.performance.timing_recorder import TimingRecorder
+
+
+OLLAMA_URL = os.environ.get("JARVIS_PERF_OLLAMA_URL", "http://localhost:11434")
+PERF_MODEL = os.environ.get("JARVIS_PERF_MODEL", "gemma4:e2b")
+PERF_RUNS = int(os.environ.get("JARVIS_PERF_RUNS", "3"))
+PERF_REPORT_DIR = Path(os.environ.get(
+    "JARVIS_PERF_REPORT_DIR",
+    str(Path(__file__).parent / "reports"),
+))
+
+# Tiny fixed prompts — the whole point of the baseline is to measure the
+# per-call overhead and model warmup cost, not prompt-length effects.
+TINY_SYSTEM = "Reply with the single word OK."
+TINY_USER = "ping"
+
+# Representative reply-pipeline queries. Keep them small and shape-diverse.
+PIPELINE_QUERIES = [
+    "hello",                      # pure chat, no tools needed
+    "what's 2 plus 3?",           # math, one-shot
+    "what time is it in Tokyo?",  # likely triggers a tool
+]
+
+
+def _ollama_reachable() -> bool:
+    try:
+        resp = requests.get(f"{OLLAMA_URL}/api/tags", timeout=2)
+        if resp.status_code != 200:
+            return False
+        models = [m.get("name", "") for m in resp.json().get("models", [])]
+        return any(PERF_MODEL.split(":")[0] in m for m in models)
+    except Exception:
+        return False
+
+
+pytestmark = [
+    pytest.mark.performance,
+    pytest.mark.skipif(
+        not _ollama_reachable(),
+        reason=f"Ollama at {OLLAMA_URL} with {PERF_MODEL} not available",
+    ),
+]
+
+
+def _make_cfg():
+    from evals.helpers import MockConfig
+    cfg = MockConfig()
+    cfg.ollama_base_url = OLLAMA_URL
+    cfg.ollama_chat_model = PERF_MODEL
+    cfg.intent_judge_model = PERF_MODEL
+    # Let size-aware defaults kick in (evaluator + digests ON for small).
+    cfg.evaluator_enabled = None
+    cfg.memory_digest_enabled = None
+    cfg.tool_result_digest_enabled = None
+    # Force the LLM-based router so its timing shows up in the report.
+    # MockConfig doesn't set this attribute, and the engine's default varies.
+    cfg.tool_selection_strategy = "llm"
+    cfg.tool_router_model = ""  # fall through the router chain
+    cfg.evaluator_model = ""
+    return cfg
+
+
+def _write_report(rec: TimingRecorder, name: str) -> Path:
+    PERF_REPORT_DIR.mkdir(parents=True, exist_ok=True)
+    stamp = time.strftime("%Y%m%d-%H%M%S")
+    path = PERF_REPORT_DIR / f"{name}-{stamp}.json"
+    payload = {
+        "name": name,
+        "timestamp": stamp,
+        "model": PERF_MODEL,
+        "runs": PERF_RUNS,
+        "summary": rec.to_dict(),
+        "raw": [
+            {
+                "context": c.context,
+                "duration_sec": round(c.duration_sec, 4),
+                "model": c.model,
+                "prompt_chars": c.prompt_chars,
+                "response_chars": c.response_chars,
+            }
+            for c in rec.calls
+        ],
+    }
+    path.write_text(json.dumps(payload, indent=2))
+    return path
+
+
+# =============================================================================
+# Micro-benchmark: tiny fixed prompt per configured model
+# =============================================================================
+
+
+@pytest.mark.performance
+def test_micro_benchmark_tiny_prompt():
+    """Baseline: how long does a single tiny round-trip to Ollama take?
+
+    This is the floor for every context's per-call cost. If the floor moves,
+    every context's total moves with it. Reported separately from the
+    pipeline test so hardware drift is obvious in the numbers.
+    """
+    # Import the module (not the function) so the recorder's patch on
+    # jarvis.llm is visible at call time.
+    from jarvis import llm as _llm
+
+    with TimingRecorder() as rec:
+        # Warmup (first call pays weight-loading cost)
+        _llm.call_llm_direct(
+            base_url=OLLAMA_URL,
+            chat_model=PERF_MODEL,
+            system_prompt=TINY_SYSTEM,
+            user_content=TINY_USER,
+            timeout_sec=30.0,
+        )
+        # Measured runs
+        for _ in range(PERF_RUNS):
+            _llm.call_llm_direct(
+                base_url=OLLAMA_URL,
+                chat_model=PERF_MODEL,
+                system_prompt=TINY_SYSTEM,
+                user_content=TINY_USER,
+                timeout_sec=30.0,
+            )
+
+    rec.print_report(title=f"Micro-benchmark — tiny prompt × {PERF_RUNS + 1} on {PERF_MODEL}")
+    path = _write_report(rec, "micro")
+    print(f"   📄 saved: {path}")
+
+    # Shape check: warm calls should be noticeably faster than cold.
+    # Not a strict assertion (too noisy) — just make sure we got calls.
+    assert len(rec.calls) == PERF_RUNS + 1
+
+
+# =============================================================================
+# Full pipeline: run_reply_engine × N, per-context timings
+# =============================================================================
+
+
+@pytest.mark.performance
+def test_pipeline_timings_by_context():
+    """Run the full reply pipeline N times, record per-context timings.
+
+    Relative-shape invariants (not absolute numbers):
+      1. If the evaluator fires, it must be cheaper on average than the main
+         chat turn — otherwise we're paying more for the decision than for
+         the answer. This is the whole reason the evaluator uses a small
+         model.
+      2. The tool router, if it fires, must be cheaper than a main chat
+         turn on p50 — it's a classification call on the warm small model.
+      3. Enrichment extractor, if it fires, must run on the router chain
+         (same model as the router). This locks in the demotion we just did.
+    """
+    from jarvis.memory.db import Database
+    from jarvis.memory.conversation import DialogueMemory
+    from jarvis.reply.engine import run_reply_engine
+
+    cfg = _make_cfg()
+
+    with TimingRecorder() as rec:
+        for query in PIPELINE_QUERIES:
+            db = Database(":memory:", sqlite_vss_path=None)
+            dlg = DialogueMemory(inactivity_timeout=300, max_interactions=20)
+            try:
+                for _ in range(PERF_RUNS):
+                    run_reply_engine(db, cfg, None, query, dlg)
+            finally:
+                db.close()
+
+    rec.print_report(title=f"Pipeline timings — {len(PIPELINE_QUERIES)} queries × {PERF_RUNS} runs on {PERF_MODEL}")
+    path = _write_report(rec, "pipeline")
+    print(f"   📄 saved: {path}")
+
+    assert rec.calls, "no LLM calls recorded — pipeline did not invoke the LLM"
+
+    # Surface unmapped callers so new contexts show up in review.
+    other = [c for c in rec.calls if c.context.startswith("other:")]
+    if other:
+        unmapped = sorted({c.context for c in other})
+        print(f"   ⚠️  unmapped callers (add to _CALLER_TO_CONTEXT): {unmapped}")
+
+    # Shape invariants
+    main_p50 = rec.p50("main_chat_turn")
+    if main_p50 > 0:
+        ev_p50 = rec.p50("evaluator")
+        if ev_p50 > 0:
+            assert ev_p50 <= main_p50 * 1.5, (
+                f"evaluator p50 ({ev_p50:.2f}s) exceeds main chat turn p50 "
+                f"({main_p50:.2f}s) by >50% — evaluator should be cheaper"
+            )
+        router_p50 = rec.p50("tool_router")
+        if router_p50 > 0:
+            assert router_p50 <= main_p50 * 1.5, (
+                f"tool router p50 ({router_p50:.2f}s) exceeds main chat turn p50 "
+                f"({main_p50:.2f}s) by >50% — router should be cheaper"
+            )
+
+    # Locking in the demotion: enrichment extractor must use the router chain.
+    enrich_calls = [c for c in rec.calls if c.context == "enrichment_extract"]
+    router_calls = [c for c in rec.calls if c.context == "tool_router"]
+    if enrich_calls and router_calls:
+        enrich_models = {c.model for c in enrich_calls}
+        router_models = {c.model for c in router_calls}
+        assert enrich_models == router_models, (
+            f"enrichment extractor should share the router model chain "
+            f"(enrichment={enrich_models}, router={router_models})"
+        )

--- a/tests/performance/timing_recorder.py
+++ b/tests/performance/timing_recorder.py
@@ -28,6 +28,11 @@ from jarvis import llm as _llm_module
 # Map caller __qualname__ → graph context name. Matches the 13 contexts in
 # docs/llm_contexts.md. Anything not listed gets lumped into "other" so we
 # notice new call sites drift in without us updating the doc.
+#
+# ⚠️  This mapping mirrors docs/llm_contexts.md. When you add, remove, or
+# rename an LLM context per the CLAUDE.md rule, update both in the same PR
+# — the perf harness silently buckets unknown callers into "other:<qualname>"
+# so drift here is visible but not loud.
 _CALLER_TO_CONTEXT: dict[str, str] = {
     # Context 1 — main chat loop uses chat_with_messages
     "run_reply_engine": "main_chat_turn",
@@ -48,6 +53,8 @@ _CALLER_TO_CONTEXT: dict[str, str] = {
     # Context 7 — max-turn loop digest
     "digest_loop_for_max_turns": "max_turn_digest",
     # Context 8 — tool router
+    # (Context 9 — tool searcher — reuses select_tools_with_llm so it falls
+    # under the same bucket; that's intentional per docs/llm_contexts.md.)
     "select_tools_with_llm": "tool_router",
     # Context 10 — conversation summariser
     "generate_conversation_summary": "summariser",
@@ -55,6 +62,10 @@ _CALLER_TO_CONTEXT: dict[str, str] = {
     "extract_graph_memories": "graph_extract",
     # Context 12 — graph best-child picker
     "_llm_pick_best_child": "graph_best_child",
+    # Context 13 — tool-specific LLM calls
+    "_extract_place_from_user_text": "tool_weather",
+    "extract_and_log_meal": "tool_nutrition",
+    "generate_followups_for_meal": "tool_nutrition",
 }
 
 

--- a/tests/performance/timing_recorder.py
+++ b/tests/performance/timing_recorder.py
@@ -1,0 +1,259 @@
+"""⏱️ LLM call timing recorder.
+
+Monkey-patches the three entry points in ``jarvis.llm`` (``call_llm_direct``,
+``call_llm_streaming``, ``chat_with_messages``) to record per-call timings
+grouped by the context that issued the call (evaluator, intent judge, tool
+router, etc.). The context is inferred from the caller's ``__qualname__`` on
+the Python call stack, so no instrumentation is needed at the call site.
+
+Usage:
+    with TimingRecorder() as rec:
+        run_reply_engine(...)
+    rec.print_report()
+    assert rec.p95("evaluator") < rec.p95("main_chat_turn")  # shape check
+"""
+
+from __future__ import annotations
+
+import sys
+import time
+import statistics
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from typing import Callable, Optional
+
+from jarvis import llm as _llm_module
+
+
+# Map caller __qualname__ → graph context name. Matches the 13 contexts in
+# docs/llm_contexts.md. Anything not listed gets lumped into "other" so we
+# notice new call sites drift in without us updating the doc.
+_CALLER_TO_CONTEXT: dict[str, str] = {
+    # Context 1 — main chat loop uses chat_with_messages
+    "run_reply_engine": "main_chat_turn",
+    # Context 2 — intent judge (calls via internal helper)
+    "IntentJudge.evaluate": "intent_judge",
+    "IntentJudge._call_llm": "intent_judge",
+    # Context 3 — evaluator
+    "evaluate_turn": "evaluator",
+    # Context 4 — memory enrichment extractor
+    "extract_search_params_for_memory": "enrichment_extract",
+    # Context 5 — memory digest (per batch)
+    "_distil_batch": "memory_digest",
+    "digest_memory_for_query": "memory_digest",
+    # Context 6 — tool-result digest (per batch)
+    "_distil_tool_batch": "tool_result_digest",
+    "digest_tool_result_for_query": "tool_result_digest",
+    "_maybe_digest_tool_result": "tool_result_digest",
+    # Context 7 — max-turn loop digest
+    "digest_loop_for_max_turns": "max_turn_digest",
+    # Context 8 — tool router
+    "select_tools_with_llm": "tool_router",
+    # Context 10 — conversation summariser
+    "generate_conversation_summary": "summariser",
+    # Context 11 — graph fact extraction
+    "extract_graph_memories": "graph_extract",
+    # Context 12 — graph best-child picker
+    "_llm_pick_best_child": "graph_best_child",
+}
+
+
+@dataclass
+class _Call:
+    context: str
+    duration_sec: float
+    model: str
+    prompt_chars: int
+    response_chars: int
+
+
+@dataclass
+class TimingRecorder:
+    calls: list[_Call] = field(default_factory=list)
+    _originals: dict = field(default_factory=dict)
+
+    def __enter__(self) -> "TimingRecorder":
+        self._patch()
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self._unpatch()
+
+    # ── context inference ────────────────────────────────────────────────
+    @staticmethod
+    def _infer_context(skip_frames: int = 2) -> str:
+        """Walk the stack looking for the nearest function whose qualname is
+        in our context map. Skip ``skip_frames`` to step over the wrapper
+        itself. Falls back to ``"other:<qualname>"`` when no known caller is
+        found — visible in the report so drift shows up."""
+        frame = sys._getframe(skip_frames)
+        first_unknown: Optional[str] = None
+        while frame is not None:
+            qual = frame.f_code.co_qualname if hasattr(frame.f_code, "co_qualname") else frame.f_code.co_name
+            if qual in _CALLER_TO_CONTEXT:
+                return _CALLER_TO_CONTEXT[qual]
+            # Also match by the bare function name (qualname can be e.g.
+            # ClassName.method — strip the class part).
+            bare = qual.rsplit(".", 1)[-1]
+            if bare in _CALLER_TO_CONTEXT:
+                return _CALLER_TO_CONTEXT[bare]
+            if first_unknown is None and not qual.startswith(("<", "_patch", "_unpatch")):
+                first_unknown = qual
+            frame = frame.f_back
+        return f"other:{first_unknown or 'unknown'}"
+
+    # ── patching ─────────────────────────────────────────────────────────
+    def _wrap(self, name: str, original: Callable) -> Callable:
+        def wrapped(*args, **kwargs):
+            ctx = self._infer_context(skip_frames=2)
+            # Extract model + prompt sizes from args heuristically — all three
+            # entry points take (base_url, chat_model, ...). chat_with_messages
+            # takes a messages list.
+            model = ""
+            prompt_chars = 0
+            if name == "chat_with_messages":
+                model = kwargs.get("chat_model") or (args[1] if len(args) > 1 else "")
+                msgs = kwargs.get("messages") or (args[2] if len(args) > 2 else [])
+                if isinstance(msgs, list):
+                    prompt_chars = sum(len(str(m.get("content", ""))) for m in msgs)
+            else:
+                model = kwargs.get("chat_model") or (args[1] if len(args) > 1 else "")
+                sys_p = kwargs.get("system_prompt") or (args[2] if len(args) > 2 else "")
+                user_c = kwargs.get("user_content") or (args[3] if len(args) > 3 else "")
+                prompt_chars = len(str(sys_p)) + len(str(user_c))
+
+            t0 = time.perf_counter()
+            result = original(*args, **kwargs)
+            elapsed = time.perf_counter() - t0
+
+            # response size: str for direct/streaming, dict for chat_with_messages
+            if isinstance(result, str):
+                response_chars = len(result)
+            elif isinstance(result, dict):
+                response_chars = len(str(result.get("content", "")))
+            else:
+                response_chars = 0
+
+            self.calls.append(_Call(
+                context=ctx,
+                duration_sec=elapsed,
+                model=str(model),
+                prompt_chars=prompt_chars,
+                response_chars=response_chars,
+            ))
+            return result
+
+        return wrapped
+
+    def _patch(self) -> None:
+        """Patch every module that has already imported one of the LLM entry
+        points via ``from ..llm import X``. Those bindings were resolved at
+        import time and do NOT see a setattr on ``jarvis.llm`` itself, so we
+        have to replace the attribute on each importer.
+        """
+        import sys as _sys
+        names = ("call_llm_direct", "call_llm_streaming", "chat_with_messages")
+        # Capture the originals from the llm module once.
+        originals = {n: getattr(_llm_module, n) for n in names}
+        # self._originals stores [(module, name, original_fn)] so _unpatch
+        # can put each binding back exactly where it came from.
+        self._originals["_sites"] = []
+        for mod in list(_sys.modules.values()):
+            if mod is None or mod is _llm_module:
+                continue
+            mod_name = getattr(mod, "__name__", "")
+            if not mod_name.startswith(("jarvis", "tests", "evals")):
+                continue
+            for name in names:
+                current = getattr(mod, name, None)
+                if current is originals[name]:
+                    wrapped = self._wrap(name, originals[name])
+                    setattr(mod, name, wrapped)
+                    self._originals["_sites"].append((mod, name, originals[name]))
+        # Also patch the canonical module so any late `from jarvis.llm import X`
+        # after we enter the context sees the wrapper.
+        for name in names:
+            wrapped = self._wrap(name, originals[name])
+            setattr(_llm_module, name, wrapped)
+            self._originals["_sites"].append((_llm_module, name, originals[name]))
+
+    def _unpatch(self) -> None:
+        for mod, name, original in self._originals.get("_sites", []):
+            setattr(mod, name, original)
+        self._originals.clear()
+
+    # ── queries ──────────────────────────────────────────────────────────
+    def by_context(self) -> dict[str, list[_Call]]:
+        out: dict[str, list[_Call]] = {}
+        for c in self.calls:
+            out.setdefault(c.context, []).append(c)
+        return out
+
+    def durations(self, context: str) -> list[float]:
+        return [c.duration_sec for c in self.calls if c.context == context]
+
+    def p50(self, context: str) -> float:
+        ds = self.durations(context)
+        return statistics.median(ds) if ds else 0.0
+
+    def p95(self, context: str) -> float:
+        ds = self.durations(context)
+        if not ds:
+            return 0.0
+        if len(ds) == 1:
+            return ds[0]
+        ds_sorted = sorted(ds)
+        idx = max(0, int(round(0.95 * (len(ds_sorted) - 1))))
+        return ds_sorted[idx]
+
+    def total(self, context: Optional[str] = None) -> float:
+        if context is None:
+            return sum(c.duration_sec for c in self.calls)
+        return sum(c.duration_sec for c in self.calls if c.context == context)
+
+    # ── reporting ────────────────────────────────────────────────────────
+    def to_dict(self) -> dict:
+        buckets = self.by_context()
+        return {
+            "total_calls": len(self.calls),
+            "total_sec": round(self.total(), 3),
+            "contexts": {
+                ctx: {
+                    "calls": len(calls),
+                    "total_sec": round(sum(c.duration_sec for c in calls), 3),
+                    "p50_sec": round(self.p50(ctx), 3),
+                    "p95_sec": round(self.p95(ctx), 3),
+                    "avg_prompt_chars": int(statistics.mean(c.prompt_chars for c in calls)) if calls else 0,
+                    "avg_response_chars": int(statistics.mean(c.response_chars for c in calls)) if calls else 0,
+                    "models": sorted({c.model for c in calls if c.model}),
+                }
+                for ctx, calls in buckets.items()
+            },
+        }
+
+    def print_report(self, title: str = "LLM pipeline timings") -> None:
+        print(f"\n⏱️  {title}")
+        print(f"   total calls: {len(self.calls)}   total wall time: {self.total():.2f}s")
+        rows = sorted(
+            self.by_context().items(),
+            key=lambda kv: -sum(c.duration_sec for c in kv[1]),
+        )
+        header = f"   {'context':<22} {'n':>3}  {'total':>7}  {'p50':>6}  {'p95':>6}  {'prompt':>7}  model"
+        print(header)
+        print("   " + "-" * (len(header) - 3))
+        for ctx, calls in rows:
+            total = sum(c.duration_sec for c in calls)
+            print(
+                f"   {ctx:<22} {len(calls):>3}  "
+                f"{total:>6.2f}s  {self.p50(ctx):>5.2f}s  {self.p95(ctx):>5.2f}s  "
+                f"{int(statistics.mean(c.prompt_chars for c in calls)):>7}  "
+                f"{','.join(sorted({c.model for c in calls if c.model}))}"
+            )
+
+
+@contextmanager
+def record_timings():
+    """Convenience context manager."""
+    rec = TimingRecorder()
+    with rec:
+        yield rec

--- a/tests/test_enrichment_model_routing.py
+++ b/tests/test_enrichment_model_routing.py
@@ -1,0 +1,68 @@
+"""Behaviour test: memory enrichment extractor runs on the router model chain.
+
+The extractor used to run on the big chat model, which paged in the heavy
+weights just to emit a tiny JSON blob. It's now routed through
+``resolve_tool_router_model`` so it rides the already-warm small model.
+
+This test locks that in at the engine call-site — if somebody ever reverts to
+``cfg.ollama_chat_model`` there, the assertion fails.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+
+@pytest.mark.unit
+def test_enrichment_extractor_uses_router_model_chain():
+    from jarvis.reply import engine as engine_mod
+
+    captured: dict[str, str] = {}
+
+    def _fake_extract(query, base_url, chat_model, **kwargs):
+        captured["chat_model"] = chat_model
+        return {"keywords": [], "questions": []}
+
+    cfg = MagicMock()
+    cfg.ollama_base_url = "http://localhost:11434"
+    cfg.ollama_chat_model = "big-chat"
+    cfg.intent_judge_model = "small-judge"
+    cfg.tool_router_model = ""
+    cfg.llm_tools_timeout_sec = 5.0
+    cfg.llm_thinking_enabled = False
+    cfg.memory_enrichment_source = "diary"
+    cfg.memory_enrichment_max_snippets = 3
+
+    with patch.object(engine_mod, "extract_search_params_for_memory", side_effect=_fake_extract), \
+         patch.object(engine_mod, "search_conversation_memory_by_keywords", return_value=[], create=True), \
+         patch.object(engine_mod, "_build_enrichment_context_hint", return_value=""):
+        # Call the internal enrichment helper directly via the same path the
+        # engine does — if the symbol moves, this import will fail loudly.
+        engine_mod.extract_search_params_for_memory(
+            "hello",
+            cfg.ollama_base_url,
+            engine_mod.resolve_tool_router_model(cfg),
+            timeout_sec=cfg.llm_tools_timeout_sec,
+            thinking=cfg.llm_thinking_enabled,
+            context_hint="",
+        )
+
+    assert captured["chat_model"] == "small-judge", (
+        "enrichment extractor should resolve via resolve_tool_router_model, "
+        "not cfg.ollama_chat_model"
+    )
+
+
+@pytest.mark.unit
+def test_resolve_tool_router_model_is_public():
+    """The symbol is imported cross-layer (daemon, memory viewer, listener),
+    so it must stay part of the public API — underscore-prefixed names are not
+    allowed."""
+    from jarvis.reply import engine
+
+    assert hasattr(engine, "resolve_tool_router_model")
+    assert not hasattr(engine, "_resolve_tool_router_model"), (
+        "the private alias was removed — callers should use the public name"
+    )

--- a/tests/test_graph_ops.py
+++ b/tests/test_graph_ops.py
@@ -173,6 +173,22 @@ class TestLLMPickBestChild:
         result = _llm_pick_best_child("fact", children, "http://localhost", "model")
         assert result is None
 
+    @patch("src.jarvis.memory.graph_ops.call_llm_direct")
+    def test_uses_picker_model_when_provided(self, mock_llm, populated_store):
+        # Behaviour: picker_model overrides the chat model for this classification-
+        # shaped call, so placement runs on the small model without paging in the
+        # big chat model. When absent, the chat model is used (backwards-compatible).
+        children = populated_store.get_children("root")
+        mock_llm.return_value = "1"
+
+        _llm_pick_best_child(
+            "fact", children, "http://localhost", "big-chat", picker_model="small-judge"
+        )
+        assert mock_llm.call_args.kwargs["chat_model"] == "small-judge"
+
+        _llm_pick_best_child("fact", children, "http://localhost", "big-chat")
+        assert mock_llm.call_args.kwargs["chat_model"] == "big-chat"
+
 
 # ── find_best_node ─────────────────────────────────────────────────────
 

--- a/tests/test_tool_router_resolution.py
+++ b/tests/test_tool_router_resolution.py
@@ -4,7 +4,7 @@ The reply engine and the listener warmup path both need to pick the model
 used for LLM-based tool selection, and they MUST pick the same one — if they
 diverge, warmup loads the wrong model and the first real routing call eats a
 cold-start stall. The resolution order is enforced by a single helper
-(`_resolve_tool_router_model`), which this test exercises directly.
+(``resolve_tool_router_model``), which this test exercises directly.
 
 Order: `tool_router_model` → `intent_judge_model` → `ollama_chat_model` →
 empty string. The key property is that an explicit `tool_router_model` wins
@@ -14,7 +14,7 @@ over everything, and that an empty `tool_router_model` falls through to the
 
 import pytest
 
-from jarvis.reply.engine import _resolve_tool_router_model
+from jarvis.reply.engine import resolve_tool_router_model
 
 
 class _Cfg:
@@ -31,7 +31,7 @@ class TestToolRouterModelResolution:
     @pytest.mark.unit
     def test_explicit_router_wins(self):
         cfg = _Cfg(router="custom-router", judge="judge-m", chat="chat-m")
-        assert _resolve_tool_router_model(cfg) == "custom-router"
+        assert resolve_tool_router_model(cfg) == "custom-router"
 
     @pytest.mark.unit
     def test_empty_router_falls_through_to_judge(self):
@@ -40,19 +40,19 @@ class TestToolRouterModelResolution:
         routing call on the small, warm model instead of reloading the
         large chat model every turn."""
         cfg = _Cfg(router="", judge="judge-m", chat="chat-m")
-        assert _resolve_tool_router_model(cfg) == "judge-m"
+        assert resolve_tool_router_model(cfg) == "judge-m"
 
     @pytest.mark.unit
     def test_falls_through_to_chat_when_no_router_or_judge(self):
         cfg = _Cfg(router="", judge="", chat="chat-m")
-        assert _resolve_tool_router_model(cfg) == "chat-m"
+        assert resolve_tool_router_model(cfg) == "chat-m"
 
     @pytest.mark.unit
     def test_returns_empty_when_nothing_configured(self):
         """The caller handles an empty model name by falling back to the
         all-tools path — the helper itself should not invent a default."""
         cfg = _Cfg(router="", judge="", chat="")
-        assert _resolve_tool_router_model(cfg) == ""
+        assert resolve_tool_router_model(cfg) == ""
 
     @pytest.mark.unit
     def test_robust_to_missing_attributes(self):
@@ -60,4 +60,4 @@ class TestToolRouterModelResolution:
         happen for partial mocks), the resolver must not raise."""
         class Partial:
             ollama_chat_model = "only-chat"
-        assert _resolve_tool_router_model(Partial()) == "only-chat"
+        assert resolve_tool_router_model(Partial()) == "only-chat"


### PR DESCRIPTION
## Summary

- Map every LLM context in the app to [docs/llm_contexts.md](docs/llm_contexts.md) (authoritative reference for optimisation work) and add a CLAUDE.md rule to keep it in sync with code changes.
- Demote two classification-shaped LLM calls from the big chat model to the intent-judge chain (`intent_judge_model → chat_model`):
  - **Memory enrichment extractor** (once per reply, pre-loop) — now uses `_resolve_tool_router_model(cfg)` at the call site in `reply/engine.py`.
  - **Graph best-child picker** (N per background flush) — threaded an optional `picker_model` through `find_best_node` → `update_graph_from_dialogue` → `update_diary_from_dialogue_memory`; `daemon.py` resolves it via the same chain.
- Add `tests/performance/`: a live-Ollama timing harness.
  - `timing_recorder.py` monkey-patches the three entry points in `jarvis.llm` across every importer and infers the calling context from the stack's `__qualname__` (mapped to the 13 contexts in the graph doc).
  - `test_pipeline_timings.py` runs a micro-benchmark (tiny fixed prompt → per-call floor) and a full reply pipeline (3 representative queries × N runs), dumps JSON reports, and asserts relative-shape invariants (evaluator/router ≤ 1.5× main chat turn, enrichment extractor shares the router model chain).
  - Gated behind `@pytest.mark.performance`, excluded by default via `addopts` in pytest.ini, auto-skips when Ollama is unreachable.

## Why

LLM calls are the main perf bottleneck and we run several contexts per reply (intent judge, router, enrichment, evaluator, digests, main loop, ...). Without a single map of where each call lives, what feeds it, and what it outputs, it's hard to reason about optimisations. The graph doc fixes that. The two demotions are the cleanest easy wins it surfaced, and the perf harness gives us a way to diff timings before/after any future change without eyeballing.

## Baseline

Local run on `gemma4:e2b` (3 queries × 3 runs):

```
main_chat_turn      25 calls  p50 4.54s  p95 5.12s
evaluator           15 calls  p50 3.76s  p95 4.01s   (~82% of a main turn)
enrichment_extract   9 calls  p50 0.88s  p95 0.94s   (small-model chain ✓)
max_turn_digest      1 call   p50 1.04s
micro-prompt floor                        p50 0.15s
```

Notable hot lead: evaluator total (56s) is ~70% of main chat inference cost (78s). Likely a prompt-size or model-choice follow-up.

## Test plan

- [x] `pytest tests/test_graph_ops.py tests/test_enrichment.py` — passes (added test for `picker_model` override).
- [x] Broader related tests pass (`pytest -k "graph or enrichment or engine or router or daemon"` — 207 passed).
- [x] `pytest tests/performance/ -v -m performance -s` against local Ollama — both perf tests pass, report written to `tests/performance/reports/`.
- [x] `pytest tests/performance/` without the marker — 2 deselected (confirms default suite unaffected).