### PR TITLE
fix(memory): dedupe graph appends across diary re-flushes

### DIFF
--- a/src/jarvis/memory/graph.py
+++ b/src/jarvis/memory/graph.py
@@ -35,7 +35,11 @@ _WS_RE = re.compile(r"\s+")
 
 
 def normalise_fact(text: str) -> str:
-    """Lowercase (Unicode-aware) + collapse whitespace for fuzzy equality."""
+    """Lowercase (Unicode-aware) + collapse all whitespace, including
+    newlines, into single spaces for fuzzy equality. ``_WS_RE`` matches
+    ``\\s+``, so any newline embedded in an extracted fact collapses to
+    a space on the candidate side, keeping the dedupe key well-formed
+    even if the extractor accidentally emits a multi-line statement."""
     folded = unicodedata.normalize("NFKC", text).casefold()
     return _WS_RE.sub(" ", folded.strip())
 

--- a/src/jarvis/memory/graph.py
+++ b/src/jarvis/memory/graph.py
@@ -11,14 +11,33 @@ See graph.spec.md for the full specification.
 
 from __future__ import annotations
 
+import re
 import sqlite3
 import threading
+import unicodedata
 import uuid
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Optional
 
 from ..debug import debug_log
+
+
+# ── Fact normalisation ─────────────────────────────────────────────────────
+#
+# Used for dedupe comparisons. Locale-safe — the user base includes
+# non-Latin scripts (e.g. Turkish, where ``"İ".lower()`` returns ``"i"``
+# but Turkish lowercase is ``"ı"``), so we use ``unicodedata.NFKC`` plus
+# ``str.casefold`` rather than ``str.lower``. ``casefold`` also folds
+# German ß to ss, and NFKC collapses visually identical code points.
+
+_WS_RE = re.compile(r"\s+")
+
+
+def normalise_fact(text: str) -> str:
+    """Lowercase (Unicode-aware) + collapse whitespace for fuzzy equality."""
+    folded = unicodedata.normalize("NFKC", text).casefold()
+    return _WS_RE.sub(" ", folded.strip())
 
 
 # ── Configuration defaults ──────────────────────────────────────────────────
@@ -427,6 +446,22 @@ class GraphMemoryStore:
             )
             self.conn.commit()
             return cur.rowcount > 0
