### PR TITLE
fix(listening): catch tail echoes from long TTS responses

### DIFF
--- a/src/jarvis/listening/listener.py
+++ b/src/jarvis/listening/listener.py
@@ -466,7 +466,7 @@ class VoiceListener(threading.Thread):
                 last_tts_text = self.echo_detector._last_tts_text or ""
                 if last_tts_text:
                     echo_score = fuzz.partial_ratio(
-                        text_lower[:150], last_tts_text.lower()[:300]
+                        text_lower, last_tts_text.lower()
                     )
                     tts_words = len(last_tts_text.split())
                     text_words = len(text_lower.split())
@@ -693,7 +693,7 @@ class VoiceListener(threading.Thread):
                     is_pure_echo = False
                     if last_tts_text_fb:
                         echo_score = fuzz.partial_ratio(
-                            text_lower[:150], last_tts_text_fb.lower()[:300]
+                            text_lower, last_tts_text_fb.lower()
                         )
                         tts_words = len(last_tts_text_fb.split())
                         text_words = len(text_lower.split())
@@ -761,7 +761,7 @@ class VoiceListener(threading.Thread):
                         # and the intent judge's extraction should be used instead.
                         if last_tts_text:
                             echo_score = fuzz.partial_ratio(
-                                text_lower[:150], last_tts_text.lower()[:300]
+                                text_lower, last_tts_text.lower()
                             )
                             tts_words = len(last_tts_text.split())
                             text_words = len(text_lower.split())
@@ -774,8 +774,8 @@ class VoiceListener(threading.Thread):
                                 # TTS too, it's genuinely pure echo. If the query is
                                 # different, the judge extracted real user speech.
                                 query_echo_score = fuzz.partial_ratio(
-                                    intent_judgment.query[:100].lower(),
-                                    last_tts_text.lower()[:200]
+                                    intent_judgment.query.lower(),
+                                    last_tts_text.lower()
                                 )
                                 if query_echo_score >= 70:
                                     debug_log(f"🔇 Echo in hot window (directed, score={echo_score}): \"{text_lower}\"", "voice")
@@ -854,7 +854,7 @@ class VoiceListener(threading.Thread):
                         # Only reject pure echo (similar word count to TTS)
                         if last_tts_text:
                             echo_score = fuzz.partial_ratio(
-                                text_lower[:150], last_tts_text.lower()[:300]
+                                text_lower, last_tts_text.lower()
                             )
                             tts_words = len(last_tts_text.split())
                             text_words = len(text_lower.split())
@@ -932,7 +932,7 @@ class VoiceListener(threading.Thread):
                             is_pure_echo = False
                             if last_tts_text:
                                 echo_score = fuzz.partial_ratio(
-                                    text_lower[:150], last_tts_text.lower()[:300]
+                                    text_lower, last_tts_text.lower()
                                 )
                                 tts_words = len(last_tts_text.split())
                                 text_words = len(text_lower.split())
@@ -972,7 +972,7 @@ class VoiceListener(threading.Thread):
                         is_pure_echo = False
                         if last_tts_text:
                             echo_score = fuzz.partial_ratio(
-                                text_lower[:150], last_tts_text.lower()[:300]
+                                text_lower, last_tts_text.lower()
                             )
                             tts_words = len(last_tts_text.split())
                             text_words = len(text_lower.split())

--- a/tests/test_hot_window_input.py
+++ b/tests/test_hot_window_input.py
@@ -861,6 +861,42 @@ class TestEchoRejectionDoesNotExtendFollowUpWindow:
         listener.state_manager.stop()
 
 
+@pytest.mark.unit
+class TestLongTtsTailEcho:
+    """Echoes of the TAIL of a long TTS response must still be rejected. The
+    fuzzy echo check previously truncated TTS to 300 chars, so tail echoes from
+    longer responses slipped through and were accepted as user speech."""
+
+    @patch("builtins.print")
+    def test_tail_echo_from_long_tts_rejected(self, _print):
+        """Echo of the final clause of a ~370-char TTS is caught, not accepted."""
+        long_tts = (
+            "You asked for something interesting, so I found that there are "
+            "over 1800 creative writing prompts available across various genres, "
+            "including themes like a character losing the ability to create or "
+            "an intangible concept becoming a real object. I also found that "
+            "evolving marketing tactics rely on using data, leveraging "
+            "analytics, and being agile to understand user behavior."
+        )
+        assert len(long_tts) > 300  # Guard: the bug only manifests past old cap
+
+        listener, _ = _create_listener(echo_tolerance=0.02, hot_window_seconds=3.0)
+        listener.echo_detector.track_tts_start(long_tts)
+        _simulate_tts_finish(listener)
+        _wait_for_hot_window_active(listener)
+
+        # Mic picks up the tail of the TTS response — this is pure echo.
+        tail_echo = "leveraging analytics and being agile to understand user behavior."
+        _install_intent_judge(
+            listener,
+            _make_judgment(directed=False, reasoning="Segment is an echo"),
+        )
+        listener._process_transcript(tail_echo, utterance_energy=0.01)
+
+        assert _accepted_query(listener) == ""
+        listener.state_manager.stop()
+
+
 # ---------------------------------------------------------------------------
 # Tests: Early beep and face state feedback
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The fuzzy echo guard in the hot-window path truncated the last TTS text to 300 chars before running `partial_ratio`. When a TTS response exceeded that length, the echoed tail fell outside the comparison window, scored low, and was accepted as user speech — showing up in the log as `Intent override: accepting hot window speech (mixed echo+speech)`.

Reproducing case from a live session:

```
🤖 Jarvis
You asked for something interesting, so I found ... evolving marketing tactics rely on using data, leveraging analytics, and being agile to understand user behavior.
📝 Heard: "leveraging analytics and being agile to understand user behavior."
🧠 Intent (hot window): not directed (Segment is an echo and contains no direct query or command.)
🧠 Intent override: accepting hot window speech (mixed echo+speech)
✨ Working on it: leveraging analytics and being agile to understand user behavior.
```

The echoed phrase started at char ~302 of the TTS string, so `last_tts_text.lower()[:300]` cut it off. `is_pure_echo` was then false and the mixed-echo override path accepted the echo as a genuine query.

## Changes

- Drop the `[:150]` / `[:300]` / `[:200]` / `[:100]` truncations on all seven fuzzy echo-comparison sites in `listener.py`. `partial_ratio` is cheap at these sizes and the caps were a precautionary bound without a measured tradeoff.
- Add `TestLongTtsTailEcho` in `test_hot_window_input.py` covering the reported case (echo of the final clause of a ~370-char TTS response).

## Test plan

- [x] `pytest tests/test_hot_window_input.py tests/test_echo_detection.py tests/test_short_query_echo.py` — all green
- [x] New test demonstrates the bug: passes after the cap removal, would fail before
- [ ] Verify on device: long response followed by echoed tail no longer triggers a phantom follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)