### PR TITLE
refactor(reply): run tool router before planner

### DIFF
--- a/EVALS.md
+++ b/EVALS.md
@@ -1,16 +1,16 @@
 # 🧪 Jarvis Evaluation Report
 
-**Generated:** 2026-04-21 02:34:51
+**Generated:** 2026-04-25 01:09:33
 
 ## 📊 TL;DR
 
-**Overall:** 🟢 **286/304 passed (94.1%)** across all categories
+**Overall:** 🟢 **328/348 passed (94.3%)** across all categories
 
 | Category | Model | Passed | Failed | Skipped | Pass Rate |
 |----------|-------|-------:|-------:|--------:|----------:|
-| 🤖 Agent behaviour | `gemma4:e2b` | 116 | 10 | 4 | 🟢 92.1% |
-| 🤖 Agent behaviour | `gpt-oss:20b` | 128 | 6 | 0 | 🟢 95.5% |
-| 🎤 Intent judge | `gemma4:e2b` (fixed) | 42 | 2 | 0 | 🟢 95.5% |
+| 🤖 Agent behaviour | `gemma4:e2b` | 136 | 9 | 4 | 🟢 93.8% |
+| 🤖 Agent behaviour | `gpt-oss:20b` | 145 | 11 | 0 | 🟢 92.9% |
+| 🎤 Intent judge | `gemma4:e2b` (fixed) | 47 | 0 | 0 | 🟢 100.0% |
 
 ### 💡 Model Selection Guide
 
@@ -28,46 +28,45 @@
 | Test Case | gemma4:e2b | gpt-oss:20b |
 |-----------|----------:|----------:|
 | 3-turn conversation with topic changes | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
+| Adversarial: all three branches in one summary | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
+| Adversarial: food preference (USER) vs list-length rule (DIRECTIVES) | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | Agent calls webSearch for info queries | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | Agent chains search → fetch for details | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | Agent uses memory + nutrition data | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
-| Assistant checks memory before asking about interests | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
-| Assistant does not deny having long-term memory | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | Bad: deflection without attempting answer | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | Bad: empty acknowledgment | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | Bad: generic greeting ignores query | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
-| calorie budget \u2192 fetchMeals | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
+| DIRECTIVES: tone, length, forbidden phrases, address form | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | Diet changed from bulking to cutting | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | Diet changed from bulking to cutting-gemma4:e2b | ⏭️ SKIPPED | 🔸 1/1 XFAIL |
 | Diet changed from bulking to cutting-gpt-oss:20b | ⏭️ SKIPPED | ❌ 0/1 (0%) |
-| dietary check \u2192 fetchMeals | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | Enrichment results appear in system message | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | Extraction with explicit quantities | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
-| find the invoice PDF on my computer | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | Follow-up references previous turn context | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
-| food decision \u2192 fetchMeals | 🔸 1/1 XFAIL | 🔸 1/1 XFAIL |
 | Good: brief but informative | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | Good: complete weekly forecast | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
-| Graph-enriched facts surface in the reply, no denial | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
-| Greeting: hello | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
-| Greeting: ni hao (Chinese) | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | Handles ambiguous portion descriptions | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
-| Instruction: be more brief | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
-| Instruction: use Celsius | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
-| jacket \u2192 getWeather | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | LLM uses enrichment-surfaced interests for personalised search | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
+| Live greeting: hello | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
+| Live greeting: ni hao (Chinese) | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
+| Live instruction: be more brief | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
+| Live instruction: use Celsius | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
+| Live unknown entity: Piranesi (book) | 🔸 1/1 XFAIL | ✅ 1/1 (100%) |
+| Live unknown entity: Possessor (film) | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
+| Live unknown entity: have-you-heard-of (Piranesi) | 🔸 1/1 XFAIL | ✅ 1/1 (100%) |
+| Live unknown entity: permission-framed (Possessor) | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
+| Live weather query with real LLM | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
+| Live: LLM checks memory before asking about interests | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
+| Live: assistant does not deny having long-term memory | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
+| Live: graph-enriched facts surface in reply, no denial | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
+| Live: weather query triggers tools | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | Location context flows to search queries | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
-| location weather query selects getWeather and few others | ✅ 1/1 (100%) | ❌ 0/1 (0%) |
-| log that I just ate a banana | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
-| LogMealTool stores meals with macros | ❌ 0/1 (0%) | ✅ 1/1 (100%) |
-| meal logging selects logMeal and few others | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
-| meal recall (colloquial) \u2192 fetchMeals | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
-| meal recall selects fetchMeals and few others | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
+| LogMealTool stores meals with macros | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | Memory enrichment: personalized news | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | Memory enrichment: time-based recall | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | Memory enrichment: topic recall | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | No deflection: tech news | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
-| No deflection: time query | ❌ 0/1 (0%) | ✅ 1/1 (100%) |
+| No deflection: time query | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | No deflection: tomorrow weather | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | No deflection: weekly rain forecast | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | Novel knowledge: local business details and user location | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
@@ -79,64 +78,94 @@
 | Nutrition: oatmeal with banana | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | Office days changed from Mon/Wed to Mon/Thu | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | Office days changed from Mon/Wed to Mon/Thu-gemma4:e2b | ⏭️ SKIPPED | 🔸 1/1 XFAIL |
-| Office days changed from Mon/Wed to Mon/Thu-gpt-oss:20b | ⏭️ SKIPPED | ✅ 1/1 (100%) |
+| Office days changed from Mon/Wed to Mon/Thu-gpt-oss:20b | ⏭️ SKIPPED | ❌ 0/1 (0%) |
 | Reframing: life events framed as facts with temporal context | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | Reframing: requests become knowledge, not interaction descriptions | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
-| Reject: assistant self-references (recommendations are not knowledge) | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
-| Reject: stale temporal snapshots (weather, time of day) | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
-| research \u2192 webSearch + fetchWebPage | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
+| Reject: assistant self-references (recommendations are not knowledge) | ✅ 1/1 (100%) | ❌ 0/1 (0%) |
+| Reject: stale temporal snapshots (weather, time of day) | ✅ 1/1 (100%) | ❌ 0/1 (0%) |
 | Returns NONE for non-food inputs | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | Returns valid JSON with all required fields | ❌ 0/1 (0%) | ✅ 1/1 (100%) |
