### PR TITLE
fix(nutrition)+feat(listening): logMeal resilience and friendlier startup banner

### DIFF
--- a/src/jarvis/listening/listener.py
+++ b/src/jarvis/listening/listener.py
@@ -2056,7 +2056,12 @@ class VoiceListener(threading.Thread):
 
             # Show ready message only after stream is confirmed active
             wake_word = getattr(self.cfg, "wake_word", "jarvis").lower()
-            print(f"\n{'─' * 50}\n🎙️  Listening! Try: \"How's the weather, {wake_word.title()}?\"", flush=True)
+            wake_title = wake_word.title()
+            print(f"\n{'─' * 50}\n🎙️  Listening! Try:", flush=True)
+            print(f"      \"How's the weather, {wake_title}?\"", flush=True)
+            print(f"      \"I just ate a Big Mac, {wake_title}.\"", flush=True)
+            print(f"      \"What are you thinking, {wake_title}?\"", flush=True)
+            print(f"      \"What do you know about me, {wake_title}?\"", flush=True)
 
             # Small-model disclaimer: SMALL models can't infer your intent
             # from vague prompts, but they can still execute complex flows
@@ -2067,15 +2072,11 @@ class VoiceListener(threading.Thread):
             chat_model_name = str(getattr(self.cfg, "ollama_chat_model", "") or "").strip()
             if chat_model_name and detect_model_size(chat_model_name) == ModelSize.SMALL:
                 print(
-                    f"  ⚠️  Small model in use ({chat_model_name}). Assume it can't infer — spell out the steps.",
+                    f"  ⚠️  Small model in use ({chat_model_name}). Assume it can't infer — spell out the steps for anything more involved:",
                     flush=True,
                 )
                 print(
-                    f"      👍 \"Check tomorrow's weather and local events, then recommend events that suit the weather, {wake_word.title()}.\"",
-                    flush=True,
-                )
-                print(
-                    f"      👎 \"What event should I go to tomorrow, {wake_word.title()}?\"",
+                    f"      \"Tell me tomorrow's weather, then find local events for tomorrow, then recommend ones that suit the weather, {wake_title}.\"",
                     flush=True,
                 )
 
@@ -2091,15 +2092,11 @@ class VoiceListener(threading.Thread):
                 has_chrome_mcp = False
             if has_chrome_mcp:
                 print(
-                    f"  🌐 Chrome MCP detected. Name the destination URL so the browser tool can act directly.",
+                    f"  🌐 Chrome MCP detected. Name the destination URL so the browser tool can act directly:",
                     flush=True,
                 )
                 print(
-                    f"      👍 \"Navigate to youtube.com, {wake_word.title()}.\"",
-                    flush=True,
-                )
-                print(
-                    f"      👎 \"Open YouTube, {wake_word.title()}.\"",
+                    f"      \"Navigate to youtube.com, {wake_title}.\"",
                     flush=True,
                 )
 

--- a/src/jarvis/listening/listening.spec.md
+++ b/src/jarvis/listening/listening.spec.md
@@ -100,8 +100,14 @@ Before the listener announces "Listening!", it pre-loads every model the first e
      🎤 Whisper 'small' loaded on cpu
      💬 Chat model 'llama3.1' ready
      🧠 Intent judge 'gemma4:e2b' ready
-🎙️  Listening! Try: "How's the weather, Jarvis?"
+🎙️  Listening! Try:
+      "How's the weather, Jarvis?"
+      "I just ate a Big Mac, Jarvis."
+      "What are you thinking, Jarvis?"
+      "What do you know about me, Jarvis?"
 ```
+
+On small models, a caveat line is appended above a more involved example to set expectations (`⚠️ Small model in use (…). Assume it can't infer — spell out the steps for anything more involved:`). The Chrome MCP tip continues to appear as its own block when the browser tool is detected.
 
 **What gets warmed:**
 - **Whisper** — loading the model; additionally a silent-audio transcribe so the first real utterance doesn't pay the cold-decode cost. Both the MLX and faster-whisper backends do this.

--- a/src/jarvis/tools/builtin/nutrition/log_meal.py
+++ b/src/jarvis/tools/builtin/nutrition/log_meal.py
@@ -24,6 +24,17 @@ NUTRITION_SYS = (
 )
 
 
+def _strip_code_fence(text: str) -> str:
+    """Strip ```json ... ``` or ``` ... ``` fences that small models often add."""
+    s = text.strip()
+    if s.startswith("```"):
+        # Drop first fence line
+        s = s.split("\n", 1)[1] if "\n" in s else s[3:]
+        if s.endswith("```"):
+            s = s[: -3]
+    return s.strip()
+
+
 def _safe_float(x: Any) -> Optional[float]:
     """Safely convert value to float."""
     try:
@@ -48,11 +59,13 @@ def extract_and_log_meal(db: Database, cfg: Any, original_text: str, source_app:
     raw = call_llm_direct(cfg.ollama_base_url, cfg.ollama_chat_model, NUTRITION_SYS, user_prompt, timeout_sec=cfg.llm_chat_timeout_sec, thinking=getattr(cfg, 'llm_thinking_enabled', False)) or ""
     text = (raw or "").strip()
     if text.upper() == "NONE":
+        debug_log(f"logMeal extractor returned NONE for text={original_text[:120]!r}", "nutrition")
         return None
     data: Dict[str, Any]
     try:
-        data = json.loads(text)
-    except Exception:
+        data = json.loads(_strip_code_fence(text))
+    except Exception as e:
+        debug_log(f"logMeal extractor JSON parse failed: {e!r}; raw={text[:200]!r}", "nutrition")
         return None
     ts = datetime.now(timezone.utc).isoformat()
     meal_id = db.insert_meal(
@@ -184,16 +197,15 @@ class LogMealTool(Tool):
         """Execute the log meal tool."""
         context.user_print("🥗 Logging your meal…")
 
-        # First attempt: use provided args if complete
-        required = [
-            "description", "calories_kcal", "protein_g", "carbs_g", "fat_g",
-            "fiber_g", "sugar_g", "sodium_mg", "potassium_mg", "micros", "confidence"
-        ]
+        # First attempt: use provided args if they carry at least a description and a kcal estimate.
+        # Missing optional fields (micros, potassium, etc.) are stored as NULL by log_meal_from_args,
+        # which is still more useful than discarding the model's output and retrying from scratch.
+        def _has_min_fields(a: Dict[str, Any]) -> bool:
+            desc = a.get("description")
+            kcal = a.get("calories_kcal")
+            return bool(desc and isinstance(desc, str)) and isinstance(kcal, (int, float))
 
-        def _has_all_fields(a: Dict[str, Any]) -> bool:
-            return all(k in a for k in required)
-
-        if args and isinstance(args, dict) and _has_all_fields(args):
+        if args and isinstance(args, dict) and _has_min_fields(args):
             debug_log("logMeal: using provided args", "nutrition")
             meal_id = log_meal_from_args(context.db, args, source_app=("stdin" if context.cfg.use_stdin else "unknown"))
             if meal_id is not None:
@@ -222,8 +234,8 @@ class LogMealTool(Tool):
                 if meal_summary:
                     debug_log("logMeal: extraction+log succeeded", "nutrition")
                     return ToolExecutionResult(success=True, reply_text=meal_summary)
-            except Exception:
-                pass
+            except Exception as e:
+                debug_log(f"logMeal extract_and_log_meal attempt {attempt+1} raised: {e!r}", "nutrition")
 
         debug_log("logMeal: failed", "nutrition")
         context.user_print("⚠️ I couldn't log that meal automatically.")

--- a/tests/tools/builtin/nutrition/test_log_meal.py
+++ b/tests/tools/builtin/nutrition/test_log_meal.py
@@ -61,6 +61,22 @@ class TestLogMealTool:
         mock_log_meal.assert_called_once()
         mock_followups.assert_called_once()
 
+    @patch('src.jarvis.tools.builtin.nutrition.log_meal.log_meal_from_args')
+    @patch('src.jarvis.tools.builtin.nutrition.log_meal.generate_followups_for_meal')
+    def test_run_with_partial_args_logs_without_retry(self, mock_followups, mock_log_meal):
+        """Partial args with description + kcal should still log directly, not fall to extractor."""
+        mock_log_meal.return_value = 789
+        mock_followups.return_value = "Hydrate."
+
+        args = {"description": "Big Mac", "calories_kcal": 540, "protein_g": 25}
+
+        result = self.tool.run(args, self.context)
+
+        assert result.success is True
+        assert "Logged meal #789" in result.reply_text
+        assert "Big Mac" in result.reply_text
+        mock_log_meal.assert_called_once()
+
     @patch('src.jarvis.tools.builtin.nutrition.log_meal.extract_and_log_meal')
     def test_run_with_extraction_fallback(self, mock_extract):
         """Test meal logging with text extraction fallback."""


### PR DESCRIPTION
## Summary

Two follow-ups that slipped between the last commit on PR #284 and its merge. Both are small and independent; grouped here to avoid a stampede of tiny PRs.

### 1. logMeal resilience (`fix(nutrition)`)

Direct-exec on a small model rarely fills all 11 nutrition fields in one go, so the strict `_has_all_fields` gate forced every meal through the LLM extractor fallback. That fallback's silent `except Exception: pass` swallowed every failure (JSON parse, code-fenced output, DB insert errors) and emitted the unhelpful `⚠️ I couldn't log that meal automatically.` message seen in testing on "I just ate a Big Mac, Jarvis."

- Replaced `_has_all_fields` with `_has_min_fields` (description + kcal). `log_meal_from_args` already stores NULL for missing numeric fields; partial output is more useful than nothing.
- Added `_strip_code_fence` so ` ```json ... ``` ` wrappers parse cleanly.
- Added `debug_log` to every failure path (NONE sentinel, JSON parse, retry-loop exception). No more silent failures.
- New test: `test_run_with_partial_args_logs_without_retry`.

### 2. Startup banner rework (`feat(listening)`)

The single "Try: How's the weather, Jarvis?" line undersold the assistant. New banner lists four distinct starter queries covering different surfaces:

```
🎙️  Listening! Try:
      "How's the weather, Jarvis?"
      "I just ate a Big Mac, Jarvis."
      "What are you thinking, Jarvis?"
      "What do you know about me, Jarvis?"
  ⚠️  Small model in use (gemma4:e2b). Assume it can't infer, spell out the steps for anything more involved:
      "Tell me tomorrow's weather, then find local events for tomorrow, then recommend ones that suit the weather, Jarvis."
  🌐 Chrome MCP detected. Name the destination URL so the browser tool can act directly:
      "Navigate to youtube.com, Jarvis."
```

The small-model caveat now sits above its more involved example so the warning has a referent. Dropped the 👍/👎 contrast framing in both tips: one clear example beats a comparison pair.

Spec (`src/jarvis/listening/listening.spec.md`) updated to match.

## Test plan

- [x] `pytest tests/tools/builtin/nutrition/test_log_meal.py` passes (5/5)
- [ ] Manual: "I just ate a Big Mac, Jarvis" logs successfully on gemma4:e2b
- [ ] Manual: startup banner renders as expected with both small and large chat models
- [ ] Manual: Chrome MCP tip appears when the MCP is installed