+
+    def node_contains_fact(self, node_id: str, fact: str) -> bool:
+        """True if ``fact`` matches any line of the node's data after
+        ``normalise_fact`` folding. Used to dedupe graph appends when the
+        cumulative daily summary re-seeds the same facts across diary flushes.
+        """
+        node = self.get_node(node_id)
+        if node is None or not node.data:
+            return False
+        target = normalise_fact(fact)
+        if not target:
+            return False
+        for line in node.data.split("\n"):
+            if normalise_fact(line) == target:
+                return True
+        return False
 
     def append_to_node(self, node_id: str, text: str) -> bool:
         """Append text to a node's data field.

--- a/src/jarvis/memory/graph.spec.md
+++ b/src/jarvis/memory/graph.spec.md
@@ -154,8 +154,9 @@ Piggybacks on the existing diary update flow in `conversation.py`:
    - **Top nodes** — checked second; matches frequently accessed knowledge domains
    - **Root traversal** — greedy top-down descent; LLM picks the best child at each level, or stops at the current node if none fit
    - **Picker model**: `update_graph_from_dialogue` / `find_best_node` / `_llm_pick_best_child` accept an optional `picker_model` override. Callers (daemon, memory viewer's diary-import endpoint) resolve it via `resolve_tool_router_model(cfg)` so the best-child classification runs on the small warm router model instead of the big chat model. When `picker_model` is `None` the picker falls back to `ollama_chat_model`.
-4. **Append**: The fact is appended to the chosen node's data
-5. **Split**: If the node now exceeds `SPLIT_THRESHOLD`, auto-split is triggered
+4. **Dedupe**: Before writing, `GraphMemoryStore.node_contains_fact` compares the fact against each line of the chosen node's data under Unicode-aware folding (`unicodedata.NFKC` + `str.casefold` + whitespace collapse), so ASCII casing, locale quirks (Turkish `İ`/`ı`, German `ß`/`ss`), and incidental whitespace don't cause false negatives. Matches are skipped, are **not** reported to the user as newly learned, and do **not** touch the node's access score (a re-extraction isn't fresh reinforcement). This stops the cumulative daily summary from re-seeding the same facts on every diary flush. The check only covers the picker's chosen node, so a later flush that routes the same fact to a different node within the branch can still leak a duplicate — an accepted trade-off versus scanning the whole subtree per fact.
+5. **Append**: The fact is appended to the chosen node's data
+6. **Split**: If the node now exceeds `SPLIT_THRESHOLD`, auto-split is triggered
 
 Cold start: each fact lands directly on its tagged branch root (User / Directives / World) until enough data accumulates there for the first auto-split. The tree structure emerges organically under each branch.
 

--- a/src/jarvis/memory/graph_ops.py
+++ b/src/jarvis/memory/graph_ops.py
@@ -573,6 +573,26 @@ def update_graph_from_dialogue(
                 branch_root_id=branch_id,
             )
 
+            # Step 2b: Dedupe — skip if this fact is already stored on the
+            # chosen node. The daily summary is cumulative, so every diary
+            # flush re-extracts the same facts; without this check, each
+            # flush appends them again. We only check the picker's chosen
+            # node — a stale picker could route a repeat fact to a different
+            # node within the same branch on a later flush and leak a
+            # duplicate, but that's rare compared to the same-node case we're
+            # fixing here. We also deliberately skip ``touch_node``: a re-
+            # extraction isn't fresh learning and shouldn't reinforce the
+            # node's access score.
+            if store.node_contains_fact(node_id, fact):
+                target = store.get_node(node_id)
+                target_name = target.name if target else node_id[:8]
+                debug_log(
+                    f"graph update: skipped duplicate '{fact[:50]}...' → "
+                    f"'{target_name}' [{branch_id}]",
+                    "memory",
+                )
+                continue
+
             # Step 3: Append the fact to the chosen node
             threshold_exceeded = store.append_to_node(node_id, fact)
             store.touch_node(node_id)

--- a/src/jarvis/memory/graph_ops.py
+++ b/src/jarvis/memory/graph_ops.py
@@ -539,7 +539,7 @@ def update_graph_from_dialogue(
     The return shape is a list rather than a bare int so the CLI can show
     *what* was learned, not just how many.
     """
