### PR TITLE
feat(output): pluck-style thinking tune + phase-locked listening rings

### DIFF
--- a/src/desktop_app/face_widget.py
+++ b/src/desktop_app/face_widget.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 import math
 import random
 import threading
+import time as _time
 from typing import Optional, List, Tuple
 from enum import Enum
 from PyQt6.QtWidgets import QWidget, QVBoxLayout, QApplication
@@ -222,7 +223,8 @@ class LowPolyFaceWidget(QWidget):
         self._spinner_angle = 0.0  # Rotation angle for thinking spinner
 
         # Listening animation - bell ring echoes
-        self._listening_pulse_time = 0.0  # Time for spawning rings
+        self._listening_started_at: Optional[float] = None  # Wall-clock start time
+        self._listening_rings_spawned = 0  # How many rings spawned this session
         self._listening_rings: List[float] = []  # Active ring expansions (0.0 to 1.0)
         self._dictation_pulse_phase = 0.0  # Steady pulse phase for DICTATING state
 
@@ -422,10 +424,18 @@ class LowPolyFaceWidget(QWidget):
     def _animate(self):
         """Animation tick - update all animated properties."""
         # Poll Jarvis state directly (more reliable than cross-thread signals)
+        prev_state = self._jarvis_state
         try:
             self._jarvis_state = self._state_manager.state
         except Exception:
             pass
+        # Re-anchor the listening ring clock each time we enter LISTENING
+        # so the first ring lands with the first audible click and later
+        # rings stay phase-locked to wall time.
+        if (self._jarvis_state == JarvisState.LISTENING
+                and prev_state != JarvisState.LISTENING):
+            self._listening_started_at = _time.monotonic()
+            self._listening_rings_spawned = 0
 
         # Update activation level based on state
         if self._jarvis_state == JarvisState.ASLEEP:
@@ -478,20 +488,25 @@ class LowPolyFaceWidget(QWidget):
             self._gaze_y *= 0.95
 
         # Listening animation - bell ring echoes.
-        # Tempo locked to the thinking pad's unison-beat period (1s,
-        # third-slowest wave after the 5s LFO and 1.67s voice-peak
-        # spacing) = 30 frames at 30 FPS.
-        if self._jarvis_state == JarvisState.LISTENING:
-            self._listening_pulse_time += 1
-            if self._listening_pulse_time >= 30:
-                self._listening_pulse_time = 0
-                self._listening_rings.append(0.0)  # Add new ring at expansion 0
+        # Phase-locked to wall time since LISTENING started, matched to
+        # the thinking pad's 2s pulse cycle. Frame-counting drifts vs
+        # the 44.1 kHz audio clock; wall time doesn't.
+        pulse_cycle_s = 2.0
+        ring_lifespan_s = 2.0
+        if self._jarvis_state == JarvisState.LISTENING and self._listening_started_at is not None:
+            elapsed = _time.monotonic() - self._listening_started_at
+            target_spawned = int(elapsed / pulse_cycle_s) + 1  # First ring at t=0
+            while self._listening_rings_spawned < target_spawned:
+                spawn_time = self._listening_rings_spawned * pulse_cycle_s
+                age = max(0.0, elapsed - spawn_time)
+                self._listening_rings.append(age / ring_lifespan_s)
+                self._listening_rings_spawned += 1
 
-            # Expand each ring over one beat (1s).
+            # Age existing rings by one frame (33ms at 30 FPS).
             new_rings = []
             for ring in self._listening_rings:
-                ring += 1.0 / 30.0
-                if ring < 1.0:  # Keep if not fully expanded
+                ring += (1.0 / 30.0) / ring_lifespan_s
+                if ring < 1.0:
                     new_rings.append(ring)
             self._listening_rings = new_rings
         else:
@@ -508,10 +523,9 @@ class LowPolyFaceWidget(QWidget):
             self._dictation_pulse_phase += 0.08  # Steady pulse speed
 
         # Spinner animation (while thinking or post-dictation processing).
-        # One full revolution per pad unison-beat period (1s = 30 frames
-        # at 30 FPS) — third-slowest wave in the thinking tone.
+        # One full revolution per pad pulse cycle (2s = 60 frames at 30 FPS).
         if self._jarvis_state in (JarvisState.THINKING, JarvisState.DICTATION_PROCESSING):
