### PR TITLE
feat(listening): tiny-model tip + interest-flavoured query eval

### DIFF
--- a/evals/conftest.py
+++ b/evals/conftest.py
@@ -102,6 +102,7 @@ TEST_DESCRIPTIONS = {
     "test_llm_uses_enrichment_for_personalised_queries": "LLM uses enrichment-surfaced interests for personalised search",
     "test_weather_query_live": "Live weather query with real LLM",
     "test_personalized_query_recalls_memory_live": "Live: LLM checks memory before asking about interests",
+    "test_explicit_recall_then_search_live": "Live: explicit 'recall interests, then search' grounds on seeded interests",
     # Nutrition extraction tests
     "test_meal_extraction_accuracy": "Extracts accurate macros for common meals",
     "test_extraction_returns_valid_json_structure": "Returns valid JSON with all required fields",

--- a/evals/conftest.py
+++ b/evals/conftest.py
@@ -102,7 +102,7 @@ TEST_DESCRIPTIONS = {
     "test_llm_uses_enrichment_for_personalised_queries": "LLM uses enrichment-surfaced interests for personalised search",
     "test_weather_query_live": "Live weather query with real LLM",
     "test_personalized_query_recalls_memory_live": "Live: LLM checks memory before asking about interests",
-    "test_explicit_recall_then_search_live": "Live: explicit 'recall interests, then search' grounds on seeded interests",
+    "test_interest_flavoured_query_live": "Live: interest-flavoured phrasings surface seeded interests into the reply",
     # Nutrition extraction tests
     "test_meal_extraction_accuracy": "Extracts accurate macros for common meals",
     "test_extraction_returns_valid_json_structure": "Returns valid JSON with all required fields",

--- a/evals/test_agent_behavior.py
+++ b/evals/test_agent_behavior.py
@@ -727,9 +727,27 @@ class TestLiveEndToEnd:
 
     @pytest.mark.eval
     @requires_judge_llm
-    def test_explicit_recall_then_search_live(self, mock_config, eval_db, eval_dialogue_memory):
+    @pytest.mark.parametrize("query", [
+        pytest.param(
+            "Recall my interests, then search the web for news on them, Jarvis.",
+            id="explicit-recall-then-search",
+        ),
+        pytest.param(
+            "Search the web for news that would interest me, Jarvis.",
+            id="news-that-would-interest-me",
+        ),
+        pytest.param(
+            "Find me news of interest to me, Jarvis.",
+            id="news-of-interest-to-me",
+        ),
+        pytest.param(
+            "What news today is interesting for me, Jarvis?",
+            id="news-interesting-for-me",
+        ),
+    ])
+    def test_interest_flavoured_query_live(self, query, mock_config, eval_db, eval_dialogue_memory):
         """
-        Live eval: explicit two-step imperative "recall X, then search Y" phrasing.
+        Live eval: interest-flavoured phrasings must surface seeded interests.
 
         Field regression (2026-04-24, gemma4:e2b): user said "Recall my interests
         and search the web for news on them, Jarvis." The intent judge paraphrased
@@ -739,15 +757,15 @@ class TestLiveEndToEnd:
         punted with "what are your interests so I can search the web for news
         for you?" instead of acting on the seeded interests.
 
-        This eval pins the bar: with interests available via enrichment, the
-        small model must either (a) search with an interest-flavoured query or
-        (b) name at least one seeded interest in its reply, and must NOT bounce
-        the question back.
+        The bar for every phrasing variant ("of interest to me", "would interest
+        me", "interesting for me", "recall my interests"): enrichment surfaces
+        the seeded interests into memory context, the planner weaves them into
+        the search step, and the reply names at least one. The model must NOT
+        bounce the question back.
         """
         from jarvis.reply.engine import run_reply_engine
         from helpers import JUDGE_MODEL
 
-        query = "Recall my interests, then search the web for news on them, Jarvis."
         capture = ToolCallCapture()
 
         mock_config.ollama_base_url = "http://localhost:11434"
@@ -778,7 +796,7 @@ class TestLiveEndToEnd:
         tools_used = [c["name"] for c in capture.calls]
         response_lower = (response or "").lower()
 
-        print(f"\n📝 Live Recall-Then-Search Eval ({JUDGE_MODEL}):")
+        print(f"\n📝 Live Interest-Flavoured Eval ({JUDGE_MODEL}):")
         print(f"   Query: {query}")
         print(f"   Tools called: {tools_used}")
         print(f"   Response: {(response or '')[:200]}...")
@@ -814,7 +832,7 @@ class TestLiveEndToEnd:
             f"Response: {(response or '')[:300]}"
         )
 
-        print(f"   ✅ Recall-then-search grounded on seeded interests")
+        print(f"   ✅ Interest-flavoured query grounded on seeded interests")
 
 
 # =============================================================================

--- a/evals/test_agent_behavior.py
+++ b/evals/test_agent_behavior.py
@@ -792,14 +792,10 @@ class TestLiveEndToEnd:
         ]
         is_asking_user = any(p in response_lower for p in asking_phrases)
 
