### PR TITLE
chore(config): default tool-result digest off; default diary recall to 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,12 +244,12 @@ Small chat models (~2B, e.g. `gemma4:e2b`) degrade sharply as their prompt grows
 - **Memory digest** — boils diary + graph recall into a short relevance-filtered note before injecting it as background context.
 - **Tool-result digest** — boils a raw tool payload (especially webSearch UNTRUSTED WEB EXTRACT blocks) into a short attributed fact note before it reaches the main reply model.
 
-Both auto-enable for small models and stay off for large models that ground on raw payloads reliably. Override in `~/.config/jarvis/config.json`:
+Memory digest auto-enables for small models and stays off for large models that ground on raw payloads reliably. Tool-result digest defaults to off, since the extra LLM pass adds latency per tool call and small models often drop salient numbers or names the main model would have grounded on; set it to `true` to force on or `null` to opt back into auto-on-for-small. Override in `~/.config/jarvis/config.json`:
 
 ```json
 {
   "memory_digest_enabled": null,          // null = auto-on for SMALL, false to force off, true to force on
-  "tool_result_digest_enabled": null,     // same semantics
+  "tool_result_digest_enabled": false,    // default off; null = auto-on for SMALL, true to force on
   "llm_digest_timeout_sec": 8.0           // tight ceiling shared by both passes
 }
 ```

--- a/docs/llm_contexts.md
+++ b/docs/llm_contexts.md
@@ -64,10 +64,10 @@ Every distinct LLM call in Jarvis, what feeds it, what consumes it, and how it i
 - **Output**: ≤400 chars text per batch (`_DIGEST_MAX_CHARS`) injected as reference-only memory context into the main loop's system message. Empty on failure.
 - **Limits**: `llm_digest_timeout_sec` (8s, shared).
 
-## 6. Tool-Result Digest (optional, SMALL models)
+## 6. Tool-Result Digest (optional, opt-in)
 
 - **File**: [src/jarvis/reply/enrichment.py](src/jarvis/reply/enrichment.py) — `digest_tool_result_for_query()` + `_distil_tool_batch()`.
-- **Trigger**: after each tool result in the loop, if `tool_result_digest_enabled` (auto-ON for SMALL, OFF for LARGE). Skipped if raw < 400 chars (`_TOOL_DIGEST_MIN_CHARS`); batched if > 2500 (`_TOOL_DIGEST_BATCH_MAX_CHARS`).
+- **Trigger**: after each tool result in the loop, if `tool_result_digest_enabled`. Default is `false` (off everywhere); `null` opts into auto-ON-for-SMALL. Skipped if raw < 400 chars (`_TOOL_DIGEST_MIN_CHARS`); batched if > 2500 (`_TOOL_DIGEST_BATCH_MAX_CHARS`).
 - **Model / gating**: `ollama_chat_model`. Gated by `tool_result_digest_enabled`.
 - **Inputs**: user query, tool name, raw tool result (e.g. webSearch payload inside UNTRUSTED WEB EXTRACT fence).
 - **System prompt**: `_TOOL_DIGEST_SYSTEM_PROMPT`. Teaches attributed fact extraction, `NONE` sentinel, no inference.

--- a/examples/config.json
+++ b/examples/config.json
@@ -77,7 +77,7 @@
   "echo_energy_threshold": 2.0,
   "echo_tolerance": 0.3,
   "dialogue_memory_timeout": 300.0,
