### PR TITLE
fix(desktop_app): stop setup wizard popping every launch on macOS

### DIFF
--- a/src/desktop_app/app.py
+++ b/src/desktop_app/app.py
@@ -2302,7 +2302,8 @@ def main() -> int:
             from desktop_app.setup_wizard import (
                 should_show_setup_wizard, SetupWizard,
                 check_ollama_server, check_ollama_cli,
-                get_required_models, check_installed_models
+                get_required_models, check_installed_models,
+                resolve_ollama_path,
             )
             print("  Setup wizard module loaded successfully", flush=True)
         except Exception as e:
@@ -2498,7 +2499,7 @@ def main() -> int:
         app.processEvents()
 
         required_models = get_required_models()
-        installed_models = check_installed_models()
+        installed_models = check_installed_models(resolve_ollama_path())
 
         # Normalize model names for comparison (remove :latest suffix)
         def normalize_model(name: str) -> str:

--- a/src/desktop_app/setup_wizard.py
+++ b/src/desktop_app/setup_wizard.py
@@ -216,21 +216,28 @@ def get_required_models() -> List[str]:
         return defaults
 
 
+def resolve_ollama_path() -> str:
+    """Resolve the ollama CLI path for subprocess invocation.
+
+    PATH first, then platform-specific install locations via check_ollama_cli,
+    then a literal "ollama" as last resort. Frozen .app launches on macOS get
+    a sanitised PATH that excludes /usr/local/bin and /opt/homebrew/bin, so
+    shutil.which alone is not enough.
+    """
+    path = shutil.which("ollama")
+    if path:
+        return path
+    _, resolved = check_ollama_cli()
+    return resolved or "ollama"
+
+
 def check_installed_models(ollama_path: Optional[str] = None) -> List[str]:
     """
     Get list of installed Ollama models.
     Returns list of model names.
     """
     if ollama_path is None:
-        # Resolve via PATH first, then fall back to platform-specific install
-        # locations. Frozen .app launches on macOS get a sanitised PATH that
-        # excludes /usr/local/bin and /opt/homebrew/bin, so shutil.which alone
-        # is not enough — without this fallback, the model check fails and the
-        # setup wizard pops on every launch.
-        ollama_path = shutil.which("ollama")
-        if not ollama_path:
-            _, resolved = check_ollama_cli()
-            ollama_path = resolved or "ollama"
+        ollama_path = resolve_ollama_path()
 
     try:
         # Hide console window on Windows