-            self._spinner_angle += 360.0 / 30.0  # 12 deg/frame → one rev per 1s
+            self._spinner_angle += 6.0  # 6 deg/frame → one rev per 2s
             if self._spinner_angle >= 360:
                 self._spinner_angle -= 360
 

--- a/src/jarvis/output/tune_player.py
+++ b/src/jarvis/output/tune_player.py
@@ -17,9 +17,8 @@ def _generate_thinking_pad_samples() -> tuple[np.ndarray, int]:
     the looping imperceptible:
 
     1. Mathematical seam: every sine frequency (in Hz) is an integer,
-       and every LFO period evenly divides the clip duration (in
-       seconds), so start and end samples match exactly — no click at
-       the wrap point.
+       so start and end samples match exactly — no click at the wrap
+       point.
     2. Short duration (10s): the sounddevice callback loops the
        buffer natively in the OS audio thread, so there's no
        per-iteration gap. A shorter buffer keeps generation cheap
@@ -27,51 +26,57 @@ def _generate_thinking_pad_samples() -> tuple[np.ndarray, int]:
 
     Tone character — choir-"ahh" / bowed-string pad:
     - A major triad (A3 / C#4 / E4) with a natural harmonic spectrum
-      (partials 1-6 with 1/n-style rolloff) so each voice has real
+      (fundamental only) so each voice has real
       timbre instead of sounding like a pure sine.
     - Three-way unison detune per chord tone (-1 Hz, 0, +1 Hz) —
       mirrors how an ensemble of human singers or strings is never
-      perfectly in tune, giving chorus-like warmth and body.
-    - Phase-offset cross-fading LFOs on the three chord voices so the
-      blend shifts continuously while total amplitude stays steady.
+      perfectly in tune, giving chorus-like warmth and body and a
+      gentle ~1 Hz beat between the outer layers.
 
     Returns (int16 mono samples, sample_rate).
     """
     sample_rate = 44100
+    # 10s buffer = 5 pulse cycles of 2s each (1s tone + 1s silence).
     duration_s = 10
+    pulse_cycle_s = 2.0
+    tone_s = 1.0  # audible portion per cycle
+    attack_s = 0.008  # ~8ms fast attack gives the slight "click"
 
     chord_roots = (220, 275, 330)  # A3, ~C#4, ~E4 — integer Hz for seamless seam
-    harmonic_gains = (1.00, 0.55, 0.30, 0.18, 0.10, 0.06)
-    harmonic_phases = (0.0, 0.7, 1.3, 2.1, 0.4, 1.9)
     unison_offsets = (-1, 0, 1)
-    lfo_period = 5.0  # amplitude cross-fade: 2 cycles per 10s loop (evenly divides)
 
     n = int(sample_rate * duration_s)
     t = np.arange(n, dtype=np.float64) / sample_rate
     two_pi = 2 * np.pi
 
-    lfo_w = two_pi / lfo_period
-    voice_amps = [
-        0.55 + 0.25 * np.sin(lfo_w * t + k * two_pi / 3)
-        for k in range(3)
-    ]
+    # Single-cycle envelope: fast linear attack → exponential decay →
+    # silence for the rest of the cycle. Tiles across the whole buffer.
+    cycle_len = int(sample_rate * pulse_cycle_s)
+    tone_len = int(sample_rate * tone_s)
+    attack_len = max(1, int(sample_rate * attack_s))
+    decay_len = tone_len - attack_len
+    one_cycle = np.zeros(cycle_len, dtype=np.float64)
+    one_cycle[:attack_len] = np.linspace(0.0, 1.0, attack_len, endpoint=True)
+    # Exponential decay from 1.0 down to effectively 0 over the tone body.
+    decay = np.exp(-4.0 * np.arange(decay_len) / decay_len)
+    one_cycle[attack_len:tone_len] = decay
+    # Tile three cycles across the 9s buffer (matches duration_s exactly).
+    num_cycles = n // cycle_len
+    envelope = np.zeros(n, dtype=np.float64)
+    for i in range(num_cycles):
+        envelope[i * cycle_len:(i + 1) * cycle_len] = one_cycle
 
-    voice_signals = []
+    # Build the triad once: three pure sines per chord tone with ±1 Hz
+    # unison detune for the characteristic beat.
+    tone = np.zeros(n, dtype=np.float64)
     for root in chord_roots:
-        unison_sum = np.zeros(n, dtype=np.float64)
         for offset in unison_offsets:
             f = root + offset
-            for h_idx, (gain, phase0) in enumerate(
-                zip(harmonic_gains, harmonic_phases)
-            ):
-                partial_freq = (h_idx + 1) * f
-                phase = two_pi * partial_freq * t + phase0
-                unison_sum += gain * np.sin(phase)
-        voice_signals.append(unison_sum)
-
-    tone = sum(a * v for a, v in zip(voice_amps, voice_signals))
+            tone += np.sin(two_pi * f * t)
     peak = float(np.max(np.abs(tone))) or 1.0
-    signal = (tone / peak) * 0.32
+    tone = tone / peak
+
+    signal = tone * envelope * 0.38
 
     samples = np.clip(signal * 32767, -32768, 32767).astype(np.int16)
     return samples, sample_rate

--- a/tests/test_tune_player.py
+++ b/tests/test_tune_player.py
@@ -38,7 +38,7 @@ def test_thinking_pad_samples_have_expected_shape():
     assert rate == 44100
     assert samples.dtype.name == "int16"
     assert samples.ndim == 1
-    # Long enough to feel continuous; sounddevice loops it natively.
+    # Long enough to contain several pulse-silence cycles.
     assert samples.size / rate >= 5.0
 
 
@@ -68,15 +68,20 @@ def test_thinking_pad_seam_is_effectively_seamless():
     assert abs(first - last) < 0.05 * 32767
 
 
-def test_thinking_pad_stays_loud_throughout():
+def test_thinking_pad_breathes():
+    """The pad is intentionally not continuous — it has a short audible
+    breath followed by a silent pause each loop so long thinking runs
+    aren't fatiguing. Verify both extremes exist."""
     samples, rate = _generate_thinking_pad_samples()
     win = rate // 10  # 100ms windows
     peaks = [
         int(abs(samples[i : i + win]).max())
         for i in range(0, samples.size - win, win)
     ]
-    # Never drops to silence — observed floor ≈ 2800.
-    assert min(peaks) > 0.05 * 32767
+    # At least one window is clearly audible (the hold section).
+    assert max(peaks) > 0.10 * 32767
+    # At least one window is effectively silent (the rest pause).
+    assert min(peaks) < 0.005 * 32767
 
 
 # --- TunePlayer lifecycle --------------------------------------------------


### PR DESCRIPTION
## Summary

Follow-up to #280 after more live iteration. The continuous ambient pad turned out to be fatiguing on long thinking runs, and the bell-echo rings drifted out of phase with it. This PR replaces the pad with a short pluck and phase-locks the ring animation to wall time.

## What changed

### Thinking tune
- Short click-and-decay pluck of the same A3 / C#4 / E4 triad from #280. 2s cycle per loop (1s audible tone + 1s silent rest), 5 cycles per 10s buffer.
- Fast 8ms linear attack + ~1s exponential decay for the slight \"click\" character. Pure sines with ±1 Hz unison detune keep the techy triad feel but let the ear rest between pulses.
- Volume bumped to 0.38 since each pulse is brief.

### Listening rings
- Rewire the bell-echo ring timing off frame counting onto wall time. Frame counting drifts against the 44.1 kHz audio clock, so rings slowly wandered out of phase with the pluck; anchoring spawns to `monotonic()` elapsed-since-LISTENING keeps them locked.
- First ring now spawns at elapsed=0 (with the first audible click), not after a 60-frame warm-up, so the animation lands on the first beep instead of the second.
- Transition detection lives in the state-polling block in `_animate` (the earlier signal handler never fired because `_animate` overwrites `_jarvis_state` from `state_manager.state` on every tick).

## Test plan

- [ ] Trigger a multi-second thinking run and confirm the pluck loops cleanly with real silence between pulses.
- [ ] Watch the face during LISTENING and confirm the first ring lands with the first audible click, and subsequent rings stay in phase with the pluck.
- [ ] Tests: `pytest tests/test_tune_player.py` (12 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)