### PR TITLE
fix(listener): show city placeholder when GeoLite2 DB is missing

### DIFF
--- a/src/jarvis/listening/listener.py
+++ b/src/jarvis/listening/listener.py
@@ -23,6 +23,7 @@ from .wake_detection import is_wake_word_detected, extract_query_after_wake, is_
 from .transcript_buffer import TranscriptBuffer
 from .intent_judge import IntentJudge, create_intent_judge, warm_up_ollama_model
 from ..debug import debug_log
+from ..utils.location import is_location_available
 
 if TYPE_CHECKING:
     from ..memory.db import Database
@@ -1570,7 +1571,11 @@ class VoiceListener(threading.Thread):
         location_enabled = getattr(self.cfg, "location_enabled", True)
         location_auto_detect = getattr(self.cfg, "location_auto_detect", True)
         location_ip_address = getattr(self.cfg, "location_ip_address", None)
-        location_known = location_enabled and (location_auto_detect or bool(location_ip_address))
+        location_known = (
+            location_enabled
+            and (location_auto_detect or bool(location_ip_address))
+            and is_location_available()
+        )
         if location_known:
             return f"\"How's the weather, {wake_title}?\""
         return f"\"How's the weather in [your city], {wake_title}?\""

--- a/src/jarvis/listening/listening.spec.md
+++ b/src/jarvis/listening/listening.spec.md
@@ -108,7 +108,7 @@ Before the listener announces "Listening!", it pre-loads every model the first e
       "What do you know about me, Jarvis?"
 ```
 
-The weather example adapts to location availability: if `location_enabled` is true and a location source is configured (`location_auto_detect` or a manual `location_ip_address`), the plain form is shown; otherwise the `[your city]` placeholder form is shown so the user understands they must substitute a real city name in their query.
+The weather example adapts to location availability: if `location_enabled` is true, a location source is configured (`location_auto_detect` or a manual `location_ip_address`), **and** the GeoLite2 database is present (`is_location_available()` returns true), the plain form is shown; otherwise the `[your city]` placeholder form is shown so the user understands they must substitute a real city name in their query.
 
 On small models, a caveat line is appended above a more involved example to set expectations (`⚠️ Small model in use (…). Assume it can't infer — spell out the steps for anything more involved:`). The Chrome MCP tip continues to appear as its own block when the browser tool is detected.
 

--- a/tests/test_voice_listener.py
+++ b/tests/test_voice_listener.py
@@ -1781,19 +1781,23 @@ class TestWeatherBannerExample:
         return listener
 
     def test_plain_form_when_auto_detect_enabled(self):
-        """Plain 'How's the weather' example when auto-detect is on."""
+        """Plain 'How's the weather' example when auto-detect is on and database is present."""
+        from unittest.mock import patch
         listener = self._make_listener(location_enabled=True, location_auto_detect=True)
-        result = listener._weather_example("Jarvis")
+        with patch("jarvis.listening.listener.is_location_available", return_value=True):
+            result = listener._weather_example("Jarvis")
         assert result == "\"How's the weather, Jarvis?\""
 
     def test_plain_form_when_manual_ip_configured(self):
-        """Plain form when auto-detect is off but a manual IP is set."""
+        """Plain form when auto-detect is off but a manual IP is set and database is present."""
+        from unittest.mock import patch
         listener = self._make_listener(
             location_enabled=True,
             location_auto_detect=False,
             location_ip_address="1.2.3.4",
         )
-        result = listener._weather_example("Jarvis")
+        with patch("jarvis.listening.listener.is_location_available", return_value=True):
+            result = listener._weather_example("Jarvis")
         assert result == "\"How's the weather, Jarvis?\""
 
     def test_city_placeholder_when_location_disabled(self):
@@ -1812,10 +1816,20 @@ class TestWeatherBannerExample:
         result = listener._weather_example("Jarvis")
         assert result == "\"How's the weather in [your city], Jarvis?\""
 
+    def test_city_placeholder_when_database_not_available(self):
+        """City placeholder form when GeoLite2 database is missing even if config enables location."""
+        from unittest.mock import patch
+        listener = self._make_listener(location_enabled=True, location_auto_detect=True)
+        with patch("jarvis.listening.listener.is_location_available", return_value=False):
+            result = listener._weather_example("Jarvis")
+        assert result == "\"How's the weather in [your city], Jarvis?\""
+
     def test_wake_title_reflected_in_example(self):
         """Wake word title is correctly used in the example string."""
-        listener = self._make_listener(location_enabled=True, location_auto_detect=True)
-        assert "Helix?" in listener._weather_example("Helix")
+        from unittest.mock import patch
+        with patch("jarvis.listening.listener.is_location_available", return_value=True):
+            listener = self._make_listener(location_enabled=True, location_auto_detect=True)
+            assert "Helix?" in listener._weather_example("Helix")
 
         listener2 = self._make_listener(location_enabled=False)
         assert "Helix?" in listener2._weather_example("Helix")


### PR DESCRIPTION
## Summary

- `_weather_example` previously checked only config flags (`location_enabled`, `location_auto_detect`, `location_ip_address`) to decide whether to show the plain weather example or the `[your city]` placeholder.
- It did not check whether the GeoLite2 database was actually present, so users without the database still saw `"How's the weather, Jarvis?"` in the banner despite the daemon printing `📍 Location features are not available` moments earlier.
- Fix: also call `is_location_available()` (which checks for the DB on disk) as a gate. If it returns `False`, the placeholder form is always shown.
- Spec and tests updated accordingly.

## Test plan

- [ ] `pytest tests/test_voice_listener.py::TestWeatherBannerExample` — all 6 tests pass
- [ ] Manually: start the daemon without the GeoLite2 database; confirm banner shows `"How's the weather in [your city], Jarvis?"`
- [ ] Manually: start the daemon with the GeoLite2 database installed; confirm banner shows `"How's the weather, Jarvis?"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)