### PR TITLE
fix(listener): show city placeholder weather example when location is unavailable

### DIFF
--- a/src/jarvis/listening/listener.py
+++ b/src/jarvis/listening/listener.py
@@ -2057,8 +2057,17 @@ class VoiceListener(threading.Thread):
             # Show ready message only after stream is confirmed active
             wake_word = getattr(self.cfg, "wake_word", "jarvis").lower()
             wake_title = wake_word.title()
+            location_enabled = getattr(self.cfg, "location_enabled", True)
+            location_auto_detect = getattr(self.cfg, "location_auto_detect", True)
+            location_ip_address = getattr(self.cfg, "location_ip_address", None)
+            location_known = location_enabled and (location_auto_detect or bool(location_ip_address))
+            weather_example = (
+                f"\"How's the weather, {wake_title}?\""
+                if location_known
+                else f"\"How's the weather in London, {wake_title}?\""
+            )
             print(f"\n{'─' * 50}\n🎙️  Listening! Try:", flush=True)
-            print(f"      \"How's the weather, {wake_title}?\"", flush=True)
+            print(f"      {weather_example}", flush=True)
             print(f"      \"I just ate a Big Mac, {wake_title}.\"", flush=True)
             print(f"      \"What are you thinking, {wake_title}?\"", flush=True)
             print(f"      \"What do you know about me, {wake_title}?\"", flush=True)

--- a/src/jarvis/listening/listener.py
+++ b/src/jarvis/listening/listener.py
@@ -1476,6 +1476,20 @@ class VoiceListener(threading.Thread):
         )
         return threads
 
+    def _weather_example(self, wake_title: str) -> str:
+        """Return the weather query example for the startup banner.
+
+        Shows the plain form when a location source is configured, or the
+        [your city] placeholder form so the user knows to supply a city.
+        """
+        location_enabled = getattr(self.cfg, "location_enabled", True)
+        location_auto_detect = getattr(self.cfg, "location_auto_detect", True)
+        location_ip_address = getattr(self.cfg, "location_ip_address", None)
+        location_known = location_enabled and (location_auto_detect or bool(location_ip_address))
+        if location_known:
+            return f"\"How's the weather, {wake_title}?\""
+        return f"\"How's the weather in [your city], {wake_title}?\""
+
     def run(self) -> None:
         """Main voice listening loop."""
         if sd is None:
@@ -2057,17 +2071,8 @@ class VoiceListener(threading.Thread):
             # Show ready message only after stream is confirmed active
             wake_word = getattr(self.cfg, "wake_word", "jarvis").lower()
             wake_title = wake_word.title()
-            location_enabled = getattr(self.cfg, "location_enabled", True)
-            location_auto_detect = getattr(self.cfg, "location_auto_detect", True)
-            location_ip_address = getattr(self.cfg, "location_ip_address", None)
-            location_known = location_enabled and (location_auto_detect or bool(location_ip_address))
-            weather_example = (
-                f"\"How's the weather, {wake_title}?\""
-                if location_known
-                else f"\"How's the weather in London, {wake_title}?\""
-            )
             print(f"\n{'─' * 50}\n🎙️  Listening! Try:", flush=True)
-            print(f"      {weather_example}", flush=True)
+            print(f"      {self._weather_example(wake_title)}", flush=True)
             print(f"      \"I just ate a Big Mac, {wake_title}.\"", flush=True)
             print(f"      \"What are you thinking, {wake_title}?\"", flush=True)
             print(f"      \"What do you know about me, {wake_title}?\"", flush=True)

--- a/src/jarvis/listening/listening.spec.md
+++ b/src/jarvis/listening/listening.spec.md
@@ -102,13 +102,13 @@ Before the listener announces "Listening!", it pre-loads every model the first e
      🧠 Intent judge 'gemma4:e2b' ready
 🎙️  Listening! Try:
       "How's the weather, Jarvis?"          ← when location is known
-      "How's the weather in London, Jarvis?"  ← when location is disabled or not configured
+      "How's the weather in [your city], Jarvis?"  ← when location is disabled or not configured
       "I just ate a Big Mac, Jarvis."
       "What are you thinking, Jarvis?"
       "What do you know about me, Jarvis?"
 ```
 
-The weather example adapts to location availability: if `location_enabled` is true and a location source is configured (`location_auto_detect` or a manual `location_ip_address`), the plain form is shown; otherwise the city-name form is shown so the user knows they need to specify a location in their query.
+The weather example adapts to location availability: if `location_enabled` is true and a location source is configured (`location_auto_detect` or a manual `location_ip_address`), the plain form is shown; otherwise the `[your city]` placeholder form is shown so the user understands they must substitute a real city name in their query.
 
 On small models, a caveat line is appended above a more involved example to set expectations (`⚠️ Small model in use (…). Assume it can't infer — spell out the steps for anything more involved:`). The Chrome MCP tip continues to appear as its own block when the browser tool is detected.
 

