### PR TITLE
test(evals): drop redundant "Live" prefix from eval labels

### DIFF
--- a/EVALS.md
+++ b/EVALS.md
@@ -31,34 +31,38 @@
 | Agent calls webSearch for info queries | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | Agent chains search → fetch for details | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | Agent uses memory + nutrition data | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
+| Assistant checks memory before asking about interests | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
+| Assistant does not deny having long-term memory | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | Bad: deflection without attempting answer | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | Bad: empty acknowledgment | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | Bad: generic greeting ignores query | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
+| calorie budget \u2192 fetchMeals | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | Diet changed from bulking to cutting | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | Diet changed from bulking to cutting-gemma4:e2b | ⏭️ SKIPPED | 🔸 1/1 XFAIL |
 | Diet changed from bulking to cutting-gpt-oss:20b | ⏭️ SKIPPED | ❌ 0/1 (0%) |
+| dietary check \u2192 fetchMeals | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | Enrichment results appear in system message | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | Extraction with explicit quantities | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
+| find the invoice PDF on my computer | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | Follow-up references previous turn context | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
+| food decision \u2192 fetchMeals | 🔸 1/1 XFAIL | 🔸 1/1 XFAIL |
 | Good: brief but informative | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | Good: complete weekly forecast | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
+| Graph-enriched facts surface in the reply, no denial | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
+| Greeting: hello | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
+| Greeting: ni hao (Chinese) | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | Handles ambiguous portion descriptions | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
+| Instruction: be more brief | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
+| Instruction: use Celsius | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
+| jacket \u2192 getWeather | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | LLM uses enrichment-surfaced interests for personalised search | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
-| Live greeting: hello | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
-| Live greeting: ni hao (Chinese) | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
-| Live instruction: be more brief | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
-| Live instruction: use Celsius | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
-| Live unknown entity: Piranesi (book) | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
-| Live unknown entity: Possessor (film) | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
-| Live unknown entity: have-you-heard-of (Piranesi) | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
-| Live unknown entity: permission-framed (Possessor) | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
-| Live weather query with real LLM | ❌ 0/1 (0%) | ✅ 1/1 (100%) |
-| Live: LLM checks memory before asking about interests | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
-| Live: assistant does not deny having long-term memory | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
-| Live: graph-enriched facts surface in reply, no denial | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
-| Live: weather query triggers tools | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | Location context flows to search queries | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
+| location weather query selects getWeather and few others | ✅ 1/1 (100%) | ❌ 0/1 (0%) |
+| log that I just ate a banana | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | LogMealTool stores meals with macros | ❌ 0/1 (0%) | ✅ 1/1 (100%) |
+| meal logging selects logMeal and few others | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
+| meal recall (colloquial) \u2192 fetchMeals | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
+| meal recall selects fetchMeals and few others | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | Memory enrichment: personalized news | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | Memory enrichment: time-based recall | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | Memory enrichment: topic recall | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
@@ -80,27 +84,12 @@
 | Reframing: requests become knowledge, not interaction descriptions | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | Reject: assistant self-references (recommendations are not knowledge) | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | Reject: stale temporal snapshots (weather, time of day) | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
+| research \u2192 webSearch + fetchWebPage | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | Returns NONE for non-food inputs | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | Returns valid JSON with all required fields | ❌ 0/1 (0%) | ✅ 1/1 (100%) |
-| Simple meal baseline (2 boiled eggs) | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
-| Tool retry: explicit tool mention | 🔸 1/1 XFAIL | ✅ 1/1 (100%) |
-| Tool retry: vague go ahead | 🔸 1/1 XFAIL | ✅ 1/1 (100%) |
-| Tool retry: vague just try | 🔸 1/1 XFAIL | ✅ 1/1 (100%) |
-| Topic switch: search → weather uses getWeather | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
-| Topic switch: weather → store hours uses webSearch | ❌ 0/1 (0%) | ✅ 1/1 (100%) |
-| calorie budget \u2192 fetchMeals | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
-| dietary check \u2192 fetchMeals | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
-| find the invoice PDF on my computer | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
-| food decision \u2192 fetchMeals | 🔸 1/1 XFAIL | 🔸 1/1 XFAIL |
-| jacket \u2192 getWeather | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
-| location weather query selects getWeather and few others | ✅ 1/1 (100%) | ❌ 0/1 (0%) |
-| log that I just ate a banana | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
-| meal logging selects logMeal and few others | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
-| meal recall (colloquial) \u2192 fetchMeals | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
-| meal recall selects fetchMeals and few others | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
-| research \u2192 webSearch + fetchWebPage | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | run forecast \u2192 getWeather | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | search the web for flight deals | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
+| Simple meal baseline (2 boiled eggs) | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | take a screenshot | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | test_active_hot_window_follow_up_accepted | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | test_casual_statement_without_wake_word_rejected | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
@@ -159,8 +148,19 @@
 | test_weather_query_calls_tool_without_asking_for_location | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | test_weather_query_still_picks_getWeather | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | test_wikipedia_rescues_when_ddg_blocks | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
