### PR TITLE
fix(output): stop thinking tune without cross-thread abort race

### DIFF
--- a/src/jarvis/output/tune_player.py
+++ b/src/jarvis/output/tune_player.py
@@ -162,8 +162,6 @@ class TunePlayer:
         self._thread: Optional[threading.Thread] = None
         self._stop_event = threading.Event()
         self._is_playing = threading.Event()
-        self._stream_lock = threading.Lock()
-        self._stream = None  # sounddevice.OutputStream, set while playing
 
     def start_tune(self) -> None:
         if not self.enabled or self._thread is not None:
@@ -175,21 +173,22 @@ class TunePlayer:
         self._thread.start()
 
     def stop_tune(self) -> None:
-        """Stop the tune immediately, releasing the audio device."""
+        """Stop the tune immediately, releasing the audio device.
+
+        We deliberately do NOT call ``stream.abort()`` from this thread —
+        only the tune thread (`_play_tune`'s finally block) touches the
+        stream. Calling abort() here and then close() over there races on
+        macOS: PortAudio/CoreAudio emits a spurious
+        ``||PaMacCore (AUHAL)|| Error … err=''!obj''`` on every stop
+        because the AudioObject is being torn down twice. Setting the
+        stop event is enough — `stream.close()` discards pending buffers
+        as if abort() had been called.
+        """
         if self._thread is None:
             return
 
         debug_log("thinking tune: stop", category="tune")
         self._stop_event.set()
-
-        with self._stream_lock:
-            stream = self._stream
-        if stream is not None:
-            try:
-                stream.abort()
-            except Exception as exc:
-                debug_log(f"thinking tune: stream abort failed: {exc!r}", category="tune")
-
         self._thread.join(timeout=1.0)
         self._thread = None
         self._is_playing.clear()
@@ -250,8 +249,6 @@ class TunePlayer:
                 return
 
             try:
-                with self._stream_lock:
-                    self._stream = stream
                 stream.start()
                 # Hand off to the OS audio thread. Wake when stop is
                 # requested — no polling loop, no per-iteration gap.
@@ -263,8 +260,6 @@ class TunePlayer:
                     stream.close()
                 except Exception as exc:
                     debug_log(f"thinking tune: stream close failed: {exc!r}", category="tune")
-                with self._stream_lock:
-                    self._stream = None
         finally:
             self._is_playing.clear()
 

--- a/tests/test_tune_player.py
+++ b/tests/test_tune_player.py
@@ -4,7 +4,9 @@ Covers:
 - Sample / WAV generation: right format/size, seam is effectively seamless.
 - TunePlayer lifecycle: idempotent start/stop, is_playing state, prompt
   stop even when a "stream" is running.
-- Sounddevice dispatch: stop_tune aborts the stream (not a subprocess).
+- Sounddevice dispatch: stop_tune closes the stream cleanly from the
+  owning thread (no cross-thread abort — that races with close on
+  macOS CoreAudio and logs a spurious !obj error).
 
 The sounddevice stream is exercised via a fake `sounddevice` module
 injected into sys.modules — works headlessly in CI.
@@ -148,7 +150,7 @@ def test_double_start_is_ignored(monkeypatch):
         tp.stop_tune()
 
 
-def test_stop_aborts_the_stream_and_returns_quickly(monkeypatch):
+def test_stop_closes_the_stream_and_returns_quickly(monkeypatch):
     created = _install_fake_sounddevice(monkeypatch)
     tp = TunePlayer(enabled=True)
     tp.start_tune()
@@ -166,8 +168,10 @@ def test_stop_aborts_the_stream_and_returns_quickly(monkeypatch):
     tp.stop_tune()
     elapsed = time.time() - t0
 
-    assert stream.aborted
+    # Only the tune thread closes the stream; stop_tune must NOT abort
+    # from the caller's thread — that races with close() on macOS.
     assert stream.closed
+    assert not stream.aborted
     assert elapsed < 1.0
     assert not tp.is_playing()
 


### PR DESCRIPTION
## Summary

On macOS, calling \`stream.abort()\` from \`stop_tune()\`'s caller thread and \`stream.close()\` from the tune thread's finally block races inside PortAudio/CoreAudio: the AudioObject is torn down twice and stderr spams \`||PaMacCore (AUHAL)|| Error on line 2796: err=''!obj''\` on every reply completion.

The \`!obj\` FourCC is \`kAudioHardwareBadObjectError\` — an AudioObjectID being referenced after it was invalidated.

Fix: only the tune thread touches the stream. \`stop_tune()\` sets the stop event and joins; the tune thread's finally block does \`stream.close()\`, which already discards pending buffers cleanly (sounddevice docs: \"If the audio stream is active, any pending buffers are discarded as if abort() had been called\"). Drops the now-dead \`_stream_lock\` / \`_stream\` fields.

## Test plan

- [x] \`pytest tests/test_tune_player.py\` — 12/12 passing
- [x] Test updated: \`test_stop_closes_the_stream_and_returns_quickly\` asserts \`stream.closed\` AND \`not stream.aborted\`
- [ ] Manual verification on macOS: run Jarvis, complete a reply, confirm no \`!obj\` error in terminal

🤖 Generated with [Claude Code](https://claude.com/claude-code)