-        msg_asked = (
+        assert not is_asking_user, (
             f"Model bounced the question back instead of acting on seeded "
             f"interests. Response: {(response or '')[:300]}"
         )
-        if is_asking_user:
-            if JUDGE_MODEL.startswith("gemma4"):
-                pytest.xfail(f"{JUDGE_MODEL} flake. {msg_asked}")
-            pytest.fail(msg_asked)
 
         # Secondary bar: the reply or the search query must name an interest.
         interest_terms = ["ai", "space", "astronomy", "machine learning", "spacex", "mars"]
@@ -812,15 +808,11 @@ class TestLiveEndToEnd:
             any(t in q for t in interest_terms) for q in search_queries
         )
 
-        msg_grounded = (
+        assert reply_mentions_interest or search_mentions_interest, (
             f"Model did not ground on seeded interests. "
             f"Tools: {tools_used}. Search queries: {search_queries}. "
             f"Response: {(response or '')[:300]}"
         )
-        if not (reply_mentions_interest or search_mentions_interest):
-            if JUDGE_MODEL.startswith("gemma4"):
-                pytest.xfail(f"{JUDGE_MODEL} flake. {msg_grounded}")
-            pytest.fail(msg_grounded)
 
         print(f"   ✅ Recall-then-search grounded on seeded interests")
 

--- a/evals/test_agent_behavior.py
+++ b/evals/test_agent_behavior.py
@@ -725,6 +725,105 @@ class TestLiveEndToEnd:
         print(f"   Response mentions user interests: {response_mentions_interests}")
         print(f"   ✅ Personalized query handling: PASS")
 
+    @pytest.mark.eval
+    @requires_judge_llm
+    def test_explicit_recall_then_search_live(self, mock_config, eval_db, eval_dialogue_memory):
+        """
+        Live eval: explicit two-step imperative "recall X, then search Y" phrasing.
+
+        Field regression (2026-04-24, gemma4:e2b): user said "Recall my interests
+        and search the web for news on them, Jarvis." The intent judge paraphrased
+        the utterance down to "search the web for news on my interests", dropping
+        the explicit recall step. Enrichment then surfaced unrelated diary
+        entries (weather chatter), the digest came back empty, and the model
+        punted with "what are your interests so I can search the web for news
+        for you?" instead of acting on the seeded interests.
+
+        This eval pins the bar: with interests available via enrichment, the
+        small model must either (a) search with an interest-flavoured query or
+        (b) name at least one seeded interest in its reply, and must NOT bounce
+        the question back.
+        """
+        from jarvis.reply.engine import run_reply_engine
+        from helpers import JUDGE_MODEL
+
+        query = "Recall my interests, then search the web for news on them, Jarvis."
+        capture = ToolCallCapture()
+
+        mock_config.ollama_base_url = "http://localhost:11434"
+        mock_config.ollama_chat_model = JUDGE_MODEL
+
+        mock_enrichment_context = [
+            "[2024-12-15] User is passionate about space exploration and astronomy",
+            "[2024-12-20] User follows AI and machine learning developments closely",
+        ]
+
+        mock_tool_run = create_mock_tool_run(capture, {
+            "webSearch": (
+                "AI breakthrough announced, SpaceX launch successful, "
+                "new Mars rover findings, open-source LLM released"
+            ),
+            "fetchWebPage": "Full article about AI and space news...",
+        })
+
+        with patch('jarvis.reply.engine.run_tool_with_retries', side_effect=mock_tool_run), \
+             patch('jarvis.reply.engine.get_location_context_with_timezone', return_value=("Location: London, UK", None)), \
+             patch('jarvis.memory.conversation.search_conversation_memory_by_keywords', return_value=mock_enrichment_context):
+
+            response = run_reply_engine(
+                db=eval_db, cfg=mock_config, tts=None,
+                text=query, dialogue_memory=eval_dialogue_memory
+            )
+
+        tools_used = [c["name"] for c in capture.calls]
+        response_lower = (response or "").lower()
+
+        print(f"\n📝 Live Recall-Then-Search Eval ({JUDGE_MODEL}):")
+        print(f"   Query: {query}")
+        print(f"   Tools called: {tools_used}")
+        print(f"   Response: {(response or '')[:200]}...")
+
+        # Primary failure mode: bouncing the question back.
+        asking_phrases = [
+            "what are your interests", "what topics", "what are you interested",
+            "could you let me know", "what kind of", "tell me what",
+            "what subjects", "any particular", "which topics", "any specific",
+            "what type of", "interested in?", "so i can search",
+        ]
+        is_asking_user = any(p in response_lower for p in asking_phrases)
+
+        msg_asked = (
+            f"Model bounced the question back instead of acting on seeded "
+            f"interests. Response: {(response or '')[:300]}"
+        )
+        if is_asking_user:
+            if JUDGE_MODEL.startswith("gemma4"):
+                pytest.xfail(f"{JUDGE_MODEL} flake. {msg_asked}")
+            pytest.fail(msg_asked)
+
+        # Secondary bar: the reply or the search query must name an interest.
+        interest_terms = ["ai", "space", "astronomy", "machine learning", "spacex", "mars"]
+        reply_mentions_interest = any(t in response_lower for t in interest_terms)
+        search_queries = [
+            (c["args"].get("search_query") or c["args"].get("query") or "").lower()
+            for c in capture.calls if c["name"] == "webSearch"
+        ]
+        search_mentions_interest = any(
+            any(t in q for t in interest_terms) for q in search_queries
+        )
+
+        msg_grounded = (
+            f"Model did not ground on seeded interests. "
+            f"Tools: {tools_used}. Search queries: {search_queries}. "
+            f"Response: {(response or '')[:300]}"
+        )
+        if not (reply_mentions_interest or search_mentions_interest):
+            if JUDGE_MODEL.startswith("gemma4"):
+                pytest.xfail(f"{JUDGE_MODEL} flake. {msg_grounded}")
+            pytest.fail(msg_grounded)
+
+        print(f"   ✅ Recall-then-search grounded on seeded interests")
+
 
 # =============================================================================
 # Helpfulness Evaluations (Anti-Deflection)

--- a/src/jarvis/listening/listener.py
+++ b/src/jarvis/listening/listener.py
@@ -2071,7 +2071,7 @@ class VoiceListener(threading.Thread):
                     flush=True,
                 )
                 print(
-                    f"      👍 \"{wake_word.title()}, recall my interests, then search the web for news on them.\"",
+                    f"      👍 \"Recall my interests, then search the web for news on them, {wake_word.title()}.\"",
                     flush=True,
                 )
                 print(

--- a/src/jarvis/listening/listener.py
+++ b/src/jarvis/listening/listener.py
@@ -2058,6 +2058,24 @@ class VoiceListener(threading.Thread):
             wake_word = getattr(self.cfg, "wake_word", "jarvis").lower()
             print(f"\n{'─' * 50}\n🎙️  Listening! Try: \"How's the weather, {wake_word.title()}?\"", flush=True)
 
+            # Small-model disclaimer: gemma4:e2b and e4b struggle with
+            # indirect or multi-step phrasing. Nudge the user toward direct
+            # queries so they get better results out of the box.
+            chat_model_lower = str(getattr(self.cfg, "ollama_chat_model", "") or "").strip().lower()
+            if chat_model_lower in ("gemma4:e2b", "gemma4:e4b"):
+                print(
+                    f"  ⚠️  Tiny model in use ({chat_model_lower}). Keep queries direct and clear for best results.",
+                    flush=True,
+                )
+                print(
+                    f"      👍 \"Search the web for news about AI, {wake_word.title()}.\"",
+                    flush=True,
+                )
+                print(
+                    f"      👎 \"Think about my interests and find something interesting to me, {wake_word.title()}.\"",
+                    flush=True,
+                )
+
             # Set face state to IDLE (awake and ready, waiting for wake word)
             try:
                 from desktop_app.face_widget import get_jarvis_state, JarvisState

--- a/src/jarvis/listening/listener.py
+++ b/src/jarvis/listening/listener.py
@@ -2071,11 +2071,11 @@ class VoiceListener(threading.Thread):
                     flush=True,
                 )
                 print(
-                    f"      👍 \"Recall my interests, then search the web for news on them, {wake_word.title()}.\"",
+                    f"      👍 \"Check tomorrow's weather, find an activity that suits it, and tell me what to wear, {wake_word.title()}.\"",
                     flush=True,
                 )
                 print(
-                    f"      👎 \"Tell me some news that might interest me, {wake_word.title()}.\"",
+                    f"      👎 \"Plan something fun for me tomorrow, {wake_word.title()}.\"",
                     flush=True,
                 )
 