--- a/src/desktop_app/setup_wizard.py
+++ b/src/desktop_app/setup_wizard.py
@@ -222,7 +222,15 @@ def check_installed_models(ollama_path: Optional[str] = None) -> List[str]:
     Returns list of model names.
     """
     if ollama_path is None:
-        ollama_path = shutil.which("ollama") or "ollama"
+        # Resolve via PATH first, then fall back to platform-specific install
+        # locations. Frozen .app launches on macOS get a sanitised PATH that
+        # excludes /usr/local/bin and /opt/homebrew/bin, so shutil.which alone
+        # is not enough — without this fallback, the model check fails and the
+        # setup wizard pops on every launch.
+        ollama_path = shutil.which("ollama")
+        if not ollama_path:
+            _, resolved = check_ollama_cli()
+            ollama_path = resolved or "ollama"
 
     try:
         # Hide console window on Windows

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -15,6 +15,7 @@ from desktop_app.setup_wizard import (
     get_required_models,
     check_installed_models,
     check_ollama_status,
+    resolve_ollama_path,
     should_show_setup_wizard,
     OllamaStatus,
     MCPPage,
@@ -193,6 +194,30 @@ nomic-embed-text:latest    def456          274 MB    1 week ago
                     assert "llama2:7b" in models
                     args, _ = run.call_args
                     assert args[0][0] == "/usr/local/bin/ollama"
+
+
+class TestResolveOllamaPath:
+    """Tests for the ollama CLI path resolver."""
+
+    def test_prefers_path_lookup(self):
+        with patch("desktop_app.setup_wizard.shutil.which", return_value="/opt/homebrew/bin/ollama"):
+            assert resolve_ollama_path() == "/opt/homebrew/bin/ollama"
+
+    def test_falls_back_to_check_ollama_cli(self):
+        with patch("desktop_app.setup_wizard.shutil.which", return_value=None):
+            with patch(
+                "desktop_app.setup_wizard.check_ollama_cli",
+                return_value=(True, "/usr/local/bin/ollama"),
+            ):
+                assert resolve_ollama_path() == "/usr/local/bin/ollama"
+
+    def test_returns_literal_when_nothing_resolves(self):
+        with patch("desktop_app.setup_wizard.shutil.which", return_value=None):
+            with patch(
+                "desktop_app.setup_wizard.check_ollama_cli",
+                return_value=(False, None),
+            ):
+                assert resolve_ollama_path() == "ollama"
 
 
 class TestCheckOllamaStatus:

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -174,6 +174,26 @@ nomic-embed-text:latest    def456          274 MB    1 week ago
 
             assert models == []
 
+    def test_falls_back_to_check_ollama_cli_when_path_unset(self):
+        """When PATH does not contain ollama (e.g. frozen macOS .app launch),
+        falls back to check_ollama_cli() so the resolved binary is invoked
+        instead of plain "ollama" which would fail with FileNotFoundError."""
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "NAME    ID    SIZE    MODIFIED\nllama2:7b    abc    3.8 GB    1d\n"
+
+        with patch("desktop_app.setup_wizard.shutil.which", return_value=None):
+            with patch(
+                "desktop_app.setup_wizard.check_ollama_cli",
+                return_value=(True, "/usr/local/bin/ollama"),
+            ):
+                with patch("subprocess.run", return_value=mock_result) as run:
+                    models = check_installed_models()
+
+                    assert "llama2:7b" in models
+                    args, _ = run.call_args
+                    assert args[0][0] == "/usr/local/bin/ollama"
+
 
 class TestCheckOllamaStatus:
     """Tests for complete Ollama status check."""


### PR DESCRIPTION
## Summary

On macOS, the setup wizard opened on every launch even when Ollama, the server, and all required models were already installed. On Windows it correctly only appeared when something was actually missing.

## Root cause

When the app launches from Finder / a frozen `.app` bundle on macOS, the inherited PATH is sanitised to `/usr/bin:/bin:/usr/sbin:/sbin` and excludes the locations where Ollama actually lives (`/usr/local/bin`, `/opt/homebrew/bin`).

`should_show_setup_wizard()` itself was fine because it routes through `check_ollama_status()`, which discovers the CLI via `check_ollama_cli()` (with hardcoded macOS fallback paths) and passes that path into `check_installed_models()`.

The problem was the *secondary* model check in `app.py` after server start (`src/desktop_app/app.py:2501`). It calls `check_installed_models()` with no path, so internally `shutil.which("ollama")` returned `None` and it fell through to running plain `"ollama"`, which subprocess could not locate. The empty result made every required model look missing and the wizard popped.

Windows was unaffected because the Ollama installer adds itself to the user PATH.

## Fix

Make `check_installed_models()` resilient: when `shutil.which` fails, fall back to `check_ollama_cli()` so the existing platform-specific fallback paths are used. This fixes the bug at the source and also hardens any future caller.

## Test plan

- [x] New unit test `test_falls_back_to_check_ollama_cli_when_path_unset` in `tests/test_setup_wizard.py` — patches `shutil.which` to return None, verifies the resolved binary from `check_ollama_cli` is invoked.
- [x] Full `tests/test_setup_wizard.py` suite passes (58 tests).
- [ ] Manually launch the macOS `.app` with Ollama + required models installed and confirm the wizard no longer opens.