+| Simple meal baseline (2 boiled eggs) | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
+| Tool retry: explicit tool mention | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
+| Tool retry: vague go ahead | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
+| Tool retry: vague just try | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
+| Topic switch: search → weather uses getWeather | ❌ 0/1 (0%) | ✅ 1/1 (100%) |
+| Topic switch: weather → store hours uses webSearch | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
+| USER: identity, location, pets, diet, job | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
+| WORLD: local business details, film attribution | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
+| calorie budget \u2192 fetchMeals | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
+| cold-memory-short-query-how's the weather | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
+| cold-memory-week-forecast-what's the weather this week | ❌ 0/1 (0%) | ✅ 1/1 (100%) |
+| dietary check \u2192 fetchMeals | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
+| explicit-recall-then-search | ✅ 1/1 (100%) | ❌ 0/1 (0%) |
+| find the invoice PDF on my computer | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
+| food decision \u2192 fetchMeals | 🔸 1/1 XFAIL | 🔸 1/1 XFAIL |
+| jacket \u2192 getWeather | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
+| location weather query selects getWeather and few others | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
+| log that I just ate a banana | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
+| meal logging selects logMeal and few others | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
+| meal recall (colloquial) \u2192 fetchMeals | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
+| meal recall selects fetchMeals and few others | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
+| news-interesting-for-me | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
+| news-of-interest-to-me | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
+| news-that-would-interest-me | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
+| recommend a book I'd like | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
+| research \u2192 webSearch + fetchWebPage | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | run forecast \u2192 getWeather | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | search the web for flight deals | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
-| Simple meal baseline (2 boiled eggs) | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
+| suggest something I'd enjoy watching ton | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | take a screenshot | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
+| tell me some news that might interest me | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | test_active_hot_window_follow_up_accepted | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | test_casual_statement_without_wake_word_rejected | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
-| test_chained_research_possessor_director | ❌ 0/1 (0%) | ✅ 1/1 (100%) |
+| test_chained_research_possessor_director | ✅ 1/1 (100%) | ❌ 0/1 (0%) |
 | test_correction_loop_accepts_single_or_retry | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | test_cross_turn_pronoun_resolution | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | test_date_query_with_date_in_context_returns_none | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
-| test_digested_tool_result_produces_grounded_reply | 🔸 1/1 XFAIL | ✅ 1/1 (100%) |
+| test_digested_tool_result_produces_grounded_reply | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
+| test_director_then_filmography_requires_two_searches | ❌ 0/1 (0%) | ✅ 1/1 (100%) |
 | test_enrichment_skips_questions_answered_by_context | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
-| test_escape_hatch_then_follow_up_action | ❌ 0/1 (0%) | ❌ 0/1 (0%) |
-| test_first_turn_calls_web_search_not_clarification | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
+| test_escape_hatch_then_follow_up_action | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
+| test_evaluator_emits_structured_tool_call_for_obvious_search | ✅ 1/1 (100%) | 🔸 1/1 XFAIL |
+| test_first_turn_calls_web_search_not_clarification | 🔸 1/1 XFAIL | ✅ 1/1 (100%) |
 | test_follow_up_after_correction_calls_web_search | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | test_follow_up_resolves_pronoun_in_search_query | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | test_followup_naming_place_routes_to_getWeather | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | test_honest_block_when_all_providers_fail | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
+| test_hot_window_query_is_directed_and_non_empty | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | test_identity_query_does_not_trigger_recommendation_engagement_rule | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | test_identity_query_surfaces_multiple_user_facts_when_present | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | test_identity_query_surfaces_user_stated_fact_over_past_qa | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | test_identity_query_with_only_past_qa_returns_none_or_no_false_facts | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | test_judge_echo_claim_overridden_in_hot_window | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | test_judge_empty_conversation_returns_empty | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
-| test_judge_mixed_summary_filters_noise | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
-| test_links_only_payload_produces_honest_cant_read_reply | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
+| test_judge_mixed_summary_filters_noise | ❌ 0/1 (0%) | ❌ 0/1 (0%) |
+| test_links_only_payload_produces_honest_cant_read_reply | 🔸 1/1 XFAIL | ✅ 1/1 (100%) |
 | test_location_query_with_location_in_context_returns_none | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | test_location_query_with_partial_hint_still_routes_sensibly | 🔸 1/1 XFAIL | ✅ 1/1 (100%) |
-| test_max_turn_triggers_digest | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
-| test_navigate_prose_gets_nudged_into_tool_call | ❌ 0/1 (0%) | ❌ 0/1 (0%) |
+| test_max_turn_triggers_digest | ❌ 0/1 (0%) | ❌ 0/1 (0%) |
+| test_navigate_prose_gets_nudged_into_tool_call | 🔸 1/1 XFAIL | ✅ 1/1 (100%) |
 | test_no_email_tool_declines_honestly | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | test_no_hint_at_all_still_routes_sensibly | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | test_no_wake_word_rejected_despite_judge | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | test_nudge_cap_stops_loop | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | test_omits_deflection_narration_for_unknown_entity | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
-| test_omits_deflection_when_topic_never_resolved | 🔸 1/1 XFAIL | 🔸 1/1 XFAIL |
-| test_open_ended_prompt_grounds_in_graph_context_live | ✅ 1/1 (100%) | ❌ 0/1 (0%) |
+| test_omits_deflection_when_topic_never_resolved | 🔸 1/1 XFAIL | ✅ 1/1 (100%) |
+| test_open_ended_prompt_grounds_in_graph_context_live | ❌ 0/1 (0%) | ❌ 0/1 (0%) |
 | test_parallel_comparison_paris_vs_london | ❌ 0/1 (0%) | ✅ 1/1 (100%) |
 | test_preserves_legitimate_user_preferences | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