--- a/src/jarvis/listening/listener.py
+++ b/src/jarvis/listening/listener.py
@@ -2071,11 +2071,11 @@ class VoiceListener(threading.Thread):
                     flush=True,
                 )
                 print(
-                    f"      👍 \"Check tomorrow's weather, find an activity that suits it, and tell me what to wear, {wake_word.title()}.\"",
+                    f"      👍 \"Check tomorrow's weather and local events, then recommend events that suit the weather, {wake_word.title()}.\"",
                     flush=True,
                 )
                 print(
-                    f"      👎 \"Plan something fun for me tomorrow, {wake_word.title()}.\"",
+                    f"      👎 \"What event should I go to tomorrow, {wake_word.title()}?\"",
                     flush=True,
                 )
 

--- a/src/jarvis/listening/listener.py
+++ b/src/jarvis/listening/listener.py
@@ -2058,21 +2058,22 @@ class VoiceListener(threading.Thread):
             wake_word = getattr(self.cfg, "wake_word", "jarvis").lower()
             print(f"\n{'─' * 50}\n🎙️  Listening! Try: \"How's the weather, {wake_word.title()}?\"", flush=True)
 
-            # Small-model disclaimer: gemma4:e2b and e4b struggle with
-            # indirect or multi-step phrasing. Nudge the user toward direct
-            # queries so they get better results out of the box.
+            # Small-model disclaimer: gemma4:e2b and e4b can't infer your
+            # intent from vague prompts, but they can still execute complex
+            # flows if you spell out the steps. Assume the model is dumb and
+            # lay things out for it.
             chat_model_lower = str(getattr(self.cfg, "ollama_chat_model", "") or "").strip().lower()
             if chat_model_lower in ("gemma4:e2b", "gemma4:e4b"):
                 print(
-                    f"  ⚠️  Tiny model in use ({chat_model_lower}). Keep queries direct and clear for best results.",
+                    f"  ⚠️  Tiny model in use ({chat_model_lower}). Assume it can't infer — spell out the steps.",
                     flush=True,
                 )
                 print(
-                    f"      👍 \"Search the web for news about AI, {wake_word.title()}.\"",
+                    f"      👍 \"{wake_word.title()}, recall what topics I'm interested in, then search the web for recent news on those topics and summarise.\"",
                     flush=True,
                 )
                 print(
-                    f"      👎 \"Think about my interests and find something interesting to me, {wake_word.title()}.\"",
+                    f"      👎 \"Tell me some news that might interest me, {wake_word.title()}.\"",
                     flush=True,
                 )
 

