### PR TITLE
fix(web_search): Wikipedia fallback handles verbose queries via full-text search, with deadline plumbing

### DIFF
--- a/src/jarvis/tools/builtin/web_search.py
+++ b/src/jarvis/tools/builtin/web_search.py
@@ -362,20 +362,144 @@ def _language_script_mismatches_query(lang: str, query: str) -> bool:
     return ascii_letters / len(letters) >= 0.8
 
 
-def _wikipedia_summary(query: str, lang: str = "en"
-                      ) -> Optional[Tuple[str, str, str]]:
+# Per-request timeout for Wikipedia API calls. Smaller than the generic
+# `_FETCH_TIMEOUT_SEC` because the helper makes up to three sequential calls
+# (opensearch + optional fulltext + REST summary) and the whole branch must
+# fit comfortably inside `_TOTAL_WALL_CLOCK_SEC`. The Wikimedia API typically
+# responds in well under a second, so 4s is plenty without burning the chain
+# budget on tail latency.
+_WIKIPEDIA_REQUEST_TIMEOUT_SEC = 4.0
+# Floor on the per-request timeout when a deadline shrinks the budget. Below
+# this we treat the budget as exhausted rather than firing a doomed-to-time-
+# out request that still costs round-trip overhead.
+_WIKIPEDIA_MIN_TIMEOUT_SEC = 0.5
+
+
+def _wikipedia_request_timeout(deadline: Optional[float]) -> Optional[float]:
+    """Return the timeout to use for a Wikipedia request, honouring `deadline`.
+
+    Returns the configured per-request timeout when no deadline is supplied,
+    a clamped remaining-budget value when a deadline is in the future, or
+    `None` when the deadline has already passed (caller must skip the call).
+    """
+    if deadline is None:
+        return _WIKIPEDIA_REQUEST_TIMEOUT_SEC
+    import time as _time
+    remaining = deadline - _time.monotonic()
+    if remaining < _WIKIPEDIA_MIN_TIMEOUT_SEC:
+        return None
+    return min(_WIKIPEDIA_REQUEST_TIMEOUT_SEC, remaining)
+
+
+def _resolve_wikipedia_title(
+    query: str,
+    search_url: str,
+    headers: Dict[str, str],
+    deadline: Optional[float] = None,
+) -> Optional[str]:
+    """Resolve a Wikipedia article title for `query`, or return None.
+
+    Cascade: opensearch first (cheap, exact-prefix match for entity queries),
+    then `list=search` (full-text relevance) when opensearch comes up empty.
+    Opensearch is a title-prefix matcher, so verbose conversational queries
+    like "modern scientists similar to Albert Einstein" return zero titles
+    from it; without the full-text cascade the Wikipedia fallback never
+    fires for the phrasings the planner produces from voice utterances.
+
+    `deadline` (monotonic timestamp) bounds total time spent here so the
+    helper cannot blow the chain-level wall-clock budget. Returns None when
+    the deadline expires or either endpoint refuses / yields nothing usable.
+    """
+    timeout = _wikipedia_request_timeout(deadline)
+    if timeout is None:
+        return None
+    search_resp = requests.get(
+        search_url,
+        params={
+            "action": "opensearch",
+            "search": query,
+            "limit": 1,
+            "namespace": 0,
+            "format": "json",
+        },
+        headers=headers,
+        timeout=timeout,
+    )
+    if search_resp.status_code != 200:
+        debug_log(
+            f"Wikipedia opensearch status {search_resp.status_code}",
+            "web",
+        )
+        return None
+    payload = search_resp.json()
+    # `payload[1]` is documented as a list of title strings, but defend
+    # against a malformed mirror or a future API change handing us a string
+    # (which would slice into single characters and produce a phantom
+    # one-letter title that flows all the way to the REST summary fetch).
+    raw_titles = payload[1] if len(payload) > 1 else []
+    titles: List[str] = raw_titles if isinstance(raw_titles, list) else []
+    if titles and isinstance(titles[0], str) and titles[0].strip():
+        return titles[0]
+
+    # Cascade to full-text search when opensearch found no prefix match.
+    timeout = _wikipedia_request_timeout(deadline)
+    if timeout is None:
+        return None
+    fulltext_resp = requests.get(
+        search_url,
+        params={
+            "action": "query",
+            "list": "search",
+            "srsearch": query,
+            "srlimit": 1,
+            "srnamespace": 0,
+            "format": "json",
+        },
+        headers=headers,
+        timeout=timeout,
+    )
+    if fulltext_resp.status_code != 200:
+        debug_log(
+            f"Wikipedia fulltext status {fulltext_resp.status_code}",
+            "web",
+        )
+        return None
+    raw_search = ((fulltext_resp.json() or {}).get("query") or {}).get("search")
+    hits = raw_search if isinstance(raw_search, list) else []
+    if not hits:
+        return None
+    first = hits[0] if isinstance(hits[0], dict) else {}
+    title = first.get("title")
+    if not isinstance(title, str) or not title.strip():
+        return None
+    debug_log(
+        f"Wikipedia fulltext resolved '{query}' → '{title}'",
+        "web",
+    )
+    return title
+
+
+def _wikipedia_summary(
+    query: str,
+    lang: str = "en",
+    deadline: Optional[float] = None,
+) -> Optional[Tuple[str, str, str]]:
     """Last-resort Wikipedia lookup.
 
     Returns `(title, url, extract)` for the best match, or None on miss.
-    Tries the REST summary endpoint directly first (works for exact-title
-    queries), then falls back to opensearch for fuzzy title resolution.
-    Uses `lang.wikipedia.org` so the reply is in the user's spoken
-    language when Whisper gave us a non-English code.
+    Resolves a title via `_resolve_wikipedia_title` (opensearch with a
+    full-text fallback) and then fetches the REST summary endpoint for
+    that title. Uses `lang.wikipedia.org` so the reply is in the user's
+    spoken language when Whisper gave us a non-English code.
 
     We deliberately do NOT reuse the generic cascade fetcher: the REST
     summary API returns a curated `extract` field — short, clean, no
     navigation cruft — which is a better fit for the untrusted-extract
     fence than the full HTML page.
+
+    `deadline` (monotonic timestamp) is forwarded to every request so a
+    nearly-exhausted chain budget cannot be blown by tail latency in this
+    branch. None means "use the default per-request timeout".
     """
     lang = (lang or "en").strip().lower() or "en"
     # Sanitise: Wikipedia's language subdomains are 2–3 letter codes. If