-| test_raw_text_preserved_in_hot_window | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | test_realistic_web_search_payload_is_not_deflected_to_links | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | test_recommendation_query_still_surfaces_engagement_when_user_facts_present | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | test_restaurant_recommendation_surfaces_past_cuisine_interest | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
-| test_single_weather_call_terminates | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
+| test_single_weather_call_terminates | ✅ 1/1 (100%) | ❌ 0/1 (0%) |
 | test_speech_long_after_tts_requires_wake_word | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | test_stop_during_tts_interrupts_immediately | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | test_time_query_with_time_in_context_returns_none | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
-| test_toolsearchtool_widens_then_navigate | ❌ 0/1 (0%) | ❌ 0/1 (0%) |
+| test_tool_calls_literal_not_surfaced_after_web_search | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
+| test_toolsearchtool_widens_then_navigate | 🔸 1/1 XFAIL | 🔸 1/1 XFAIL |
 | test_tts_echo_segments_skipped_user_query_extracted | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | test_turn1_possessor_then_turn2_weather | 🔸 1/1 XFAIL | ✅ 1/1 (100%) |
+| test_two_turn_celebrity_flow | 🔸 1/1 XFAIL | ❌ 0/1 (0%) |
 | test_unknown_entity_with_poisoned_diary_still_triggers_web_search_live | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | test_unrelated_domain_still_returns_none | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | test_unrelated_topics_are_not_welded_into_one_clause | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
@@ -145,26 +174,20 @@
 | test_wake_word_query_after_echo_segments | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | test_wake_word_query_uses_judge_extraction | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | test_watch_recommendation_surfaces_recently_discussed_films | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
-| test_weather_query_calls_tool_without_asking_for_location | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | test_weather_query_still_picks_getWeather | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
+| test_wikipedia_payload_produces_grounded_reply | 🔸 1/1 XFAIL | ✅ 1/1 (100%) |
 | test_wikipedia_rescues_when_ddg_blocks | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
-| Tool retry: explicit tool mention | 🔸 1/1 XFAIL | ✅ 1/1 (100%) |
-| Tool retry: vague go ahead | 🔸 1/1 XFAIL | ✅ 1/1 (100%) |
-| Tool retry: vague just try | 🔸 1/1 XFAIL | ✅ 1/1 (100%) |
-| Topic switch: search → weather uses getWeather | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
-| Topic switch: weather → store hours uses webSearch | ❌ 0/1 (0%) | ✅ 1/1 (100%) |
-| Unknown entity: have-you-heard-of (Piranesi) | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
-| Unknown entity: permission-framed (Possessor) | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
-| Unknown entity: Piranesi (book) | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
-| Unknown entity: Possessor (film) | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
+| warm-memory-short-query-how's the weather | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | weather + meals | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
-| Weather query is answered with current conditions | ❌ 0/1 (0%) | ✅ 1/1 (100%) |
 | weather query selects getWeather and few others | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
-| Weather query still triggers tools after a greeting | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | web search query selects webSearch and few others | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | weekly weather keeps getWeather | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
+| what is the capital of France | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
+| what should I cook for dinner | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
+| what's 2 plus 2 | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | what's on my screen right now? | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
 | what's the weather like? | ✅ 1/1 (100%) | ✅ 1/1 (100%) |
+| who is Britney Spears | ❌ 0/1 (0%) | ✅ 1/1 (100%) |
 
 ---
 
@@ -186,7 +209,7 @@
 | cross_segment_answer_that_with_noise | 1/1 (100%) | ✅ |
 | cross_segment_answered_that_whisper_variant | 1/1 (100%) | ✅ |
 | cross_segment_dinosaur_opinion | 1/1 (100%) | ✅ |
-| cross_segment_go_ahead_and_answer | 0/1 (0%) | ❌ |
+| cross_segment_go_ahead_and_answer | 1/1 (100%) | ✅ |
 | cross_segment_hot_window_followup | 1/1 (100%) | ✅ |
 | cross_segment_imperative_superseded_by_new_question | 1/1 (100%) | ✅ |
 | echo_plus_followup_extracted | 1/1 (100%) | ✅ |
@@ -195,7 +218,7 @@
 | hot_window_simple_followup | 1/1 (100%) | ✅ |
 | mentioned_in_narrative_past_tense | 1/1 (100%) | ✅ |
 | multi_person_vague_reference | 1/1 (100%) | ✅ |
-| multi_person_weather_discussion | 0/1 (0%) | ❌ |
+| multi_person_weather_discussion | 1/1 (100%) | ✅ |
 | multiple_echoes_then_interrupt | 1/1 (100%) | ✅ |
 | no_wake_word_casual_speech | 1/1 (100%) | ✅ |
 | no_wake_word_in_buffer | 1/1 (100%) | ✅ |
@@ -215,6 +238,9 @@
 | wake_word_open_imperative_surprise_me | 1/1 (100%) | ✅ |
 | wake_word_open_imperative_tell_me_a_joke | 1/1 (100%) | ✅ |
 | wake_word_open_imperative_tell_me_anything | 1/1 (100%) | ✅ |
+| wake_word_share_statement_burger | 1/1 (100%) | ✅ |
+| wake_word_share_statement_feeling | 1/1 (100%) | ✅ |
+| wake_word_share_statement_trailing | 1/1 (100%) | ✅ |
 | wake_word_simple_question | 1/1 (100%) | ✅ |
 | wake_word_statement_remember | 1/1 (100%) | ✅ |
 | wake_word_trailing_after_named_entity | 1/1 (100%) | ✅ |

--- a/docs/llm_contexts.md
+++ b/docs/llm_contexts.md
@@ -78,7 +78,7 @@ Every distinct LLM call in Jarvis, what feeds it, what consumes it, and how it i
 ## 7. Tool Router (pre-loop tool selection)
 
 - **File**: [src/jarvis/tools/selection.py](src/jarvis/tools/selection.py) — `select_tools_with_llm()` (~line 331).
