### PR TITLE
feat(listening): Chrome MCP navigate tip on startup

### DIFF
--- a/src/jarvis/listening/listener.py
+++ b/src/jarvis/listening/listener.py
@@ -2079,6 +2079,30 @@ class VoiceListener(threading.Thread):
                     flush=True,
                 )
 
+            # Chrome MCP tip: the chrome MCP exposes a `navigate` tool that
+            # takes a URL. Vague phrasing like "Open YouTube" forces the model
+            # to guess a URL; "Navigate to youtube.com" maps directly to the
+            # tool's argument and is more reliable on small models.
+            try:
+                from ..tools.registry import get_cached_mcp_tools
+                mcp_tool_names = list(get_cached_mcp_tools().keys())
+                has_chrome_mcp = any("chrome" in name.lower() for name in mcp_tool_names)
+            except Exception:
+                has_chrome_mcp = False
+            if has_chrome_mcp:
+                print(
+                    f"  🌐 Chrome MCP detected. Name the destination URL so the browser tool can act directly.",
+                    flush=True,
+                )
+                print(
+                    f"      👍 \"Navigate to youtube.com, {wake_word.title()}.\"",
+                    flush=True,
+                )
+                print(
+                    f"      👎 \"Open YouTube, {wake_word.title()}.\"",
+                    flush=True,
+                )
+
             # Set face state to IDLE (awake and ready, waiting for wake word)
             try:
                 from desktop_app.face_widget import get_jarvis_state, JarvisState


### PR DESCRIPTION
## Summary
- When a chrome-named MCP server is detected, print a startup tip steering users toward URL-first phrasing ("Navigate to youtube.com") instead of vague verbs ("Open YouTube").
- The chrome navigate tool takes a URL; naming the destination maps directly to the argument and is more reliable, especially on small models.

## Test plan
- [ ] Start listener with a chrome MCP configured, confirm the 🌐 tip appears after the 🎙️ Listening line.
- [ ] Start listener without chrome MCP, confirm no tip is printed.