@@ -393,78 +517,22 @@ def _wikipedia_summary(query: str, lang: str = "en"
         "Accept": "application/json",
         "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
     }
-    # Resolve a likely title via opensearch — cheaper and handles "what
-    # is possessor movie" ↔ "Possessor (film)" without us having to
-    # second-guess capitalisation. Opensearch is a title-prefix matcher,
-    # so it returns nothing for verbose conversational queries like
-    # "modern scientists similar to Albert Einstein". When that happens
-    # we cascade to the full-text search endpoint (`list=search`), which
-    # ranks articles by relevance to the whole phrase and surfaces a
-    # usable title where opensearch gave up. Without this cascade the
-    # Wikipedia fallback effectively never fires for the queries the
-    # planner produces from voice utterances.
     try:
         import urllib.parse
         search_url = f"https://{lang}.wikipedia.org/w/api.php"
-        search_resp = requests.get(
-            search_url,
-            params={
-                "action": "opensearch",
-                "search": query,
-                "limit": 1,
-                "namespace": 0,
-                "format": "json",
-            },
-            headers=headers,
-            timeout=5,
+        title = _resolve_wikipedia_title(
+            query, search_url, headers, deadline=deadline
         )
-        if search_resp.status_code != 200:
-            debug_log(
-                f"Wikipedia opensearch status {search_resp.status_code}",
-                "web",
-            )
-            return None
-        payload = search_resp.json()
-        titles = payload[1] if len(payload) > 1 else []
-        title: Optional[str] = titles[0] if titles else None
         if not title:
-            fulltext_resp = requests.get(
-                search_url,
-                params={
-                    "action": "query",
-                    "list": "search",
-                    "srsearch": query,
-                    "srlimit": 1,
-                    "srnamespace": 0,
-                    "format": "json",
-                },
-                headers=headers,
-                timeout=5,
-            )
-            if fulltext_resp.status_code != 200:
-                debug_log(
-                    f"Wikipedia fulltext status {fulltext_resp.status_code}",
-                    "web",
-                )
-                return None
-            hits = (
-                ((fulltext_resp.json() or {}).get("query") or {}).get("search")
-                or []
-            )
-            if not hits:
-                return None
-            title = (hits[0] or {}).get("title") or None
-            if not title:
-                return None
-            debug_log(
-                f"Wikipedia fulltext resolved '{query}' → '{title}'",
-                "web",
-            )
+            return None
+        timeout = _wikipedia_request_timeout(deadline)
+        if timeout is None:
+            return None
         summary_url = (
             f"https://{lang}.wikipedia.org/api/rest_v1/page/summary/"
             + urllib.parse.quote(title, safe="")
         )
-        summary_resp = requests.get(summary_url, headers=headers, timeout=5)
+        summary_resp = requests.get(summary_url, headers=headers, timeout=timeout)
         if summary_resp.status_code != 200:
             debug_log(
                 f"Wikipedia summary status {summary_resp.status_code}",
@@ -735,17 +803,27 @@ class WebSearchTool(Tool):
                 context.user_print(
                     f"📚 Searching Wikipedia ({lang}) for '{search_query}'…"
                 )
-                wiki = _wikipedia_summary(search_query, lang=lang)
+                # Forward the chain deadline so the helper's three sequential
+                # API calls cannot stretch past the overall wall-clock cap on
+                # a tail-latency day. Without this the helper happily spends
+                # 3 × _WIKIPEDIA_REQUEST_TIMEOUT_SEC even if the chain has
+                # only ~2s of budget left, breaching the voice-assistant
+                # latency contract.
+                wiki = _wikipedia_summary(
+                    search_query, lang=lang, deadline=chain_deadline
+                )
                 # If the localised Wikipedia had no page, retry in
                 # English before giving up. Many topics only exist on
                 # en.wikipedia.org and the user usually prefers a
                 # grounded answer over an honest "nothing found".
-                if not wiki and lang != "en":
+                if not wiki and lang != "en" and _budget_left() > 0:
                     debug_log(
                         f"Wikipedia ({lang}) returned no match; retrying 'en'",
                         "web",
                     )
-                    wiki = _wikipedia_summary(search_query, lang="en")
+                    wiki = _wikipedia_summary(
+                        search_query, lang="en", deadline=chain_deadline
+                    )
                     if wiki:
                         lang = "en"
                 if wiki:

--- a/src/jarvis/tools/builtin/web_search.py
+++ b/src/jarvis/tools/builtin/web_search.py
@@ -395,7 +395,14 @@ def _wikipedia_summary(query: str, lang: str = "en"
     }
     # Resolve a likely title via opensearch — cheaper and handles "what
     # is possessor movie" ↔ "Possessor (film)" without us having to
-    # second-guess capitalisation.
+    # second-guess capitalisation. Opensearch is a title-prefix matcher,
+    # so it returns nothing for verbose conversational queries like
+    # "modern scientists similar to Albert Einstein". When that happens
+    # we cascade to the full-text search endpoint (`list=search`), which
+    # ranks articles by relevance to the whole phrase and surfaces a
+    # usable title where opensearch gave up. Without this cascade the
+    # Wikipedia fallback effectively never fires for the queries the
+    # planner produces from voice utterances.
     try:
         import urllib.parse
         search_url = f"https://{lang}.wikipedia.org/w/api.php"
@@ -419,9 +426,40 @@ def _wikipedia_summary(query: str, lang: str = "en"
             return None
         payload = search_resp.json()
         titles = payload[1] if len(payload) > 1 else []
-        if not titles:
-            return None
-        title = titles[0]
+        title: Optional[str] = titles[0] if titles else None
+        if not title:
+            fulltext_resp = requests.get(
+                search_url,
+                params={
+                    "action": "query",
+                    "list": "search",
+                    "srsearch": query,
+                    "srlimit": 1,
+                    "srnamespace": 0,
+                    "format": "json",
+                },
+                headers=headers,
+                timeout=5,
+            )
+            if fulltext_resp.status_code != 200:
+                debug_log(
+                    f"Wikipedia fulltext status {fulltext_resp.status_code}",
+                    "web",
+                )
+                return None
+            hits = (
+                ((fulltext_resp.json() or {}).get("query") or {}).get("search")
+                or []
+            )
+            if not hits:
+                return None
+            title = (hits[0] or {}).get("title") or None
+            if not title:
+                return None
+            debug_log(
+                f"Wikipedia fulltext resolved '{query}' → '{title}'",
+                "web",
+            )
         summary_url = (
             f"https://{lang}.wikipedia.org/api/rest_v1/page/summary/"
             + urllib.parse.quote(title, safe="")

--- a/src/jarvis/tools/builtin/web_search.spec.md
+++ b/src/jarvis/tools/builtin/web_search.spec.md
@@ -152,7 +152,13 @@ answer, the tool walks a fallback chain before giving up:
      an honest "nothing found" for those.
    Fetches an opensearch title and then the REST summary endpoint; the
    curated `extract` field goes into the fence directly (no HTML
-   scraping, cleaner payload).
+   scraping, cleaner payload). Opensearch is a title-prefix matcher and
+   returns nothing for verbose conversational queries such as
+   "modern scientists similar to Albert Einstein" — when that happens
+   the helper cascades to the full-text endpoint (`list=search`,
+   `srlimit=1`) to resolve a relevant title, then continues with the
+   REST summary fetch. Without the full-text cascade the planner's
+   typical phrasings produce zero hits and the fallback never fires.
 3. **Honest block envelope** — if every provider fails, the envelope
    admits it and forbids unverified facts (same framing as the
    links-only envelope).

--- a/src/jarvis/tools/builtin/web_search.spec.md
+++ b/src/jarvis/tools/builtin/web_search.spec.md
@@ -159,6 +159,14 @@ answer, the tool walks a fallback chain before giving up:
    `srlimit=1`) to resolve a relevant title, then continues with the
    REST summary fetch. Without the full-text cascade the planner's
    typical phrasings produce zero hits and the fallback never fires.
+   Every Wikipedia request honours the chain-level deadline forwarded
+   by the caller: each request's timeout collapses to whatever budget
+   remains, and once the remaining budget falls below
+   `_WIKIPEDIA_MIN_TIMEOUT_SEC` the helper returns `None` rather than
+   firing a request that is doomed to time out. The localised-miss
+   retry against `en.wikipedia.org` is also gated on remaining budget,
+   so the worst case across the Wikipedia branch never breaches
+   `_TOTAL_WALL_CLOCK_SEC`.
 3. **Honest block envelope** — if every provider fails, the envelope
    admits it and forbids unverified facts (same framing as the
    links-only envelope).
@@ -219,6 +227,17 @@ Regression tests assert:
    `anomaly-modal` / `anomaly.js` in body) produces the rate-limited
    envelope, not a phantom result count and not a "use this information"
    envelope over empty payload.
+6. **Wikipedia title cascade**: when opensearch returns no titles for a
+   query, `_resolve_wikipedia_title` cascades to `list=search` (full-
+   text) before giving up. Tests cover the happy path, the "both empty
+   → `None`" path, and the defensive guards for non-200 fulltext
+   responses, hits whose `title` key is missing/empty, and malformed
+   `search` payloads (anything that is not a list).
+7. **Wikipedia deadline plumbing**: when a `deadline` is forwarded to
+   `_wikipedia_summary`, every internal request honours it — a deadline
+   already in the past causes the helper to short-circuit to `None`
+   without hitting the network, and a near-expiry deadline shrinks the
+   per-request timeout rather than firing a doomed full-timeout request.
 
 ### Non-goals
 

--- a/tests/tools/builtin/test_web_search.py
+++ b/tests/tools/builtin/test_web_search.py
@@ -731,6 +731,108 @@ class TestWikipediaSummaryHelper:
         assert second_call.kwargs["params"]["list"] == "search"
 
     @patch("src.jarvis.tools.builtin.web_search.requests.get")
+    def test_fulltext_status_error_returns_none(self, mock_get):
+        """If `list=search` itself returns a non-200 status (Wikimedia hiccup,
+        rate limit, transient outage), the helper must return None and let the
+        envelope fall through to the honest-block path — not raise, not return
+        a half-resolved title that then 404s on the summary fetch."""
+        from src.jarvis.tools.builtin.web_search import _wikipedia_summary
+        bad = Mock()
+        bad.status_code = 503
+        mock_get.side_effect = [self._mk_search([]), bad]
+        assert _wikipedia_summary("q", lang="en") is None
+
+    @patch("src.jarvis.tools.builtin.web_search.requests.get")
+    def test_fulltext_hit_without_title_returns_none(self, mock_get):
+        """`list=search` is documented to return objects with a `title` key,
+        but a malformed mirror or future API change could ship hits with
+        missing/empty titles. The defensive guard must collapse to None
+        rather than feeding an empty string to `urllib.parse.quote` and
+        firing a doomed REST summary fetch on `…/page/summary/`."""
+        from src.jarvis.tools.builtin.web_search import _wikipedia_summary
+        bad_hits = Mock()
+        bad_hits.status_code = 200
+        bad_hits.json.return_value = {"query": {"search": [{}]}}  # no "title"
+        mock_get.side_effect = [self._mk_search([]), bad_hits]
+        assert _wikipedia_summary("q", lang="en") is None
+
+    @patch("src.jarvis.tools.builtin.web_search.requests.get")
+    def test_fulltext_search_not_a_list_treated_as_empty(self, mock_get):
+        """Defensive: `query.search` is documented as a list, but if the API
+        ever ships back a string/dict/null in that slot, the helper must
+        treat it as empty rather than indexing into it (which would, e.g.,
+        slice a string into a single-character title)."""
+        from src.jarvis.tools.builtin.web_search import _wikipedia_summary
+        for malformed in (None, "broken", {"unexpected": "shape"}, 42):
+            mock_get.reset_mock()
+            weird = Mock()
+            weird.status_code = 200
+            weird.json.return_value = {"query": {"search": malformed}}
+            mock_get.side_effect = [self._mk_search([]), weird]
+            assert _wikipedia_summary("q", lang="en") is None, (
+                f"search={malformed!r} should resolve to None"
+            )
+
+    @patch("src.jarvis.tools.builtin.web_search.requests.get")
+    def test_opensearch_titles_not_a_list_treated_as_empty(self, mock_get):
+        """`payload[1]` is documented as a list of strings. A malformed
+        response that hands us a string here would otherwise slice into
+        single characters (`titles[0]` becomes the first letter), producing
+        a phantom one-character title that flows all the way to the REST
+        summary fetch. Treat anything non-list as empty and cascade."""
+        from src.jarvis.tools.builtin.web_search import _wikipedia_summary
+        weird = Mock()
+        weird.status_code = 200
+        weird.json.return_value = ["q", "broken-string-not-a-list", [], []]
+        mock_get.side_effect = [
+            weird,
+            self._mk_fulltext(["Real Title"]),
+            self._mk_summary("e", title="Real Title"),
+        ]
+        result = _wikipedia_summary("q", lang="en")
+        assert result is not None
+        assert result[0] == "Real Title"
+
+    @patch("src.jarvis.tools.builtin.web_search.requests.get")
+    def test_deadline_in_past_short_circuits(self, mock_get):
+        """A deadline already in the past must collapse the helper to None
+        without firing any HTTP request — the chain budget is exhausted and
+        firing more requests can only make the latency situation worse."""
+        import time as _time
+        from src.jarvis.tools.builtin.web_search import _wikipedia_summary
+        result = _wikipedia_summary(
+            "q", lang="en", deadline=_time.monotonic() - 1.0
+        )
+        assert result is None
+        assert mock_get.call_count == 0
+
+    @patch("src.jarvis.tools.builtin.web_search.requests.get")
+    def test_deadline_shrinks_request_timeout(self, mock_get):
+        """A near-expiry deadline must shrink the per-request `timeout`
+        rather than fire the default 4s request that would happily blow the
+        chain budget. Verify the timeout argument is clamped below the
+        default for a deadline ~1s out."""
+        import time as _time
+        from src.jarvis.tools.builtin.web_search import (
+            _WIKIPEDIA_REQUEST_TIMEOUT_SEC,
+            _wikipedia_summary,
+        )
+        mock_get.side_effect = [
+            self._mk_search(["Thing"]),
+            self._mk_summary("e"),
+        ]
+        _wikipedia_summary(
+            "q", lang="en", deadline=_time.monotonic() + 1.0
+        )
+        # Both calls must have a timeout strictly below the default and
+        # strictly above zero — the clamp should produce something near 1s.
+        for call in mock_get.call_args_list:
+            t = call.kwargs.get("timeout")
+            assert t is not None and 0 < t < _WIKIPEDIA_REQUEST_TIMEOUT_SEC, (
+                f"expected clamped timeout, got {t!r}"
+            )
+
+    @patch("src.jarvis.tools.builtin.web_search.requests.get")
     def test_uses_language_subdomain(self, mock_get):
         from src.jarvis.tools.builtin.web_search import _wikipedia_summary
         mock_get.side_effect = [

--- a/tests/tools/builtin/test_web_search.py
+++ b/tests/tools/builtin/test_web_search.py
@@ -675,6 +675,14 @@ class TestWikipediaSummaryHelper:
         }
         return r
 
+    def _mk_fulltext(self, titles):
+        r = Mock()
+        r.status_code = 200
+        r.json.return_value = {
+            "query": {"search": [{"title": t} for t in titles]}
+        }
+        return r
+
     @patch("src.jarvis.tools.builtin.web_search.requests.get")
     def test_returns_title_url_extract(self, mock_get):
         from src.jarvis.tools.builtin.web_search import _wikipedia_summary
@@ -687,9 +695,40 @@ class TestWikipediaSummaryHelper:
 
     @patch("src.jarvis.tools.builtin.web_search.requests.get")
     def test_no_titles_returns_none(self, mock_get):
+        """When opensearch AND the full-text fallback both come up empty, the
+        helper bows out with `None` rather than fabricating a result."""
         from src.jarvis.tools.builtin.web_search import _wikipedia_summary
-        mock_get.side_effect = [self._mk_search([])]
+        mock_get.side_effect = [self._mk_search([]), self._mk_fulltext([])]
         assert _wikipedia_summary("nonsense blob", lang="en") is None
+
+    @patch("src.jarvis.tools.builtin.web_search.requests.get")
+    def test_opensearch_empty_falls_back_to_fulltext(self, mock_get):
+        """Opensearch is a title-prefix matcher; the planner's verbose queries
+        ('modern scientists similar to Albert Einstein') return zero titles
+        from it. The helper must cascade to `list=search` (full-text) so the
+        Wikipedia fallback actually fires for real-world phrasings."""
+        from src.jarvis.tools.builtin.web_search import _wikipedia_summary
+        mock_get.side_effect = [
+            self._mk_search([]),  # opensearch: no prefix match
+            self._mk_fulltext(["Albert Einstein"]),  # full-text: relevance hit
+            self._mk_summary(
+                "German-born theoretical physicist…",
+                title="Albert Einstein",
+                page_url="https://en.wikipedia.org/wiki/Albert_Einstein",
+            ),
+        ]
+        result = _wikipedia_summary(
+            "modern scientists similar to Albert Einstein", lang="en"
+        )
+        assert result == (
+            "Albert Einstein",
+            "https://en.wikipedia.org/wiki/Albert_Einstein",
+            "German-born theoretical physicist…",
+        )
+        # Verify the second call hit the full-text endpoint, not summary.
+        second_call = mock_get.call_args_list[1]
+        assert second_call.kwargs["params"]["action"] == "query"
+        assert second_call.kwargs["params"]["list"] == "search"
 
     @patch("src.jarvis.tools.builtin.web_search.requests.get")
     def test_uses_language_subdomain(self, mock_get):


### PR DESCRIPTION
## Summary
- **Root fix**: Wikipedia fallback's `opensearch` call is a title-prefix matcher and returns no titles for the verbose, conversational queries the planner builds from voice utterances (e.g. *"modern scientists similar to Albert Einstein"*). The helper bailed on empty title lists, so the fallback effectively never fired in real use. Cascade to `action=query&list=search&srlimit=1` (full-text relevance) when opensearch comes up empty, then continue with the existing REST summary fetch on the resolved title. Verified live: the verbose query above now resolves to `Albert Einstein` and pulls a clean extract.
- **Helper refactor**: extracted `_resolve_wikipedia_title` so the opensearch → fulltext cascade is one named function, and the main helper drops two levels of nesting.
- **Deadline plumbing**: `_wikipedia_summary` now accepts a `deadline` (monotonic timestamp) which the call site forwards from `chain_deadline`. `_wikipedia_request_timeout` clamps each internal request's timeout to whatever budget remains and short-circuits to `None` when the remaining budget falls below `_WIKIPEDIA_MIN_TIMEOUT_SEC`. The localised-miss en-retry at the call site is also gated on `_budget_left() > 0`. Net effect: the Wikipedia branch can never breach `_TOTAL_WALL_CLOCK_SEC` even on tail-latency days. Per-request timeout tightened from 5s to 4s.
- **Defensive parsing**: `payload[1]` from opensearch is now type-checked as a list before slicing (a malformed mirror handing back a string would otherwise produce a one-character phantom title). `hits[0]` from `list=search` is type-checked as a dict and its `title` field must be a non-empty string before flowing into `urllib.parse.quote`.
- **Docstring + spec**: rewrote the `_wikipedia_summary` docstring (was already wrong pre-PR — claimed "REST summary first then opensearch" while doing the opposite). Spec now documents deadline plumbing and adds explicit test guarantees for the title cascade and deadline behaviour.

## Test plan
- [x] `pytest tests/tools/builtin/test_web_search.py` — 52 passed (was 46; +6 new cases: fulltext-non-200, fulltext-hit-without-title, malformed search list, opensearch-titles-not-a-list, deadline-in-past, deadline-shrinks-timeout)
- [x] Live `_wikipedia_summary("modern scientists similar to Albert Einstein", lang="en")` → resolves to `Albert Einstein` article via fulltext cascade
- [x] Live with past deadline → returns `None` without hitting the network
- [x] Live with `+3s` deadline → still succeeds with shrunk per-request timeouts
- [ ] Manual voice check: ask Jarvis a verbose follow-up that forces the DDG bot-challenge path and confirm the reply is grounded in the Wikipedia extract rather than the honest-block envelope

🤖 Generated with [Claude Code](https://claude.com/claude-code)