### PR TITLE
perf(config): trim memory enrichment to 3; restore digest defaults; fix intent judge num_ctx

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,11 +244,11 @@ Small chat models (~2B, e.g. `gemma4:e2b`) degrade sharply as their prompt grows
 - **Memory digest** — boils diary + graph recall into a short relevance-filtered note before injecting it as background context.
 - **Tool-result digest** — boils a raw tool payload (especially webSearch UNTRUSTED WEB EXTRACT blocks) into a short attributed fact note before it reaches the main reply model.
 
-Memory digest auto-enables for small models and stays off for large models that ground on raw payloads reliably. Tool-result digest defaults to off, since the extra LLM pass adds latency per tool call and small models often drop salient numbers or names the main model would have grounded on; set it to `true` to force on or `null` to opt back into auto-on-for-small. Override in `~/.config/jarvis/config.json`:
+Both digest passes default to off, since the extra LLM pass adds latency and small models often drop salient facts the main model would have grounded on. Set to `true` to force on, or `null` to opt back into auto-on-for-SMALL. Override in `~/.config/jarvis/config.json`:
 
 ```json
 {
-  "memory_digest_enabled": null,          // null = auto-on for SMALL, false to force off, true to force on
+  "memory_digest_enabled": false,         // default off; null = auto-on for SMALL, true to force on
   "tool_result_digest_enabled": false,    // default off; null = auto-on for SMALL, true to force on
   "llm_digest_timeout_sec": 8.0           // tight ceiling shared by both passes
 }

--- a/README.md
+++ b/README.md
@@ -244,12 +244,12 @@ Small chat models (~2B, e.g. `gemma4:e2b`) degrade sharply as their prompt grows
 - **Memory digest** — boils diary + graph recall into a short relevance-filtered note before injecting it as background context.
 - **Tool-result digest** — boils a raw tool payload (especially webSearch UNTRUSTED WEB EXTRACT blocks) into a short attributed fact note before it reaches the main reply model.
 
-Memory digest auto-enables for small models (≤7B) and stays off for large models that ground on raw payloads reliably. Tool-result digest defaults to off. Override in `~/.config/jarvis/config.json`:
+Both digest passes auto-enable for small models (≤7B) and stay off for large models. For small models, tool-result digest also prevents large fetch_web_page payloads from blowing the context window. Override in `~/.config/jarvis/config.json`:
 
 ```json
 {
   "memory_digest_enabled": null,          // null = auto-on for SMALL, false to force off, true to force on
-  "tool_result_digest_enabled": false,    // default off; null = auto-on for SMALL, true to force on
+  "tool_result_digest_enabled": null,     // null = auto-on for SMALL, false to force off, true to force on
   "llm_digest_timeout_sec": 8.0           // tight ceiling shared by both passes
 }
 ```

--- a/README.md
+++ b/README.md
@@ -244,11 +244,11 @@ Small chat models (~2B, e.g. `gemma4:e2b`) degrade sharply as their prompt grows
 - **Memory digest** — boils diary + graph recall into a short relevance-filtered note before injecting it as background context.
 - **Tool-result digest** — boils a raw tool payload (especially webSearch UNTRUSTED WEB EXTRACT blocks) into a short attributed fact note before it reaches the main reply model.
 
-Both digest passes default to off, since the extra LLM pass adds latency and small models often drop salient facts the main model would have grounded on. Set to `true` to force on, or `null` to opt back into auto-on-for-SMALL. Override in `~/.config/jarvis/config.json`:
+Memory digest auto-enables for small models (≤7B) and stays off for large models that ground on raw payloads reliably. Tool-result digest defaults to off. Override in `~/.config/jarvis/config.json`:
 
 ```json
 {
-  "memory_digest_enabled": false,         // default off; null = auto-on for SMALL, true to force on
+  "memory_digest_enabled": null,          // null = auto-on for SMALL, false to force off, true to force on
   "tool_result_digest_enabled": false,    // default off; null = auto-on for SMALL, true to force on
   "llm_digest_timeout_sec": 8.0           // tight ceiling shared by both passes
 }