-  "memory_enrichment_max_results": 10,
+  "memory_enrichment_max_results": 5,
   "memory_search_max_results": 15,
   "agentic_max_turns": 8,
   "stop_commands": [

--- a/src/jarvis/config.py
+++ b/src/jarvis/config.py
@@ -453,15 +453,18 @@ def get_default_config() -> Dict[str, Any]:
         # dialogue_memory_timeout drives the short-term memory window AND the forced
         # diary update interval. After a diary update, enrichment retrieves older context.
         "dialogue_memory_timeout": 300.0,
-        "memory_enrichment_max_results": 10,
+        "memory_enrichment_max_results": 5,
         "memory_search_max_results": 15,
         "memory_enrichment_source": "diary",  # "all", "diary", or "graph"
         # None = auto (on for small models, off for large). Set true/false to force.
         "memory_digest_enabled": None,
         # Distil raw tool results (e.g. webSearch extracts) into a short
-        # attributed fact note for small models. Same auto semantics as
-        # memory_digest_enabled.
-        "tool_result_digest_enabled": None,
+        # attributed fact note for small models. Defaults to off: the extra
+        # digest LLM pass adds latency per tool call and, on small models,
+        # often drops salient numbers/names the main model would have
+        # grounded on. Set to ``true`` to force on, or ``null`` to opt back
+        # into the old auto-on-for-small behaviour.
+        "tool_result_digest_enabled": False,
 
         # Agentic Loop
         "agentic_max_turns": 8,
@@ -632,7 +635,7 @@ def load_settings() -> Settings:
 
     # Dialogue memory window and forced diary update share this duration
     dialogue_memory_timeout = float(merged.get("dialogue_memory_timeout", 300.0))
-    memory_enrichment_max_results = int(merged.get("memory_enrichment_max_results", 10))
+    memory_enrichment_max_results = int(merged.get("memory_enrichment_max_results", 5))
     memory_search_max_results = int(merged.get("memory_search_max_results", 15))
     memory_enrichment_source = str(merged.get("memory_enrichment_source", "diary")).lower()
     if memory_enrichment_source not in ("all", "diary", "graph"):

--- a/src/jarvis/reply/reply.spec.md
+++ b/src/jarvis/reply/reply.spec.md
@@ -272,7 +272,7 @@ Turn 4: LLM → {content: "Here's a comprehensive comparison of the iPhone 15 mo
 - Memory enrichment:
   - `memory_enrichment_max_results` limits recalled snippets.
   - `memory_digest_enabled` (default `null` = auto-on for SMALL models, off for LARGE) distils the combined diary + graph dump into a short relevance-filtered note via a cheap LLM pass before injecting into the system prompt. See **Memory Digest for Small Models** below.
-  - `tool_result_digest_enabled` (default `null` = auto-on for SMALL models, off for LARGE) distils raw tool-result payloads (especially webSearch UNTRUSTED WEB EXTRACT blocks) into a short attributed fact note before appending as a tool-role message. See **Tool-Result Digest for Small Models** below.
+  - `tool_result_digest_enabled` (default `false`) distils raw tool-result payloads (especially webSearch UNTRUSTED WEB EXTRACT blocks) into a short attributed fact note before appending as a tool-role message. Defaults to off because the extra digest pass adds latency per tool call and on small models frequently drops salient facts (numbers, names) the main model would otherwise ground on. Set to `true` to force on, or `null` to opt back into the auto-on-for-SMALL behaviour. See **Tool-Result Digest for Small Models** below.
 - Tools and MCP:
   - All builtin tools are always available; MCP servers added from `cfg.mcps`.
 - Agentic loop:
@@ -346,7 +346,7 @@ Small models struggle with long tool outputs the same way they struggle with lon
 `digest_tool_result_for_query` (in `src/jarvis/reply/enrichment.py`) runs a cheap LLM pass over the raw tool output and returns an attributed fact note that replaces the tool-role message content before it reaches the main model.
 
 Behaviour:
-- **Gating**: `tool_result_digest_enabled` (config). `None` (default) means auto-on for SMALL models, off for LARGE. Explicit `true`/`false` forces.
+- **Gating**: `tool_result_digest_enabled` (config). Default is `false` — the digest is opt-in. `null` opts into the auto-on-for-SMALL behaviour (off for LARGE), and explicit `true`/`false` forces.
 - **Short-circuit**: if the raw result is below `_TOOL_DIGEST_MIN_CHARS` (400 chars), it's passed through unchanged.
 - **Single-batch fast path**: if the raw result fits under `_TOOL_DIGEST_BATCH_MAX_CHARS` (2500 chars), one distil call produces the note. This is the typical case for webSearch.
 - **Multi-batch fallback**: if the raw result exceeds the per-batch cap, it's split on paragraph boundaries (blank-line-separated) so envelope framing and fence markers stay in whichever chunk contains them; each chunk is distilled independently and surviving notes are joined.


### PR DESCRIPTION
## Summary

- **`tool_result_digest_enabled` now defaults to `false`.** The digest was auto-on for small models, but the extra LLM pass added latency per tool call and, on small models, frequently dropped salient numbers/names the main model would otherwise ground on. Users who want it can set ``true`` (force on) or ``null`` (opt back into auto-on-for-SMALL).
- **`memory_enrichment_max_results` default lowered from 10 to 5.** Enrichment snippets land in the system prompt on every turn; the marginal recall value of entries 6–10 rarely pays for their prompt-token cost on small models.

Spec files, README, example config, and LLM-contexts graph updated to match.

## Test plan

- [x] `tests/test_enrichment.py`, `tests/test_dialogue_memory.py`, `tests/test_location_context.py` pass locally.
- [ ] Field check with a small local model: tool-call reply no longer waits on the digest; diary recall stays on topic with the smaller window.