--- a/src/jarvis/listening/listening.spec.md
+++ b/src/jarvis/listening/listening.spec.md
@@ -101,11 +101,14 @@ Before the listener announces "Listening!", it pre-loads every model the first e
      💬 Chat model 'llama3.1' ready
      🧠 Intent judge 'gemma4:e2b' ready
 🎙️  Listening! Try:
-      "How's the weather, Jarvis?"
+      "How's the weather, Jarvis?"          ← when location is known
+      "How's the weather in London, Jarvis?"  ← when location is disabled or not configured
       "I just ate a Big Mac, Jarvis."
       "What are you thinking, Jarvis?"
       "What do you know about me, Jarvis?"
 ```
+
+The weather example adapts to location availability: if `location_enabled` is true and a location source is configured (`location_auto_detect` or a manual `location_ip_address`), the plain form is shown; otherwise the city-name form is shown so the user knows they need to specify a location in their query.
 
 On small models, a caveat line is appended above a more involved example to set expectations (`⚠️ Small model in use (…). Assume it can't infer — spell out the steps for anything more involved:`). The Chrome MCP tip continues to appear as its own block when the browser tool is detected.
 

--- a/tests/test_voice_listener.py
+++ b/tests/test_voice_listener.py
@@ -1751,3 +1751,61 @@ class TestIsWhisperHallucination:
             "(definition + faster-whisper site + MLX site). Found: "
             f"{src.count('is_whisper_hallucination(')}"
         )
+
+
+class TestWeatherBannerExample:
+    """Tests for the adaptive weather example in the startup banner."""
+
+    def _make_listener(self, **cfg_overrides):
+        from unittest.mock import MagicMock
+        from jarvis.listening.listener import VoiceListener
+
+        cfg = MagicMock()
+        cfg.wake_word = cfg_overrides.get("wake_word", "jarvis")
+        cfg.location_enabled = cfg_overrides.get("location_enabled", True)
+        cfg.location_auto_detect = cfg_overrides.get("location_auto_detect", True)
+        cfg.location_ip_address = cfg_overrides.get("location_ip_address", None)
+
+        listener = object.__new__(VoiceListener)
+        listener.cfg = cfg
+        return listener
+
+    def test_plain_form_when_auto_detect_enabled(self):
+        """Plain 'How's the weather' example when auto-detect is on."""
+        listener = self._make_listener(location_enabled=True, location_auto_detect=True)
+        result = listener._weather_example("Jarvis")
+        assert result == "\"How's the weather, Jarvis?\""
+
+    def test_plain_form_when_manual_ip_configured(self):
+        """Plain form when auto-detect is off but a manual IP is set."""
+        listener = self._make_listener(
+            location_enabled=True,
+            location_auto_detect=False,
+            location_ip_address="1.2.3.4",
+        )
+        result = listener._weather_example("Jarvis")
+        assert result == "\"How's the weather, Jarvis?\""
+
+    def test_city_placeholder_when_location_disabled(self):
+        """City placeholder form when location is explicitly disabled."""
+        listener = self._make_listener(location_enabled=False)
+        result = listener._weather_example("Jarvis")
+        assert result == "\"How's the weather in [your city], Jarvis?\""
+
+    def test_city_placeholder_when_no_location_source(self):
+        """City placeholder form when auto-detect is off and no manual IP is set."""
+        listener = self._make_listener(
+            location_enabled=True,
+            location_auto_detect=False,
+            location_ip_address=None,
+        )
+        result = listener._weather_example("Jarvis")
+        assert result == "\"How's the weather in [your city], Jarvis?\""
+
+    def test_wake_title_reflected_in_example(self):
+        """Wake word title is correctly used in the example string."""
+        listener = self._make_listener(location_enabled=True, location_auto_detect=True)
+        assert "Helix?" in listener._weather_example("Helix")
+
+        listener2 = self._make_listener(location_enabled=False)
+        assert "Helix?" in listener2._weather_example("Helix")


### PR DESCRIPTION
## Summary

- The \"Listening!\" banner's weather example now adapts to location availability
- When location is enabled and a source is configured (auto-detect or manual IP), shows \`\"How's the weather, Jarvis?\"\`
- When location is disabled or unconfigured, shows \`\"How's the weather in [your city], Jarvis?\"\` so the user clearly understands they need to substitute their own city name
- Logic extracted into \`VoiceListener._weather_example()\` for testability
- 5 unit tests added covering all config combinations
- Spec updated to document both variants and selection logic

## Reviewer notes

The \`[your city]\` bracket notation was chosen over a real city name (e.g. \"London\") because users would likely just repeat the example verbatim rather than substituting their own city.

\`geoip2\` is pinned in requirements.txt so the \"library not available\" guard in \`location.py\` is not a real-world concern for normal installs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)