--- a/src/jarvis/listening/listener.py
+++ b/src/jarvis/listening/listener.py
@@ -2069,7 +2069,7 @@ class VoiceListener(threading.Thread):
                     flush=True,
                 )
                 print(
-                    f"      👍 \"{wake_word.title()}, recall what topics I'm interested in, then search the web for recent news on those topics and summarise.\"",
+                    f"      👍 \"{wake_word.title()}, recall my interests, then search the web for news on them.\"",
                     flush=True,
                 )
                 print(

--- a/src/jarvis/listening/listener.py
+++ b/src/jarvis/listening/listener.py
@@ -2058,14 +2058,16 @@ class VoiceListener(threading.Thread):
             wake_word = getattr(self.cfg, "wake_word", "jarvis").lower()
             print(f"\n{'─' * 50}\n🎙️  Listening! Try: \"How's the weather, {wake_word.title()}?\"", flush=True)
 
-            # Small-model disclaimer: gemma4:e2b and e4b can't infer your
-            # intent from vague prompts, but they can still execute complex
-            # flows if you spell out the steps. Assume the model is dumb and
-            # lay things out for it.
-            chat_model_lower = str(getattr(self.cfg, "ollama_chat_model", "") or "").strip().lower()
-            if chat_model_lower in ("gemma4:e2b", "gemma4:e4b"):
+            # Small-model disclaimer: SMALL models can't infer your intent
+            # from vague prompts, but they can still execute complex flows
+            # if you spell out the steps. Assume the model is dumb and lay
+            # things out for it. Classification lives in model_variants so
+            # it stays in sync when supported models change.
+            from ..reply.prompts.model_variants import detect_model_size, ModelSize
+            chat_model_name = str(getattr(self.cfg, "ollama_chat_model", "") or "").strip()
+            if chat_model_name and detect_model_size(chat_model_name) == ModelSize.SMALL:
                 print(
-                    f"  ⚠️  Tiny model in use ({chat_model_lower}). Assume it can't infer — spell out the steps.",
+                    f"  ⚠️  Small model in use ({chat_model_name}). Assume it can't infer — spell out the steps.",
                     flush=True,
                 )
                 print(

--- a/src/jarvis/reply/enrichment.py
+++ b/src/jarvis/reply/enrichment.py
@@ -56,6 +56,7 @@ Examples:
 "what did I eat yesterday?" → {{"keywords": ["eat", "food", "cooking", "nutrition"], "from": "2025-08-21T00:00:00Z", "to": "2025-08-21T23:59:59Z"}}
 "remember that password I mentioned today?" → {{"keywords": ["password", "accounts", "security", "credentials"], "from": "2025-08-22T00:00:00Z", "to": "2025-08-22T23:59:59Z"}}
 "what news might interest me?" → {{"keywords": ["interests", "hobbies", "preferences", "likes", "passionate"], "questions": ["what topics interest the user?", "what are the user's hobbies?"]}}
+"news of interest to me" / "news that would interest me" / "news interesting for me" / "recall my interests and search for news on them" → {{"keywords": ["interests", "hobbies", "preferences", "likes", "passionate"], "questions": ["what topics interest the user?", "what are the user's hobbies?"]}}
 "recommend a restaurant I'd enjoy" (no location in context) → {{"keywords": ["food preferences", "restaurants", "cuisine", "dining", "favorites"], "questions": ["what cuisine does the user like?", "where is the user located?"]}}
 "recommend a restaurant I'd enjoy" (location already in context) → {{"keywords": ["food preferences", "restaurants", "cuisine", "dining", "favorites"], "questions": ["what cuisine does the user like?"]}}
 "suggest a movie for me" → {{"keywords": ["movies", "films", "entertainment", "preferences", "genres"], "questions": ["what film genres does the user enjoy?", "what movies has the user watched recently?"]}}


### PR DESCRIPTION
## Summary
- After the "Listening!" line, print a disclaimer when the configured chat model classifies as SMALL (via `detect_model_size` so it tracks the canonical classifier when supported models change).
- Disclaimer shows a good/bad example tied to the same task: a weather+events recommendation spelled out as explicit steps vs. the short sentence a smart model could have synthesised into them.
- Adds a parametrised live eval `test_interest_flavoured_query_live` covering four phrasings ("recall my interests", "of interest to me", "that would interest me", "interesting for me") — all pass on `gemma4:e2b` with enrichment surfacing interests, planner decomposing per interest, reply grounding.
- Strengthens the enrichment extractor prompt with a multi-phrasing example so the small model picks `interests` keywords for all variants.

## Why
Small Gemma variants flop on indirect/vague prompts but handle complex flows fine when steps are spelled out. Telling the user this up-front sets expectations. The eval locks in the planner-driven behaviour as a regression guard.

## Planner traces (gemma4:e2b)
- `"What event should I go to tomorrow, Jarvis?"` → 1 step: `webSearch events`
- `"Check tomorrow's weather and local events, then recommend events that suit the weather, Jarvis."` → 3 steps: `webSearch weather | webSearch events | webSearch outdoor activities | reply`

## Test plan
- [ ] Run with `ollama_chat_model=gemma4:e2b`, confirm disclaimer prints once after "Listening!".
- [ ] Run with `gemma4:e4b`, confirm same.
- [ ] Run with `gpt-oss:20b`, confirm no disclaimer.
- [ ] `EVAL_JUDGE_MODEL=gemma4:e2b pytest evals/test_agent_behavior.py::TestLiveEndToEnd::test_interest_flavoured_query_live` — all 4 variants pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)