+| Tool retry: explicit tool mention | 🔸 1/1 XFAIL | ✅ 1/1 (100%) |
+| Tool retry: vague go ahead | 🔸 1/1 XFAIL | ✅ 1/1 (100%) |
+| Tool retry: vague just try | 🔸 1/1 XFAIL | ✅ 1/1 (100%) |
+| Topic switch: search → weather uses getWeather | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
+| Topic switch: weather → store hours uses webSearch | ❌ 0/1 (0%) | ✅ 1/1 (100%) |
+| Unknown entity: have-you-heard-of (Piranesi) | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
+| Unknown entity: permission-framed (Possessor) | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
+| Unknown entity: Piranesi (book) | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
+| Unknown entity: Possessor (film) | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | weather + meals | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
+| Weather query is answered with current conditions | ❌ 0/1 (0%) | ✅ 1/1 (100%) |
 | weather query selects getWeather and few others | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
+| Weather query still triggers tools after a greeting | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | web search query selects webSearch and few others | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | weekly weather keeps getWeather | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | what's on my screen right now? | ✅ 1/1 (100%) | ✅ 1/1 (100%) |

--- a/evals/conftest.py
+++ b/evals/conftest.py
@@ -100,9 +100,9 @@ TEST_DESCRIPTIONS = {
     "test_enrichment_extracts_correct_keywords": "Enrichment extracts personalization keywords",
     "test_enrichment_provides_context_to_llm": "Enrichment results appear in system message",
     "test_llm_uses_enrichment_for_personalised_queries": "LLM uses enrichment-surfaced interests for personalised search",
-    "test_weather_query_live": "Live weather query with real LLM",
-    "test_personalized_query_recalls_memory_live": "Live: LLM checks memory before asking about interests",
-    "test_interest_flavoured_query_live": "Live: interest-flavoured phrasings surface seeded interests into the reply",
+    "test_weather_query_live": "Weather query is answered with current conditions",
+    "test_personalized_query_recalls_memory_live": "Assistant checks memory before asking about interests",
+    "test_interest_flavoured_query_live": "Interest-flavoured phrasings surface seeded interests in the reply",
     # Nutrition extraction tests
     "test_meal_extraction_accuracy": "Extracts accurate macros for common meals",
     "test_extraction_returns_valid_json_structure": "Returns valid JSON with all required fields",
@@ -119,15 +119,15 @@ TEST_DESCRIPTIONS = {
     "test_three_turn_topic_changes": "3-turn conversation with topic changes",
     "test_rapid_topic_switching": "Rapid back-and-forth topic switching",
     # Greeting no-tools live tests
-    "test_greeting_no_tools_live": "Live: greeting should not trigger tool calls",
-    "test_user_instructions_no_tools_live": "Live: user instructions don't trigger tool calls",
-    "test_weather_still_triggers_tools_live": "Live: weather query triggers tools",
+    "test_greeting_no_tools_live": "Greetings do not trigger tool calls",
+    "test_user_instructions_no_tools_live": "User instructions do not trigger tool calls",
+    "test_weather_still_triggers_tools_live": "Weather query still triggers tools after a greeting",
     # Helpfulness / anti-deflection tests
-    "test_no_deflection_for_weather_forecast_live": "Live: no deflection for weather forecasts",
-    "test_no_deflection_for_answerable_queries_live": "Live: no deflection for answerable queries",
-    "test_tool_retry_after_failure_live": "Live: tool retry after initial failure",
-    "test_graph_knowledge_surfaced_in_reply_live": "Live: graph-enriched facts surface in reply, no denial",
-    "test_does_not_deny_long_term_memory_live": "Live: assistant does not deny having long-term memory",
+    "test_no_deflection_for_weather_forecast_live": "No deflection on weather forecast questions",
+    "test_no_deflection_for_answerable_queries_live": "No deflection on answerable questions",
+    "test_tool_retry_after_failure_live": "Assistant retries a tool after the first attempt fails",
+    "test_graph_knowledge_surfaced_in_reply_live": "Graph-enriched facts surface in the reply, no denial",
+    "test_does_not_deny_long_term_memory_live": "Assistant does not deny having long-term memory",
 }
 
 

--- a/evals/test_greeting_no_tools.py
+++ b/evals/test_greeting_no_tools.py
@@ -53,8 +53,8 @@ class TestGreetingNoToolsLive:
     @pytest.mark.eval
     @requires_judge_llm
     @pytest.mark.parametrize("query,should_use_tools", [
-        pytest.param("hello", False, id="Live greeting: hello"),
-        pytest.param("ni hao", False, id="Live greeting: ni hao (Chinese)"),
+        pytest.param("hello", False, id="Greeting: hello"),
+        pytest.param("ni hao", False, id="Greeting: ni hao (Chinese)"),
     ])
     def test_greeting_no_tools_live(
         self,
@@ -98,8 +98,8 @@ class TestGreetingNoToolsLive:
     @pytest.mark.eval
     @requires_judge_llm
     @pytest.mark.parametrize("query,should_use_tools", [
-        pytest.param("always use Celsius when telling me temperatures", False, id="Live instruction: use Celsius"),
-        pytest.param("be more brief in your responses", False, id="Live instruction: be more brief"),
+        pytest.param("always use Celsius when telling me temperatures", False, id="Instruction: use Celsius"),
+        pytest.param("be more brief in your responses", False, id="Instruction: be more brief"),
     ])
     def test_user_instructions_no_tools_live(
         self,
@@ -138,14 +138,14 @@ class TestGreetingNoToolsLive:
     @pytest.mark.eval
     @requires_judge_llm
     @pytest.mark.parametrize("query", [
-        pytest.param("what do you know about the Possessor movie", id="Live unknown entity: Possessor (film)"),
-        pytest.param("tell me about the book Piranesi", id="Live unknown entity: Piranesi (book)"),
+        pytest.param("what do you know about the Possessor movie", id="Unknown entity: Possessor (film)"),
+        pytest.param("tell me about the book Piranesi", id="Unknown entity: Piranesi (book)"),
         # Permission-framed phrasing. Regression: the small model previously
         # read "what can you tell me" as "tell me what you can do" and deflected
         # with "I can search the web if you'd like" instead of calling webSearch.
-        pytest.param("what can you tell me about the movie Possessor", id="Live unknown entity: permission-framed (Possessor)"),
+        pytest.param("what can you tell me about the movie Possessor", id="Unknown entity: permission-framed (Possessor)"),
         # "Have you heard of" is another common permission-framed variant.
-        pytest.param("have you heard of the film Piranesi", id="Live unknown entity: have-you-heard-of (Piranesi)"),
+        pytest.param("have you heard of the film Piranesi", id="Unknown entity: have-you-heard-of (Piranesi)"),
     ])
     def test_unknown_named_entity_triggers_web_search_live(
         self,


### PR DESCRIPTION
## Summary
- Strip the "Live:" / "Live " prefix from `TEST_DESCRIPTIONS` values, the two `Live`-named class blurbs, and the parametrize ids in `evals/test_greeting_no_tools.py`. Every eval in the suite drives a real model, so the prefix was uninformative.
- Refresh `EVALS.md` to use the cleaned labels and resort comparison tables alphabetically so the report stays readable for non-technical reviewers.

## Test plan
- [ ] `pytest evals/test_greeting_no_tools.py -k Greeting --collect-only` shows the renamed parametrize ids
- [ ] Next eval suite run regenerates `EVALS.md` with the new labels (manual verification on a future run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)