-    # Step 1: Extract discrete facts from the conversation summary
+    # Step 1: Extract discrete branch-tagged facts from the summary
     facts = extract_graph_memories(
         summary=summary,
         ollama_base_url=ollama_base_url,
@@ -558,7 +558,7 @@ def update_graph_from_dialogue(
     stored: "list[tuple[str, str]]" = []
     for branch_id, fact in facts:
         try:
-            # Step 2: Find the best node for this fact within its branch.
+            # Step 2: Place — find the best node for this fact within its branch.
             # The branch tag comes from the extractor's classification pass
             # (USER / DIRECTIVES / WORLD) — traversal stays inside that
             # subtree so the purpose-shaped top-level taxonomy is preserved.
@@ -573,7 +573,7 @@ def update_graph_from_dialogue(
                 branch_root_id=branch_id,
             )
 
-            # Step 2b: Dedupe — skip if this fact is already stored on the
+            # Step 3: Dedupe — skip if this fact is already stored on the
             # chosen node. The daily summary is cumulative, so every diary
             # flush re-extracts the same facts; without this check, each
             # flush appends them again. We only check the picker's chosen
@@ -582,7 +582,7 @@ def update_graph_from_dialogue(
             # duplicate, but that's rare compared to the same-node case we're
             # fixing here. We also deliberately skip ``touch_node``: a re-
             # extraction isn't fresh learning and shouldn't reinforce the
-            # node's access score.
+            # node's access score. (Mirrors step 4 in graph.spec.md.)
             if store.node_contains_fact(node_id, fact):
                 target = store.get_node(node_id)
                 target_name = target.name if target else node_id[:8]
@@ -593,7 +593,7 @@ def update_graph_from_dialogue(
                 )
                 continue
 
-            # Step 3: Append the fact to the chosen node
+            # Step 4: Append the fact to the chosen node
             threshold_exceeded = store.append_to_node(node_id, fact)
             store.touch_node(node_id)
 
@@ -602,7 +602,7 @@ def update_graph_from_dialogue(
             stored.append((fact, node_name))
             debug_log(f"graph update: stored '{fact[:50]}...' → '{node_name}' [{branch_id}]", "memory")
 
-            # Step 4: Auto-split if the node has grown too large
+            # Step 5: Auto-split if the node has grown too large
             if threshold_exceeded:
                 debug_log(f"graph update: node '{node_name}' exceeded threshold, splitting", "memory")
                 auto_split_node(

--- a/tests/test_graph_ops.py
+++ b/tests/test_graph_ops.py
@@ -465,6 +465,58 @@ class TestAppendToNode:
         assert exceeded is False
 
 
+@pytest.mark.unit
+class TestNodeContainsFact:
+    """Tests for GraphMemoryStore.node_contains_fact (dedupe primitive)."""
+
+    def test_returns_false_for_empty_node(self, store):
+        node = store.create_node(name="T", description="T", data="", parent_id="root")
+        assert store.node_contains_fact(node.id, "anything") is False
+
+    def test_returns_false_for_nonexistent_node(self, store):
+        assert store.node_contains_fact("nope", "anything") is False
+
+    def test_returns_false_for_empty_fact(self, store):
+        node = store.create_node(name="T", description="T", data="hello", parent_id="root")
+        assert store.node_contains_fact(node.id, "   ") is False
+
+    def test_exact_line_match(self, store):
+        node = store.create_node(
+            name="T", description="T", data="Line A\nLine B", parent_id="root"
+        )
+        assert store.node_contains_fact(node.id, "Line A") is True
+        assert store.node_contains_fact(node.id, "Line B") is True
+        assert store.node_contains_fact(node.id, "Line C") is False
+
+    def test_case_and_whitespace_insensitive(self, store):
+        node = store.create_node(
+            name="T", description="T", data="Justin Bieber is Canadian.", parent_id="root"
+        )
+        assert store.node_contains_fact(node.id, "justin bieber is canadian.") is True
+        assert store.node_contains_fact(node.id, "  Justin   Bieber  is Canadian.  ") is True
+
+    def test_turkish_dotted_i_folds(self, store):
+        """Locale-naive .lower() returns the wrong key for Turkish İ; the
+        store must use casefold + NFKC so İstanbul / i̇stanbul collide."""
+        node = store.create_node(
+            name="T", description="T", data="İstanbul is large.", parent_id="root"
+        )
+        assert store.node_contains_fact(node.id, "i̇stanbul is large.") is True
+
+    def test_german_sharp_s_folds_to_ss(self, store):
+        node = store.create_node(
+            name="T", description="T", data="Straße", parent_id="root"
+        )
+        assert store.node_contains_fact(node.id, "strasse") is True
+
+    def test_substring_is_not_a_match(self, store):
+        """Dedupe is line-equality, not substring — avoid false positives."""
+        node = store.create_node(
+            name="T", description="T", data="Justin Bieber is Canadian.", parent_id="root"
+        )
+        assert store.node_contains_fact(node.id, "Justin Bieber") is False
+
+
 # ── update_graph_from_dialogue (end-to-end) ────────────────────────────
 
 
@@ -537,6 +589,90 @@ class TestUpdateGraphFromDialogue:
         )
 
         assert stored == []
+
+    @patch("src.jarvis.memory.graph_ops.call_llm_direct")
+    def test_skips_duplicate_facts_on_second_flush(self, mock_llm, store):
+        """Re-extracting the same fact from a growing daily summary must
+        not duplicate it in the graph.
+
+        Mirrors production: two diary flushes in quick succession both
+        extract the same fact from the cumulative summary. The second
+        flush should be a no-op for the graph, not a duplicate append.
+        """
+        # First flush: branch root has no children, so extraction is the
+        # only LLM call needed.
+        mock_llm.return_value = (
+            '[{"branch": "WORLD", "fact": "Justin Bieber is a Canadian singer."}]'
+        )
+        stored1 = update_graph_from_dialogue(
+            store=store,
+            summary="User asked about Justin Bieber.",
+            ollama_base_url="http://localhost",
+            ollama_chat_model="model",
+        )
+        assert len(stored1) == 1
+
+        # Second flush: same fact re-extracted, should be deduped.
+        mock_llm.return_value = (
+            '[{"branch": "WORLD", "fact": "Justin Bieber is a Canadian singer."}]'
+        )
+        stored2 = update_graph_from_dialogue(
+            store=store,
+            summary="User asked about Justin Bieber.",
+            ollama_base_url="http://localhost",
+            ollama_chat_model="model",
+        )
+        assert stored2 == [], "duplicate fact should not be reported as learned"
+
+        world = store.get_node("world")
+        assert world.data.count("Justin Bieber") == 1
+
+    @patch("src.jarvis.memory.graph_ops.call_llm_direct")
+    def test_dedupe_handles_non_latin_case_folding(self, mock_llm, store):
+        """Locale-safe folding: Turkish İ/i̇ and German ß/ss collapse to the
+        same dedupe key. Python's ``str.lower`` would miss these cases —
+        the store uses ``casefold`` + NFKC instead."""
+        mock_llm.return_value = (
+            '[{"branch": "WORLD", "fact": "İstanbul is the largest city in Turkey."}]'
+        )
+        update_graph_from_dialogue(
+            store=store,
+            summary="s",
+            ollama_base_url="http://localhost",
+            ollama_chat_model="model",
+        )
+
+        mock_llm.return_value = (
+            '[{"branch": "WORLD", "fact": "i̇stanbul is the largest city in turkey."}]'
+        )
+        stored = update_graph_from_dialogue(
+            store=store,
+            summary="s",
+            ollama_base_url="http://localhost",
+            ollama_chat_model="model",
+        )
+        assert stored == [], "Turkish İ/i̇ variants should dedupe"
+
+        mock_llm.return_value = (
+            '[{"branch": "WORLD", "fact": "Straße names are ordered alphabetically."}]'
+        )
+        update_graph_from_dialogue(
+            store=store,
+            summary="s",
+            ollama_base_url="http://localhost",
+            ollama_chat_model="model",
+        )
+
+        mock_llm.return_value = (
+            '[{"branch": "WORLD", "fact": "strasse names are ordered alphabetically."}]'
+        )
+        stored = update_graph_from_dialogue(
+            store=store,
+            summary="s",
+            ollama_base_url="http://localhost",
+            ollama_chat_model="model",
+        )
+        assert stored == [], "German ß should casefold to ss for dedupe"
 
 
 # ── Warm profile helpers ──────────────────────────────────────────────

--- a/tests/test_graph_ops.py
+++ b/tests/test_graph_ops.py
@@ -674,6 +674,37 @@ class TestUpdateGraphFromDialogue:
         )
         assert stored == [], "German ß should casefold to ss for dedupe"
 
+    @patch("src.jarvis.memory.graph_ops._llm_pick_best_child")
+    @patch("src.jarvis.memory.graph_ops.call_llm_direct")
+    def test_dedupe_on_child_after_split(self, mock_llm, mock_pick, store):
+        """Dedupe must trigger on whichever node traversal lands on, not
+        only on the branch root. Pre-populate a child of ``world`` with a
+        fact, force the picker to descend into it, then re-extract the
+        same fact and assert no duplicate append."""
+        child = store.create_node(
+            name="Music",
+            description="Musicians, bands, songs.",
+            data="Justin Bieber is a Canadian singer.",
+            parent_id="world",
+        )
+
+        # Force the picker to descend into the Music child on every call.
+        mock_pick.return_value = child.id
+
+        mock_llm.return_value = (
+            '[{"branch": "WORLD", "fact": "Justin Bieber is a Canadian singer."}]'
+        )
+        stored = update_graph_from_dialogue(
+            store=store,
+            summary="User asked about Justin Bieber.",
+            ollama_base_url="http://localhost",
+            ollama_chat_model="model",
+        )
+
+        assert stored == [], "duplicate on a child node should still dedupe"
+        refreshed = store.get_node(child.id)
+        assert refreshed.data.count("Justin Bieber is a Canadian singer.") == 1
+
 
 # ── Warm profile helpers ──────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- Skip graph appends when the chosen node already contains the fact under Unicode-aware folding (NFKC + `casefold` + whitespace collapse).
- Live on `GraphMemoryStore.node_contains_fact` so dedupe sits in the data-store layer next to `append_to_node`.
- Duplicates are logged for debugging but not reported to the user as newly learned, and do **not** touch the node's access score.
- Rebased onto develop after the purpose-driven branch refactor (#284) and extractor tightening (#291) landed.

## Why

After a reply, a second diary flush fired moments later (TTS echo added pending chunks) and produced an identical `🧠 Knowledge graph: learned 4 new facts` block with the same items the first flush had just stored. Root cause: `update_graph_from_dialogue` extracts facts from the full daily summary, and the daily summary is cumulative, so every flush re-extracts the same facts. Without dedupe they were appended again to the same node, producing duplicate lines in the graph and duplicate user-facing notifications. The recent extractor hardening reduces *bogus* facts but doesn't address legitimate repeats from cumulative summaries, so the dedupe is still needed.

## Changes

- `graph.py`: new `normalise_fact` helper (NFKC + `casefold` + whitespace collapse) and `GraphMemoryStore.node_contains_fact`, the line-equality dedupe primitive.
- `graph_ops.py`: in the per-fact loop of `update_graph_from_dialogue` (now iterating `(branch_id, fact)` tuples after #284), call `store.node_contains_fact(node_id, fact)` after `find_best_node` and `continue` on match. `touch_node` is intentionally skipped for dupes. Inline step labels renumbered to match the spec (1 Extract, 2 Place, 3 Dedupe, 4 Append, 5 Split).
- `graph.spec.md`: new explicit "Dedupe" step in the Automatic Writes flow, documenting the Unicode folding, the deliberate access-score skip, and the cross-branch-duplicate trade-off.
- `test_graph_ops.py`: new `TestNodeContainsFact` unit suite (exact match, case/whitespace insensitivity, Turkish İ/i̇ folding, German ß/ss folding, substring non-match, empty-node/empty-fact handling), two end-to-end regression tests for duplicate-across-flushes and Turkish/German locale folding, and a child-after-split dedupe test that forces traversal to descend before deduping.

## Trade-offs documented in code and spec

- **Cross-node duplicates within a branch:** dedupe only checks the target node. If the picker routes the same fact to a different node within the same branch subtree on a later flush, a duplicate can leak. Accepted as rare in practice; scanning the whole subtree per fact would be costly.
- **No access-score bump on dupes:** a re-extraction from a cumulative summary isn't fresh reinforcement, so `touch_node` is intentionally skipped. Future-us might revisit if we want "fact got re-mentioned today" to influence decay.

## Test plan

- [x] `pytest tests/test_graph_ops.py` (56 passed, 10 new)
- [x] `pytest tests/test_dialogue_memory.py tests/test_diary_enrichment_flow.py tests/test_graph_ops.py`
- [ ] Live voice smoke: trigger a reply, let the echo fire a second diary flush, confirm only the first flush logs "learned N new facts".