--- a/docs/llm_contexts.md
+++ b/docs/llm_contexts.md
@@ -18,7 +18,7 @@ Every distinct LLM call in Jarvis, what feeds it, what consumes it, and how it i
   - Tool schema: native via `generate_tools_json_schema()` ([src/jarvis/tools/registry.py](src/jarvis/tools/registry.py)) or text fallback via `_text_tool_call_guidance()` ([engine.py:68](src/jarvis/reply/engine.py:68))
   - Tool results from prior turns (raw or digested — see #6)
 - **Output**: OpenAI-style `{content, tool_calls, thinking}`. Consumed by the evaluator (#3), tool orchestrator, and TTS pipeline.
-- **Limits**: `num_ctx: 8192` (explicit). Timeout `llm_chat_timeout_sec` (45s). Auto-fallback from native to text tool-calls on HTTP 400 (`ToolsNotSupportedError`), sticky for the session. Risk: `fetch_web_page` truncates at 50,000 chars (~37k tokens) — a single fetch result landing in the messages history will blow the 8192 window; the model will silently see a truncated context.
+- **Limits**: `num_ctx: 8192` (explicit). Timeout `llm_chat_timeout_sec` (45s). Auto-fallback from native to text tool-calls on HTTP 400 (`ToolsNotSupportedError`), sticky for the session. Risk: `fetch_web_page` truncates at 50,000 chars (~37k tokens) — mitigated for SMALL models by tool-result digest (#6) which compresses the payload before it enters the messages history. LARGE models receive the raw payload and may silently see a truncated context.
 
 ## 2. Intent Judge
 
@@ -67,7 +67,7 @@ Every distinct LLM call in Jarvis, what feeds it, what consumes it, and how it i
 ## 6. Tool-Result Digest (optional, opt-in)
 
 - **File**: [src/jarvis/reply/enrichment.py](src/jarvis/reply/enrichment.py) — `digest_tool_result_for_query()` + `_distil_tool_batch()`.
-- **Trigger**: after each tool result in the loop, if `tool_result_digest_enabled`. Default is `false` (off everywhere); `null` opts into auto-ON-for-SMALL. Skipped if raw < 400 chars (`_TOOL_DIGEST_MIN_CHARS`); batched if > 2500 (`_TOOL_DIGEST_BATCH_MAX_CHARS`).
+- **Trigger**: after each tool result in the loop, if `tool_result_digest_enabled` (default `null` = auto-ON for SMALL ≤7B, OFF for LARGE). Primary motivation on small models: prevents `fetch_web_page`'s 50k-char payloads from filling the 8192 num_ctx window. Skipped if raw < 400 chars (`_TOOL_DIGEST_MIN_CHARS`); batched if > 2500 (`_TOOL_DIGEST_BATCH_MAX_CHARS`).
 - **Model / gating**: `ollama_chat_model`. Gated by `tool_result_digest_enabled`.
 - **Inputs**: user query, tool name, raw tool result (e.g. webSearch payload inside UNTRUSTED WEB EXTRACT fence).
 - **System prompt**: `_TOOL_DIGEST_SYSTEM_PROMPT`. Teaches attributed fact extraction, `NONE` sentinel, no inference.

--- a/docs/llm_contexts.md
+++ b/docs/llm_contexts.md
@@ -54,10 +54,10 @@ Every distinct LLM call in Jarvis, what feeds it, what consumes it, and how it i
 - **Output**: `{keywords, from?, to?, questions?}`. Consumed by memory search at ~engine.py:1359.
 - **Limits**: up to 2 retries; timeout from `llm_tools_timeout_sec`.
 
-## 5. Memory Digest (optional, SMALL models)
+## 5. Memory Digest (optional, opt-in)
 
 - **File**: [src/jarvis/reply/enrichment.py](src/jarvis/reply/enrichment.py) — `digest_memory_for_query()` + `_distil_batch()`.
-- **Trigger**: once per reply when enrichment returns hits AND `memory_digest_enabled` (auto-ON for SMALL ≤7B, OFF for LARGE). Skipped if raw < `_DIGEST_MIN_CHARS` (400). Batched if raw > `_DIGEST_BATCH_MAX_CHARS` (2000).
+- **Trigger**: once per reply when enrichment returns hits AND `memory_digest_enabled` (default OFF; `null` = auto-ON for SMALL ≤7B / OFF for LARGE). Skipped if raw < `_DIGEST_MIN_CHARS` (400). Batched if raw > `_DIGEST_BATCH_MAX_CHARS` (2000).
 - **Model / gating**: `ollama_chat_model`. Gated by `memory_digest_enabled`.
 - **Inputs**: user query, raw diary entries, raw graph nodes.
 - **System prompt**: `_DIGEST_SYSTEM_PROMPT` at [enrichment.py:122](src/jarvis/reply/enrichment.py:122). Teaches relevance filtering, preference-signal detection, attribution preservation, `NONE` sentinel, identity queries.

--- a/docs/llm_contexts.md
+++ b/docs/llm_contexts.md
@@ -18,7 +18,7 @@ Every distinct LLM call in Jarvis, what feeds it, what consumes it, and how it i
   - Tool schema: native via `generate_tools_json_schema()` ([src/jarvis/tools/registry.py](src/jarvis/tools/registry.py)) or text fallback via `_text_tool_call_guidance()` ([engine.py:68](src/jarvis/reply/engine.py:68))
   - Tool results from prior turns (raw or digested — see #6)
 - **Output**: OpenAI-style `{content, tool_calls, thinking}`. Consumed by the evaluator (#3), tool orchestrator, and TTS pipeline.
-- **Limits**: no explicit `max_tokens` — Ollama defaults. Timeout `llm_chat_timeout_sec` (45s). Auto-fallback from native to text tool-calls on HTTP 400 (`ToolsNotSupportedError`), sticky for the session.
+- **Limits**: `num_ctx: 8192` (explicit). Timeout `llm_chat_timeout_sec` (45s). Auto-fallback from native to text tool-calls on HTTP 400 (`ToolsNotSupportedError`), sticky for the session. Risk: `fetch_web_page` truncates at 50,000 chars (~37k tokens) — a single fetch result landing in the messages history will blow the 8192 window; the model will silently see a truncated context.
 
 ## 2. Intent Judge
 
@@ -32,7 +32,7 @@ Every distinct LLM call in Jarvis, what feeds it, what consumes it, and how it i
   - State flags (wake_word_mode, hot_window_mode, during_tts)
 - **System prompt**: `SYSTEM_PROMPT_TEMPLATE` at [intent_judge.py:135](src/jarvis/listening/intent_judge.py:135). Teaches query extraction, echo detection, stop commands, pronoun/topic disambiguation, imperative re-addressing, declaratives to the wake word.
 - **Output**: strict JSON `IntentJudgment{directed, query, stop, confidence, reasoning}` ([intent_judge.py:94](src/jarvis/listening/intent_judge.py:94)). Consumed by the listening state machine which dispatches to the reply engine.
-- **Limits**: `intent_judge_timeout_sec` (15s).
+- **Limits**: `intent_judge_timeout_sec` (15s). `num_ctx: 4096` (explicit — transcript buffer can reach 400+ tokens; Ollama's model default of 2048 would silently truncate it).
 
 ## 3. Evaluator (post-turn decision)
 

--- a/examples/config.json
+++ b/examples/config.json
@@ -77,7 +77,7 @@
   "echo_energy_threshold": 2.0,
   "echo_tolerance": 0.3,
   "dialogue_memory_timeout": 300.0,
-  "memory_enrichment_max_results": 5,
+  "memory_enrichment_max_results": 3,
   "memory_search_max_results": 15,
   "agentic_max_turns": 8,
   "stop_commands": [

--- a/src/jarvis/config.py
+++ b/src/jarvis/config.py
@@ -456,11 +456,8 @@ def get_default_config() -> Dict[str, Any]:
         "memory_enrichment_max_results": 3,
         "memory_search_max_results": 15,
         "memory_enrichment_source": "diary",  # "all", "diary", or "graph"
-        # Defaults to off: the digest LLM pass adds latency and, on small
-        # models, often drops salient facts the main model would have
-        # grounded on. Set ``true`` to force on, or ``null`` to opt back
-        # into the old auto-on-for-small behaviour.
-        "memory_digest_enabled": False,
+        # None = auto (on for small models ≤7B, off for large). Set true/false to force.
+        "memory_digest_enabled": None,
         # Distil raw tool results (e.g. webSearch extracts) into a short
         # attributed fact note for small models. Defaults to off: the extra
         # digest LLM pass adds latency per tool call and, on small models,

--- a/src/jarvis/config.py
+++ b/src/jarvis/config.py
@@ -460,11 +460,10 @@ def get_default_config() -> Dict[str, Any]:
         "memory_digest_enabled": None,
         # Distil raw tool results (e.g. webSearch extracts) into a short
         # attributed fact note for small models. Defaults to off: the extra
-        # digest LLM pass adds latency per tool call and, on small models,
-        # often drops salient numbers/names the main model would have
-        # grounded on. Set to ``true`` to force on, or ``null`` to opt back
-        # into the old auto-on-for-small behaviour.
-        "tool_result_digest_enabled": False,
+        # None = auto (on for small models ≤7B, off for large). Set true/false to force.
+        # Auto-on for small models mitigates fetch_web_page's 50k-char payloads
+        # blowing the 8192 num_ctx window before the main model sees them.
+        "tool_result_digest_enabled": None,
 
         # Agentic Loop
         "agentic_max_turns": 8,

--- a/src/jarvis/config.py
+++ b/src/jarvis/config.py
@@ -453,11 +453,14 @@ def get_default_config() -> Dict[str, Any]:
         # dialogue_memory_timeout drives the short-term memory window AND the forced
         # diary update interval. After a diary update, enrichment retrieves older context.
         "dialogue_memory_timeout": 300.0,
-        "memory_enrichment_max_results": 5,
+        "memory_enrichment_max_results": 3,
         "memory_search_max_results": 15,
         "memory_enrichment_source": "diary",  # "all", "diary", or "graph"
-        # None = auto (on for small models, off for large). Set true/false to force.
-        "memory_digest_enabled": None,
+        # Defaults to off: the digest LLM pass adds latency and, on small
+        # models, often drops salient facts the main model would have
+        # grounded on. Set ``true`` to force on, or ``null`` to opt back
+        # into the old auto-on-for-small behaviour.
+        "memory_digest_enabled": False,
         # Distil raw tool results (e.g. webSearch extracts) into a short
         # attributed fact note for small models. Defaults to off: the extra
         # digest LLM pass adds latency per tool call and, on small models,
@@ -635,7 +638,7 @@ def load_settings() -> Settings:
 
     # Dialogue memory window and forced diary update share this duration
     dialogue_memory_timeout = float(merged.get("dialogue_memory_timeout", 300.0))
-    memory_enrichment_max_results = int(merged.get("memory_enrichment_max_results", 5))
+    memory_enrichment_max_results = int(merged.get("memory_enrichment_max_results", 3))
     memory_search_max_results = int(merged.get("memory_search_max_results", 15))
     memory_enrichment_source = str(merged.get("memory_enrichment_source", "diary")).lower()
     if memory_enrichment_source not in ("all", "diary", "graph"):

--- a/src/jarvis/listening/intent_judge.py
+++ b/src/jarvis/listening/intent_judge.py
@@ -422,6 +422,7 @@ Examples:
                     "options": {
                         "temperature": 0.0,
                         "num_predict": 200,
+                        "num_ctx": 4096,
                     },
                 },
                 timeout=self.config.timeout_sec,

--- a/src/jarvis/reply/reply.spec.md
+++ b/src/jarvis/reply/reply.spec.md
@@ -271,7 +271,7 @@ Turn 4: LLM → {content: "Here's a comprehensive comparison of the iPhone 15 mo
   - `llm_chat_timeout_sec` (messages loop turn)
 - Memory enrichment:
   - `memory_enrichment_max_results` limits recalled snippets.
-  - `memory_digest_enabled` (default `false`) distils the combined diary + graph dump into a short relevance-filtered note via a cheap LLM pass before injecting into the system prompt. Defaults to off because the extra digest pass adds latency and on small models frequently drops salient facts the main model would otherwise ground on. Set to `true` to force on, or `null` to opt back into the auto-on-for-SMALL behaviour. See **Memory Digest for Small Models** below.
+  - `memory_digest_enabled` (default `null` = auto-on for SMALL models ≤7B, off for LARGE) distils the combined diary + graph dump into a short relevance-filtered note via a cheap LLM pass before injecting into the system prompt. See **Memory Digest for Small Models** below.
   - `tool_result_digest_enabled` (default `false`) distils raw tool-result payloads (especially webSearch UNTRUSTED WEB EXTRACT blocks) into a short attributed fact note before appending as a tool-role message. Defaults to off because the extra digest pass adds latency per tool call and on small models frequently drops salient facts (numbers, names) the main model would otherwise ground on. Set to `true` to force on, or `null` to opt back into the auto-on-for-SMALL behaviour. See **Tool-Result Digest for Small Models** below.
 - Tools and MCP:
   - All builtin tools are always available; MCP servers added from `cfg.mcps`.
@@ -327,7 +327,7 @@ Small models (~2B parameters) degrade sharply as the system prompt grows. The ra
 To mitigate both, `digest_memory_for_query` (in `src/jarvis/reply/enrichment.py`) runs a cheap LLM pass over the raw diary + graph block and produces a short relevance-filtered note that replaces both `conversation_context` and `graph_context` in the reply system prompt.
 
 Behaviour:
-- **Gating**: `memory_digest_enabled` (config). Default `false` (off). `None` means auto-on for SMALL models, off for LARGE. Explicit `true`/`false` forces.
+- **Gating**: `memory_digest_enabled` (config). `None` (default) means auto-on for SMALL models, off for LARGE. Explicit `true`/`false` forces.
 - **Short-circuit**: if the raw block is below `_DIGEST_MIN_CHARS` (400 chars), it's passed through unchanged — the LLM round-trip costs more than it saves.
 - **Batching**: if the raw block exceeds `_DIGEST_BATCH_MAX_CHARS` (2000 chars, ~500 tokens), snippets are greedy-packed into batches, each distilled independently; surviving notes are joined. Single large snippets become their own oversized batch rather than being split mid-text.
 - **Graph is alpha**: when no graph nodes are present, only diary entries are digested. When only graph nodes are present, graph nodes alone are digested. Either channel is optional.

--- a/src/jarvis/reply/reply.spec.md
+++ b/src/jarvis/reply/reply.spec.md
@@ -272,7 +272,7 @@ Turn 4: LLM → {content: "Here's a comprehensive comparison of the iPhone 15 mo
 - Memory enrichment:
   - `memory_enrichment_max_results` limits recalled snippets.
   - `memory_digest_enabled` (default `null` = auto-on for SMALL models ≤7B, off for LARGE) distils the combined diary + graph dump into a short relevance-filtered note via a cheap LLM pass before injecting into the system prompt. See **Memory Digest for Small Models** below.
-  - `tool_result_digest_enabled` (default `false`) distils raw tool-result payloads (especially webSearch UNTRUSTED WEB EXTRACT blocks) into a short attributed fact note before appending as a tool-role message. Defaults to off because the extra digest pass adds latency per tool call and on small models frequently drops salient facts (numbers, names) the main model would otherwise ground on. Set to `true` to force on, or `null` to opt back into the auto-on-for-SMALL behaviour. See **Tool-Result Digest for Small Models** below.
+  - `tool_result_digest_enabled` (default `null` = auto-on for SMALL models ≤7B) distils raw tool-result payloads (especially webSearch UNTRUSTED WEB EXTRACT blocks and fetch_web_page responses) into a short attributed fact note before appending as a tool-role message. Auto-on for small models mitigates large payloads (fetch_web_page truncates at 50,000 chars) blowing the 8192 num_ctx window. Set to `true` to force on, `false` to force off. See **Tool-Result Digest for Small Models** below.
 - Tools and MCP:
   - All builtin tools are always available; MCP servers added from `cfg.mcps`.
 - Agentic loop:

--- a/src/jarvis/reply/reply.spec.md
+++ b/src/jarvis/reply/reply.spec.md
@@ -271,7 +271,7 @@ Turn 4: LLM → {content: "Here's a comprehensive comparison of the iPhone 15 mo
   - `llm_chat_timeout_sec` (messages loop turn)
 - Memory enrichment:
   - `memory_enrichment_max_results` limits recalled snippets.
-  - `memory_digest_enabled` (default `null` = auto-on for SMALL models, off for LARGE) distils the combined diary + graph dump into a short relevance-filtered note via a cheap LLM pass before injecting into the system prompt. See **Memory Digest for Small Models** below.
+  - `memory_digest_enabled` (default `false`) distils the combined diary + graph dump into a short relevance-filtered note via a cheap LLM pass before injecting into the system prompt. Defaults to off because the extra digest pass adds latency and on small models frequently drops salient facts the main model would otherwise ground on. Set to `true` to force on, or `null` to opt back into the auto-on-for-SMALL behaviour. See **Memory Digest for Small Models** below.
   - `tool_result_digest_enabled` (default `false`) distils raw tool-result payloads (especially webSearch UNTRUSTED WEB EXTRACT blocks) into a short attributed fact note before appending as a tool-role message. Defaults to off because the extra digest pass adds latency per tool call and on small models frequently drops salient facts (numbers, names) the main model would otherwise ground on. Set to `true` to force on, or `null` to opt back into the auto-on-for-SMALL behaviour. See **Tool-Result Digest for Small Models** below.
 - Tools and MCP:
   - All builtin tools are always available; MCP servers added from `cfg.mcps`.
@@ -327,7 +327,7 @@ Small models (~2B parameters) degrade sharply as the system prompt grows. The ra
 To mitigate both, `digest_memory_for_query` (in `src/jarvis/reply/enrichment.py`) runs a cheap LLM pass over the raw diary + graph block and produces a short relevance-filtered note that replaces both `conversation_context` and `graph_context` in the reply system prompt.
 
 Behaviour:
-- **Gating**: `memory_digest_enabled` (config). `None` (default) means auto-on for SMALL models, off for LARGE. Explicit `true`/`false` forces.
+- **Gating**: `memory_digest_enabled` (config). Default `false` (off). `None` means auto-on for SMALL models, off for LARGE. Explicit `true`/`false` forces.
 - **Short-circuit**: if the raw block is below `_DIGEST_MIN_CHARS` (400 chars), it's passed through unchanged — the LLM round-trip costs more than it saves.
 - **Batching**: if the raw block exceeds `_DIGEST_BATCH_MAX_CHARS` (2000 chars, ~500 tokens), snippets are greedy-packed into batches, each distilled independently; surviving notes are joined. Single large snippets become their own oversized batch rather than being split mid-text.
 - **Graph is alpha**: when no graph nodes are present, only diary entries are digested. When only graph nodes are present, graph nodes alone are digested. Either channel is optional.


### PR DESCRIPTION
## Summary

- **`memory_enrichment_max_results` 5 → 3**: reduces the raw diary block injected per reply.
- **`memory_digest_enabled` and `tool_result_digest_enabled` both restored to `null`** (auto-on for SMALL ≤7B, off for LARGE): both digest passes are the correct mitigation for small-model context overflow. Tool-result digest in particular prevents `fetch_web_page`'s 50,000-char payloads from consuming the 8192 `num_ctx` window before the main model sees them.
- **Intent judge `num_ctx: 4096`**: the 120s transcript buffer can carry 400+ tokens of speech. Ollama's model default (2048 for `gemma4:e2b`) silently truncated it on busy conversations.
- **`docs/llm_contexts.md`**: all `num_ctx` values now documented; `fetch_web_page` blowout risk noted with its mitigation (tool-result digest for SMALL, known risk for LARGE).

## Files changed

- `src/jarvis/config.py` — `memory_enrichment_max_results` 5 → 3; both digest defaults → `null`
- `src/jarvis/listening/intent_judge.py` — `num_ctx: 4096` added to inference options
- `src/jarvis/reply/reply.spec.md` — updated both digest default descriptions
- `docs/llm_contexts.md` — context window sizes and blowout risk documented
- `README.md` — config example updated
- `examples/config.json` — example value updated to 3

## Test plan

- [ ] Existing unit and integration tests pass
- [ ] Memory enrichment injects at most 3 results by default
- [ ] Memory digest auto-enables on `gemma4:e2b` (SMALL), stays off on a LARGE model
- [ ] Tool-result digest auto-enables on `gemma4:e2b`; a `fetch_web_page` result is compressed before entering the messages history
- [ ] Intent judge handles a full 120s transcript without truncation