-- **Trigger**: once per reply before the loop. Always runs — the router is the authoritative tool picker. When the pre-flight planner (#12) referenced tools, those names are unioned into the router's allow-list but never replace it; small models tend to default to `webSearch` where a dedicated tool like `getWeather` should win, and the router is tuned for that classification. `tool_selection_strategy == "llm"` is the default; other strategies (`all`, `keyword`, `embedding`) also run here.
+- **Trigger**: once per reply, **at the very front of the flow before the planner (#12)**. Always runs — the router is the authoritative tool picker, and its narrowed catalogue is what the planner sees. When the planner later references tools, those names are unioned into the router's allow-list but never replace it; small models tend to default to `webSearch` where a dedicated tool like `getWeather` should win, and the router is tuned for that classification. `tool_selection_strategy == "llm"` is the default; other strategies (`all`, `keyword`, `embedding`) also run here.
 - **Model / gating**: `resolve_tool_router_model(cfg)` chain — `tool_router_model → intent_judge_model → ollama_chat_model`.
 - **Inputs**: user query, tool catalogue (builtin + MCP with descriptions), optional narrow-down hint.
 - **System prompt**: inline (~lines 260-315). Teaches pick up-to-5 tools or `none`.
@@ -125,9 +125,9 @@ Every distinct LLM call in Jarvis, what feeds it, what consumes it, and how it i
 ## 12. Task-list Planner (pre-flight decomposition, gates the whole turn)
 
 - **File**: [src/jarvis/reply/planner.py](src/jarvis/reply/planner.py) — `plan_query()`.
-- **Trigger**: once per reply, **at the very front of the reply flow** (before memory search, before tool routing). Skipped when `cfg.planner_enabled = False`, when the query is shorter than `MIN_QUERY_CHARS` (4), or when no model / base URL is available.
+- **Trigger**: once per reply, **after the tool router and before memory search**. Skipped when `cfg.planner_enabled = False`, when the query is shorter than `MIN_QUERY_CHARS` (4), or when no model / base URL is available.
 - **Model / gating**: resolution chain `planner_model (override) → ollama_chat_model`. The planner tracks the chat model so upgrading the chat model (via setup wizard or config) automatically upgrades plan quality.
-- **Inputs**: user query, dialogue context, full builtin + MCP tool catalogue (names + one-line descriptions). **No** memory context — the planner decides *whether* memory is needed.
+- **Inputs**: user query, dialogue context, **router-narrowed** tool catalogue (names + one-line descriptions) — not the full 30+ list. **No** memory context — the planner decides *whether* memory is needed.
 - **System prompt**: `_PROMPT_TEMPLATE` in `planner.py`. Teaches the `searchMemory topic='...'` directive for prior-conversation lookups, short imperative tool steps, angle-bracket entity placeholders, final synthesis step, same-language output, no numbering.
 - **Output**: list of plan steps (max `MAX_STEPS` = 5). Gates memory enrichment (#3 / #4) and augments the tool router (#7 — planner's picks are unioned in, not replacing). Single-step `["Reply to the user."]` plans are the planner's positive "no memory, no tools" signal. An empty list is fail-open — the engine reverts to running #3 unconditionally. Consumed further by the engine to build the `ACTION PLAN:` system-message block and drive the direct-exec loop (#13) for small models.
 - **Limits**: `planner_timeout_sec` (6s). Fail-open → `[]`.
@@ -191,10 +191,11 @@ Driven by `detect_model_size(model_name) → SMALL (≤7B) | LARGE (8B+)`:
 ```
 user input
   └─▶ [2] Intent Judge            (voice only, SMALL)
-        └─▶ [12] Planner (pre-flight — gates the rest of the turn)
-              ├─ plan requests searchMemory  → [3] Enrichment extract → [4] Memory digest (optional)
-              ├─ plan empty (fail-open)      → [3] Enrichment extract → [4] Memory digest + [7] Tool router
-              └─ plan reply-only             → skip #3, #4, and #7 entirely
+        └─▶ [7] Tool router (narrows catalogue for the planner)
+              └─▶ [12] Planner (gates memory; advisory for the router allow-list)
+                    ├─ plan requests searchMemory  → [3] Enrichment extract → [4] Memory digest (optional)
+                    ├─ plan empty (fail-open)      → [3] Enrichment extract → [4] Memory digest
+                    └─ plan reply-only             → skip #3 and #4 entirely
                     └─▶ AGENTIC LOOP  (≤ agentic_max_turns)
                                       ├─ [13] Plan step resolver (SMALL, direct-exec)
                                       ├─ [1] Main chat turn

--- a/evals/conftest.py
+++ b/evals/conftest.py
@@ -57,7 +57,7 @@ CLASS_DESCRIPTIONS = {
     "TestToolUsage": "Validates tool selection and argument quality",
     "TestMultiStepReasoning": "Complex scenarios requiring tool chaining and synthesis",
     "TestMemoryEnrichment": "Tests automatic memory enrichment keyword extraction",
-    "TestLiveEndToEnd": "Live tests with real LLM inference",
+    "TestLiveEndToEnd": "End-to-end tests against real LLM inference",
     "TestNutritionExtraction": "Tests LLM nutrition extraction accuracy for meal logging",
     "TestNutritionToolIntegration": "Tests full meal logging tool with macro extraction",
     "TestNutritionModelComparison": "Baseline tests for comparing nutrition extraction across models",
@@ -79,7 +79,7 @@ CLASS_DESCRIPTIONS = {
     "TestTopicSwitching": "Tests correct tool selection when conversation topic changes",
     "TestFollowUpContext": "Tests context retention for follow-up questions",
     "TestMultiTurnExtended": "Extended multi-turn scenarios with longer conversations",
-    "TestGreetingNoToolsLive": "Live tests that greetings don't trigger tool calls",
+    "TestGreetingNoToolsLive": "Tests that greetings don't trigger tool calls",
     "TestHelpfulness": "Tests that agent uses tools proactively instead of deflecting",
     "TestDiaryRecencyOrder": "Tests that diary search returns newer entries before older ones",
     "TestGraphRecencySuperseding": "Tests that graph handles contradicting facts with date context",
@@ -128,6 +128,17 @@ TEST_DESCRIPTIONS = {
     "test_tool_retry_after_failure_live": "Assistant retries a tool after the first attempt fails",
     "test_graph_knowledge_surfaced_in_reply_live": "Graph-enriched facts surface in the reply, no denial",
     "test_does_not_deny_long_term_memory_live": "Assistant does not deny having long-term memory",
+    # Multi-step entity / complex flow tests
+    "test_chained_research_possessor_director": "Chained research: who directed Possessor and what else have they made",
+    "test_parallel_comparison_paris_vs_london": "Parallel weather lookup: compare Paris and London",
+    "test_director_then_filmography_requires_two_searches": "Director-then-filmography needs two searches",
+    "test_two_turn_celebrity_flow": "Two-turn celebrity flow: identity then pronoun follow-up",
+    "test_single_weather_call_terminates": "Single weather query ends after one tool call",
+    "test_max_turn_triggers_digest": "Max-turn cap delivers a digest reply, never silence",
+    # Knowledge extraction
+    "test_judge_mixed_summary_filters_noise": "Mixed summary: keep novel facts, drop stale weather/recommendations",
+    "test_judge_empty_conversation_returns_empty": "Trivial conversations produce no extracted facts",
+    "test_open_ended_prompt_grounds_in_graph_context_live": "Open-ended prompt grounds in stored knowledge",
 }
 
 
@@ -178,6 +189,47 @@ def _extract_judge_notes(stdout: Optional[str]) -> Optional[Dict[str, str]]:
     return notes if notes else None
 
 
+def _humanise_test_name(test_name: str) -> str:
+    """Turn ``test_some_thing_does_X`` into ``Some thing does X``.
+
+    Last-resort fallback used when a test has no entry in TEST_DESCRIPTIONS
+    and no parametrize id. Keeps the report readable for non-technical
+    readers — they shouldn't have to parse Python identifiers.
+    """
+    name = test_name
+    if name.startswith("test_"):
+        name = name[5:]
+    name = name.replace("_", " ").strip()
+    if not name:
+        return test_name
+    return name[0].upper() + name[1:]
+
+
+def _strip_redundant_prefix(label: str) -> str:
+    """Drop noisy prefixes from human-readable case labels.
+
+    Every eval is live by design (the suite drives a real model), so the
+    ``Live:`` / ``Live `` prefix is uninformative. Same for trailing model
+    suffixes like ``-gpt-oss:20b`` that pytest cross-products into
+    parametrize ids — the Model column already shows that.
+    """
+    s = label.strip()
+    # Trailing "-<model>" suffix injected by pytest parametrize cross-product.
+    for suffix in ("-gpt-oss:20b", "-gemma4:e2b", "-gemma4:e4b"):
+        if s.endswith(suffix):
+            s = s[: -len(suffix)].rstrip()
+            break
+    # Leading "Live:" / "Live " prefix is redundant — the suite is live.
+    lower = s.lower()
+    for prefix in ("live: ", "live: ", "live "):
+        if lower.startswith(prefix):
+            s = s[len(prefix):].lstrip()
+            if s:
+                s = s[0].upper() + s[1:]
+            break
+    return s
+
+
 def _get_test_description(test_name: str, case_id: Optional[str]) -> str:
     """
     Get the description for a test case.
@@ -186,11 +238,14 @@ def _get_test_description(test_name: str, case_id: Optional[str]) -> str:
     For non-parametrized tests, use the TEST_DESCRIPTIONS lookup.
     """
     if case_id:
-        # Parametrized test: the ID is the description (defined in the test file)
-        return case_id
+        return _strip_redundant_prefix(case_id)
 
-    # Non-parametrized test: use lookup or fall back to test name
-    return TEST_DESCRIPTIONS.get(test_name, test_name)
+    raw = TEST_DESCRIPTIONS.get(test_name)
+    if raw is not None:
+        return _strip_redundant_prefix(raw)
+    # Last-resort: humanise the raw test name so the report doesn't expose
+    # Python identifiers to non-technical readers.
+    return _humanise_test_name(test_name)
 
 
 # =============================================================================

--- a/evals/test_evaluator_loop.py
+++ b/evals/test_evaluator_loop.py
@@ -399,9 +399,15 @@ class TestNudgeCapEnforcement:
 
 
 class TestMaxTurnDigestCaveat:
-    """Forcing the evaluator to always return 'continue' drives the loop to
-    exhaust agentic_max_turns. The max-turn digest path must fire and the
-    reply must remain non-empty (not a raw empty string)."""
+    """Behaviour: when the agentic loop exhausts ``agentic_max_turns``
+    without ever emitting a natural-language reply (a pathological pure-
+    tool-call loop), the engine must still deliver a non-empty reply by
+    running the digest backstop.
+
+    Evaluator-driven coverage was removed when the evaluator was retired
+    in favour of the planner. The behaviour the user cares about — "you
+    must never be left with an empty reply, even if the loop misbehaves"
+    — is asserted here without coupling to deprecated internals."""
 
     @pytest.mark.eval
     @requires_judge_llm
@@ -409,11 +415,9 @@ class TestMaxTurnDigestCaveat:
         self, mock_config, eval_db, eval_dialogue_memory
     ):
         from jarvis.reply.engine import run_reply_engine
-        from jarvis.reply.evaluator import EvaluatorResult
 
         _configure(mock_config)
         mock_config.agentic_max_turns = 3
-        mock_config.evaluator_nudge_max = 99  # defeat the cap for this test
         capture = ToolCallCapture()
 
         def _respond(name, args):
@@ -430,15 +434,29 @@ class TestMaxTurnDigestCaveat:
             digest_spy_calls.append(
                 {"user_query": user_query, "loop_messages_len": len(loop_messages)}
             )
-            # Short caveated reply — what the real digest pass would return.
-            return "(Heads up, I couldn't finish this one) Based on what I "\
-                   "gathered so far, I don't have a complete answer."
-
-        # Force evaluator to always ask for continuation.
-        def _always_continue(*_args, **_kwargs):
-            return EvaluatorResult(
-                terminal=False, nudge="please try a tool", reason="forced-continue"
+            return (
+                "(Heads up, I couldn't finish this one) Based on what I "
+                "gathered so far, I don't have a complete answer."
             )
+
+        # Force the chat model into an infinite tool-call loop: every turn
+        # returns a structured tool_call instead of natural-language content,
+        # so the loop never sees a terminal text reply and runs out of turns.
+        def _always_tool_call(*_args, **_kwargs):
+            return {
+                "message": {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "function": {
+                                "name": "getWeather",
+                                "arguments": {"location": "London"},
+                            }
+                        }
+                    ],
+                }
+            }
 
         with patch("jarvis.reply.engine.select_tools", side_effect=router), \
              patch("jarvis.reply.engine.run_tool_with_retries", side_effect=runner), \
@@ -446,7 +464,7 @@ class TestMaxTurnDigestCaveat:
                  "jarvis.reply.engine.get_location_context_with_timezone",
                  return_value=("Location: London, UK", None),
              ), \
-             patch("jarvis.reply.engine.evaluate_turn", side_effect=_always_continue), \
+             patch("jarvis.reply.engine.chat_with_messages", side_effect=_always_tool_call), \
              patch("jarvis.reply.engine.digest_loop_for_max_turns", side_effect=_spy_digest):
             reply = run_reply_engine(
                 db=eval_db, cfg=mock_config, tts=None,
@@ -460,8 +478,8 @@ class TestMaxTurnDigestCaveat:
         print(f"   reply: {(reply or '')[:240]}...")
 
         assert digest_spy_calls, (
-            "digest_loop_for_max_turns should have been called when the "
-            "evaluator kept saying continue until agentic_max_turns."
+            "digest_loop_for_max_turns must fire when the loop exhausts "
+            "agentic_max_turns without producing a text reply."
         )
         assert digest_spy_calls[0]["loop_messages_len"] > 0, (
             "Digest must receive the loop's accumulated messages, not an empty "

--- a/src/jarvis/reply/engine.py
+++ b/src/jarvis/reply/engine.py
@@ -748,16 +748,6 @@ def run_reply_engine(db: "Database", cfg, tts: Optional[Any],
     _all_builtin_names = list(BUILTIN_TOOLS.keys())
     _all_mcp_names = list(mcp_tools.keys())
     _full_catalog_names = _all_builtin_names + _all_mcp_names
-    _full_tools_schema = generate_tools_json_schema(_full_catalog_names, mcp_tools)
-    _planner_tool_catalog: list[tuple[str, str]] = []
-    for _schema in (_full_tools_schema or []):
-        _fn = _schema.get("function", {}) if isinstance(_schema, dict) else {}
-        if isinstance(_fn, dict):
-            _nm = _fn.get("name")
-            _desc = (_fn.get("description") or "").strip().splitlines()
-            _first = _desc[0] if _desc else ""
-            if _nm:
-                _planner_tool_catalog.append((str(_nm), _first[:120]))
 
     _dialogue_lines: list[str] = []
     for _m in (recent_messages or [])[-6:]:
@@ -766,6 +756,43 @@ def run_reply_engine(db: "Database", cfg, tts: Optional[Any],
         if _role in ("user", "assistant") and _content:
             _dialogue_lines.append(f"{_role}: {_content[:200]}")
     _dialogue_ctx = "\n".join(_dialogue_lines)
+
+    # Step 2a: Tool routing FIRST.
+    #
+    # The router runs before the planner so the planner sees a concrete,
+    # narrowed tool catalogue rather than the full 30+ list. Two gains:
+    # small planners stop paraphrasing tool names ("get the weather")
+    # because the relevant ones are already named for them; and the
+    # narrowed list keeps the planner's prompt tight, which matters for
+    # gemma-class chat models that lose accuracy fast as the prompt grows.
+    context_hint = _build_enrichment_context_hint(cfg, recent_messages)
+    try:
+        strategy = ToolSelectionStrategy(getattr(cfg, "tool_selection_strategy", "llm"))
+    except ValueError:
+        strategy = ToolSelectionStrategy.LLM
+    routed_tools = select_tools(
+        query=redacted,
+        builtin_tools=BUILTIN_TOOLS,
+        mcp_tools=mcp_tools,
+        strategy=strategy,
+        llm_base_url=cfg.ollama_base_url,
+        llm_model=resolve_tool_router_model(cfg),
+        llm_timeout_sec=float(getattr(cfg, "llm_tools_timeout_sec", 8.0)),
+        embed_model=getattr(cfg, "ollama_embed_model", "nomic-embed-text"),
+        embed_timeout_sec=float(getattr(cfg, "llm_embed_timeout_sec", 10.0)),
+        context_hint=context_hint,
+    )
+    _selection_source = strategy.value
+    _planner_schema = generate_tools_json_schema(routed_tools, mcp_tools)
+    _planner_tool_catalog: list[tuple[str, str]] = []
+    for _schema in (_planner_schema or []):
+        _fn = _schema.get("function", {}) if isinstance(_schema, dict) else {}
+        if isinstance(_fn, dict):
+            _nm = _fn.get("name")
+            _desc = (_fn.get("description") or "").strip().splitlines()
+            _first = _desc[0] if _desc else ""
+            if _nm:
+                _planner_tool_catalog.append((str(_nm), _first[:120]))
 
     action_plan: list[str] = []
     try:
@@ -854,7 +881,6 @@ def run_reply_engine(db: "Database", cfg, tts: Optional[Any],
 
     questions: list[str] = []
 
-    context_hint = _build_enrichment_context_hint(cfg, recent_messages)
     search_params: dict = {}
 
     # Extract keywords and implicit questions only when the planner asked
@@ -1034,37 +1060,22 @@ def run_reply_engine(db: "Database", cfg, tts: Optional[Any],
 
     # Step 6: Tool allow-list for this turn.
     #
-    # The tool router (`select_tools`) is the authoritative picker. The
-    # planner's tool references are advisory — unioned into the allow-list
-    # so a tool the planner named but the router missed is still callable,
-    # but the router's picks are never dropped. Small models (gemma4:e2b)
+    # The router already ran at the very top of the flow (Step 2a) so the
+    # planner could see a narrowed catalogue. We reuse that selection here
+    # rather than re-running select_tools — one router LLM call per turn,
+    # not two. The planner's tool references are advisory: unioned into
+    # the allow-list when the plan named concrete tools the router missed,
+    # but never replacing the router's picks. Small models (gemma4:e2b)
     # tend to default to the most universal tool they know (typically
     # `webSearch`) when they should pick a specific one (`getWeather`,
     # `getTime`); the dedicated router is tuned for that classification
     # and consistently outperforms the planner at it. An earlier variant
-    # of this step let the planner REPLACE the router to save one LLM
-    # call; that was reverted when measurable tool-picking quality dropped.
+    # let the planner REPLACE the router to save one LLM call; that was
+    # reverted when measurable tool-picking quality dropped.
     _plan_under_specified = bool(action_plan) and plan_has_unresolved_tool_steps(
         action_plan, _full_catalog_names
     )
-    try:
-        strategy = ToolSelectionStrategy(getattr(cfg, "tool_selection_strategy", "llm"))
-    except ValueError:
-        strategy = ToolSelectionStrategy.LLM
-
-    allowed_tools = select_tools(
-        query=redacted,
-        builtin_tools=BUILTIN_TOOLS,
-        mcp_tools=mcp_tools,
-        strategy=strategy,
-        llm_base_url=cfg.ollama_base_url,
-        llm_model=resolve_tool_router_model(cfg),
-        llm_timeout_sec=float(getattr(cfg, "llm_tools_timeout_sec", 8.0)),
-        embed_model=getattr(cfg, "ollama_embed_model", "nomic-embed-text"),
-        embed_timeout_sec=float(getattr(cfg, "llm_embed_timeout_sec", 10.0)),
-        context_hint=context_hint,
-    )
-    _selection_source = strategy.value
+    allowed_tools = list(routed_tools)
     if action_plan and not _plan_under_specified:
         for _plan_name in tool_names_in_plan(action_plan, _full_catalog_names):
             if _plan_name not in allowed_tools:

--- a/src/jarvis/reply/engine.py
+++ b/src/jarvis/reply/engine.py
@@ -759,12 +759,12 @@ def run_reply_engine(db: "Database", cfg, tts: Optional[Any],
 
     # Step 2a: Tool routing FIRST.
     #
-    # The router runs before the planner so the planner sees a concrete,
-    # narrowed tool catalogue rather than the full 30+ list. Two gains:
-    # small planners stop paraphrasing tool names ("get the weather")
-    # because the relevant ones are already named for them; and the
-    # narrowed list keeps the planner's prompt tight, which matters for
-    # gemma-class chat models that lose accuracy fast as the prompt grows.
+    # The router runs before the planner so the planner sees concrete,
+    # narrowed tool names — not a 30+ catalogue it has to paraphrase. Two
+    # gains: small planners stop inventing tool names ("get the weather")
+    # because the relevant ones are already named for them; and tool steps
+    # come out concrete ("getWeather location='Paris'") so the direct-exec
+    # fast path parses without needing the resolver LLM round-trip.
     context_hint = _build_enrichment_context_hint(cfg, recent_messages)
     try:
         strategy = ToolSelectionStrategy(getattr(cfg, "tool_selection_strategy", "llm"))
@@ -782,7 +782,6 @@ def run_reply_engine(db: "Database", cfg, tts: Optional[Any],
         embed_timeout_sec=float(getattr(cfg, "llm_embed_timeout_sec", 10.0)),
         context_hint=context_hint,
     )
-    _selection_source = strategy.value
     _planner_schema = generate_tools_json_schema(routed_tools, mcp_tools)
     _planner_tool_catalog: list[tuple[str, str]] = []
     for _schema in (_planner_schema or []):
@@ -1060,22 +1059,16 @@ def run_reply_engine(db: "Database", cfg, tts: Optional[Any],
 
     # Step 6: Tool allow-list for this turn.
     #
-    # The router already ran at the very top of the flow (Step 2a) so the
-    # planner could see a narrowed catalogue. We reuse that selection here
-    # rather than re-running select_tools — one router LLM call per turn,
-    # not two. The planner's tool references are advisory: unioned into
-    # the allow-list when the plan named concrete tools the router missed,
-    # but never replacing the router's picks. Small models (gemma4:e2b)
-    # tend to default to the most universal tool they know (typically
-    # `webSearch`) when they should pick a specific one (`getWeather`,
-    # `getTime`); the dedicated router is tuned for that classification
-    # and consistently outperforms the planner at it. An earlier variant
-    # let the planner REPLACE the router to save one LLM call; that was
-    # reverted when measurable tool-picking quality dropped.
+    # The router already ran upstream (before the planner) so the planner's
+    # tool steps reference concrete router-chosen names. We start from the
+    # router's picks and union in any names the planner referenced — these
+    # should already be a subset, but we keep the union as a safety net in
+    # case the planner paraphrased and `tool_names_in_plan` mapped one back.
     _plan_under_specified = bool(action_plan) and plan_has_unresolved_tool_steps(
         action_plan, _full_catalog_names
     )
     allowed_tools = list(routed_tools)
+    _selection_source = strategy.value
     if action_plan and not _plan_under_specified:
         for _plan_name in tool_names_in_plan(action_plan, _full_catalog_names):
             if _plan_name not in allowed_tools:

--- a/src/jarvis/reply/planner.spec.md
+++ b/src/jarvis/reply/planner.spec.md
@@ -9,25 +9,25 @@ entirely and confabulate from training. The planner fixes this by
 running a single cheap classification-shaped LLM pass **at the very
 front of the reply flow** that emits a short ordered list of sub-tasks.
 
-The planner runs **before** memory search and tool routing, and it
-**gates** both: every preparatory step the reply flow might take
-(pulling past-conversation memory, narrowing the tool allow-list,
-direct-executing tool calls) is decided by the plan.
+The planner runs **after the tool router** and **before memory
+search**. The router narrows the catalogue first so the planner's
+tool steps reference concrete chosen names; the planner then **gates
+memory enrichment** and **drives direct execution** for small models.
 
 The engine uses the plan for three things:
 1. **Gate memory enrichment** — the planner emits an explicit
    `searchMemory topic='<topic>'` directive on queries that need past
    user context; we skip the keyword-extraction LLM call, the diary
    / graph lookup, and the memory-digest LLM call otherwise.
-2. **Augment the tool router** — the tool names the planner references
-   are unioned into the router-selected allow-list, so a tool the
-   planner named but the router missed is still callable. The router
-   (`select_tools`) remains the authoritative picker; an earlier
-   variant let the planner replace it to save one LLM call, but
-   measurable tool-picking quality dropped (gemma4:e2b class models
-   default to the most universal tool they know — typically
-   `webSearch` — when they should pick a dedicated one like
-   `getWeather`). The dedicated router is tuned for that classification.
+2. **Confirm the tool allow-list** — the router's picks are
+   authoritative; the tool names the planner references are unioned
+   in as a safety net. Feeding the planner the narrowed catalogue
+   (instead of the full 30+ list) stops small planners from
+   paraphrasing ("get the weather") and from defaulting to
+   `webSearch` when a more specific tool exists. An earlier variant
+   let the planner replace the router to save one LLM call, but
+   measurable tool-picking quality dropped — the dedicated router
+   stays the authoritative picker.
 3. **Drive direct execution** for small models, as before — each
    planned step is resolved to a concrete tool call without
    round-tripping the chat model for intermediate turns.
@@ -41,12 +41,13 @@ integration in `src/jarvis/reply/engine.py`.
 
 ### When the planner runs
 
-- **First**, immediately after the dialogue context is assembled and
-  MCP tools are loaded. Memory search and tool routing run *after* the
-  planner so that both can be gated on its output.
-- The planner sees the full builtin + MCP tool catalog (name +
-  one-line description). It does not see memory content — it decides
-  whether memory is needed, via the `searchMemory` directive.
+- After the dialogue context is assembled, MCP tools are loaded, and
+  the tool router has produced a narrowed catalogue. Memory search
+  runs *after* the planner so it can be gated on its output.
+- The planner sees the **router-narrowed** tool catalogue (name +
+  one-line description), not the full 30+ list. It does not see memory
+  content — it decides whether memory is needed, via the
+  `searchMemory` directive.
 - Only when the query is at least `MIN_QUERY_CHARS` long (default 4).
   Pure noise like "hi" / "ok" still short-circuits.
 - Only when `cfg.planner_enabled` is True (default).

--- a/src/jarvis/reply/planner.spec.md
+++ b/src/jarvis/reply/planner.spec.md
@@ -9,10 +9,10 @@ entirely and confabulate from training. The planner fixes this by
 running a single cheap classification-shaped LLM pass **at the very
 front of the reply flow** that emits a short ordered list of sub-tasks.
 
-The planner runs **after the tool router** and **before memory
-search**. The router narrows the catalogue first so the planner's
-tool steps reference concrete chosen names; the planner then **gates
-memory enrichment** and **drives direct execution** for small models.
+The planner runs **after the tool router** and **before memory search**.
+The router narrows the catalogue first so the planner's tool steps reference
+concrete chosen names; the planner then **gates memory enrichment** and
+**drives direct execution** for small models.
 
 The engine uses the plan for three things:
 1. **Gate memory enrichment** — the planner emits an explicit
@@ -24,10 +24,7 @@ The engine uses the plan for three things:
    in as a safety net. Feeding the planner the narrowed catalogue
    (instead of the full 30+ list) stops small planners from
    paraphrasing ("get the weather") and from defaulting to
-   `webSearch` when a more specific tool exists. An earlier variant
-   let the planner replace the router to save one LLM call, but
-   measurable tool-picking quality dropped — the dedicated router
-   stays the authoritative picker.
+   `webSearch` when a more specific tool exists.
 3. **Drive direct execution** for small models, as before — each
    planned step is resolved to a concrete tool call without
    round-tripping the chat model for intermediate turns.

--- a/tests/test_engine_tool_search_loop.py
+++ b/tests/test_engine_tool_search_loop.py
@@ -156,8 +156,14 @@ def test_initial_allowlist_always_includes_toolsearchtool(
             )
 
     assert captured_allow_lists, "generate_tools_json_schema was never called"
-    assert "toolSearchTool" in captured_allow_lists[0], (
-        f"toolSearchTool missing from initial allow-list: {captured_allow_lists[0]}"
+    # The engine now runs the router before the planner, which builds an
+    # auxiliary schema for the planner's tool catalogue (router-narrowed,
+    # no escape hatch) before the final chat-model schema. The escape hatch
+    # only joins in the chat-model allow-list. Assert it appears somewhere
+    # in the captured calls — implementations are free to reuse the same
+    # schema generator at multiple call sites.
+    assert any("toolSearchTool" in al for al in captured_allow_lists), (
+        f"toolSearchTool missing from any allow-list: {captured_allow_lists}"
     )
 
 


### PR DESCRIPTION
## Summary
- The tool router (\`select_tools\`) now runs at the very front of the reply flow, before the planner, so the planner sees the **router-narrowed** tool catalogue instead of the full 30+ list. Small planners stop paraphrasing tool names ("get the weather") and stop defaulting to \`webSearch\` when a dedicated tool exists.
- The chat-model allow-list reuses the same \`routed_tools\` selection — one router LLM call per turn instead of two. Planner-referenced tools still get unioned in as a safety net.
- \`planner.spec.md\` and \`docs/llm_contexts.md\` updated to reflect the new ordering (router → planner → memory → loop).

## Test plan
- [x] \`pytest tests/test_engine_planner_integration.py tests/test_engine_tool_search_loop.py tests/test_planner.py\` (82 passed)
- [ ] Live eval suite rerun (separate task — affects \`EVALS.md\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)