### PR TITLE
fix(memory+tools): close memory leaks across daemon hot paths

### DIFF
--- a/src/jarvis/llm.py
+++ b/src/jarvis/llm.py
@@ -44,9 +44,9 @@ def call_llm_direct(base_url: str, chat_model: str, system_prompt: str, user_con
     }
     
     try:
-        resp = requests.post(f"{base_url.rstrip('/')}/api/chat", json=payload, timeout=timeout_sec)
-        resp.raise_for_status()
-        data = resp.json()
+        with requests.post(f"{base_url.rstrip('/')}/api/chat", json=payload, timeout=timeout_sec) as resp:
+            resp.raise_for_status()
+            data = resp.json()
 
         if isinstance(data, dict):
             content = extract_text_from_response(data)
@@ -100,31 +100,36 @@ def call_llm_streaming(
         "think": thinking,
     }
 
+    # Use ``with`` so the streaming response (and the underlying TCP
+    # connection) is released even if iter_lines exits early via an
+    # exception or the caller stops consuming. Without this an aborted
+    # stream pinned the connection until GC, which could happen many
+    # turns later under sustained reply load.
     try:
-        resp = requests.post(
+        with requests.post(
             f"{base_url.rstrip('/')}/api/chat",
             json=payload,
             timeout=timeout_sec,
-            stream=True
-        )
-        resp.raise_for_status()
+            stream=True,
+        ) as resp:
+            resp.raise_for_status()
 
-        full_response = []
-        for line in resp.iter_lines():
-            if line:
-                try:
-                    data = json.loads(line)
-                    if "message" in data and isinstance(data["message"], dict):
-                        content = data["message"].get("content", "")
-                        if content:
-                            full_response.append(content)
-                            if on_token:
-                                on_token(content)
-                except json.JSONDecodeError:
-                    continue
+            full_response = []
+            for line in resp.iter_lines():
+                if line:
+                    try:
+                        data = json.loads(line)
+                        if "message" in data and isinstance(data["message"], dict):
+                            content = data["message"].get("content", "")
+                            if content:
+                                full_response.append(content)
+                                if on_token:
+                                    on_token(content)
+                    except json.JSONDecodeError:
+                        continue
 
-        result = "".join(full_response)
-        return result if result.strip() else None
+            result = "".join(full_response)
+            return result if result.strip() else None
 
     except requests.exceptions.Timeout:
         return None
@@ -206,9 +211,9 @@ def chat_with_messages(
         payload["tools"] = tools
 
     try:
-        resp = requests.post(f"{base_url.rstrip('/')}/api/chat", json=payload, timeout=timeout_sec)
-        resp.raise_for_status()
-        data = resp.json()
+        with requests.post(f"{base_url.rstrip('/')}/api/chat", json=payload, timeout=timeout_sec) as resp:
+            resp.raise_for_status()
+            data = resp.json()
         if isinstance(data, dict):
             return data
     except requests.exceptions.Timeout:

--- a/src/jarvis/memory/conversation.py
+++ b/src/jarvis/memory/conversation.py
@@ -3,6 +3,7 @@ import json
 import re
 import time
 import threading
+from collections import OrderedDict
 from datetime import datetime, timezone
 from typing import Iterator, Optional, List, Tuple, Union, Callable
 from .db import Database
@@ -640,7 +641,14 @@ class DialogueMemory:
         # inspect entry age, but reads are NOT bounded by RECENT_WINDOW_SEC
         # any more — long active conversations would otherwise see warm
         # profile / router caches expire while the session is still going.
-        self._hot_cache: dict[str, Tuple[float, object]] = {}
+        # LRU-bounded so per-query keys (router cache, enrichment extractor
+        # cache) cannot grow without limit during long active sessions.
+        # Reads bump recency; writes evict the least-recently-used entry
+        # once the cap is reached. ``WARM_PROFILE_CACHE_KEY`` is a single
+        # query-agnostic entry so the cap easily covers it; explicit
+        # invalidation hooks (``clear_hot_cache``, ``invalidate_warm_profile``,
+        # new-conversation reset) still apply unchanged.
+        self._hot_cache: "OrderedDict[str, Tuple[float, object]]" = OrderedDict()
         # Hard ceiling on stored tool turns. With the default
         # ``tool_carryover_max_turns=2`` re-injected per reply, 16 lets a
         # session accumulate roughly 8x the visible budget before the
@@ -783,10 +791,19 @@ class DialogueMemory:
     # and the graph-mutation invalidator agree on it.
     WARM_PROFILE_CACHE_KEY = "warm_profile_block"
 
+    # LRU cap for the conversation-scoped scratch cache. The engine writes
+    # at most three keys per turn (router, enrichment extractor, warm
+    # profile) of which two are query-dependent, so 128 covers ~64 unique
+    # queries per active session — well above any realistic hot window
+    # while keeping memory growth bounded for marathon sessions.
+    HOT_CACHE_MAX_ENTRIES = 128
+
     def hot_cache_get(self, key: str) -> Optional[object]:
         """Return the cached value for ``key`` if present, else ``None``.
 
-        No age-based expiry: callers control invalidation via
+        Reads bump the entry to the most-recently-used end so the LRU
+        eviction policy reflects access patterns, not just insertion
+        order. No age-based expiry: callers control invalidation via
         ``clear_hot_cache``, ``invalidate_warm_profile``, or new-
         conversation reset in the engine.
         """
@@ -794,18 +811,27 @@ class DialogueMemory:
             entry = self._hot_cache.get(key)
             if not entry:
                 return None
+            self._hot_cache.move_to_end(key)
             _ts, value = entry
             return value
 
     def hot_cache_put(self, key: str, value: object) -> None:
-        """Store value under key with current timestamp."""
+        """Store value under key with current timestamp.
+
+        Evicts the least-recently-used entry once ``HOT_CACHE_MAX_ENTRIES``
+        is exceeded so per-query keys (router/enrichment caches) cannot
+        grow without bound during long sessions.
+        """
         with self._lock:
             self._hot_cache[key] = (time.time(), value)
+            self._hot_cache.move_to_end(key)
+            while len(self._hot_cache) > self.HOT_CACHE_MAX_ENTRIES:
+                self._hot_cache.popitem(last=False)
 
     def clear_hot_cache(self) -> None:
         """Drop all conversation-scoped cache entries."""
         with self._lock:
-            self._hot_cache = {}
+            self._hot_cache = OrderedDict()
 
     def invalidate_warm_profile(self) -> None:
         """Drop the cached warm-profile block. Called from the graph

--- a/src/jarvis/tools/builtin/fetch_web_page.py
+++ b/src/jarvis/tools/builtin/fetch_web_page.py
@@ -50,11 +50,15 @@ class FetchWebPageTool(Tool):
                 'Connection': 'keep-alive',
                 'Upgrade-Insecure-Requests': '1',
             }
-            response = requests.get(url, headers=headers, timeout=15, allow_redirects=True)
-            response.raise_for_status()
+            # ``with`` releases the connection back to the pool deterministically
+            # even if BeautifulSoup or the link extraction raises midway.
+            with requests.get(url, headers=headers, timeout=15, allow_redirects=True) as response:
+                response.raise_for_status()
+                response_content = response.content
+                response_text = response.text
             try:
                 from bs4 import BeautifulSoup
-                soup = BeautifulSoup(response.content, 'html.parser')
+                soup = BeautifulSoup(response_content, 'html.parser')
                 for script in soup(["script", "style", "meta", "link", "noscript"]):
                     script.decompose()
                 title = ""
@@ -104,7 +108,7 @@ class FetchWebPageTool(Tool):
                 context.user_print("✅ Page content fetched.")
                 return ToolExecutionResult(success=True, reply_text=reply_text)
             except ImportError:
-                text = response.text[:10000]
+                text = response_text[:10000]
                 reply_text = f"**URL:** {url}\n**Raw Content:**\n{text}"
                 debug_log("fetchWebPage: BeautifulSoup not available, returning raw text", "web")
                 context.user_print("✅ Page content fetched (raw).")

--- a/src/jarvis/tools/external/mcp_client.py
+++ b/src/jarvis/tools/external/mcp_client.py
@@ -90,6 +90,37 @@ def _resolve_command(command: str) -> str:
     )
 
 
+class _StdioConnection:
+    """Async context manager that wraps a ``stdio_client`` session AND
+    owns the ``/dev/null`` file used to suppress the MCP server's stderr.
+
+    The wrapped context manager is built synchronously by
+    ``MCPClient._connect_stdio`` so existing call sites and tests that
+    construct a connection eagerly continue to work. The wrapper's job
+    is to close the devnull handle when the async context exits,
+    regardless of how the inner context terminates. Without this the
+    devnull handle leaked once per ``_session`` call (i.e. every MCP
+    tool invocation), eventually exhausting the process FD limit on
+    long-running daemons.
+    """
+
+    def __init__(self, inner_cm, errlog) -> None:
+        self._cm = inner_cm
+        self._errlog = errlog
+
+    async def __aenter__(self):
+        return await self._cm.__aenter__()
+
+    async def __aexit__(self, exc_type, exc, tb):
+        try:
+            return await self._cm.__aexit__(exc_type, exc, tb)
+        finally:
+            try:
+                self._errlog.close()
+            except Exception:
+                pass
+
+
 class MCPClient:
     """Lightweight manager to connect to external MCP servers and call tools."""
 
@@ -97,6 +128,14 @@ class MCPClient:
         self.server_configs: Dict[str, Dict[str, Any]] = mcps_config or {}
 
     def _connect_stdio(self, server_cfg: Dict[str, Any]):
+        """Build an async context manager for the stdio transport.
+
+        Returns an ``_StdioConnection`` that owns both the stdio_client
+        session and the ``/dev/null`` handle used to silence the server
+        subprocess's stderr. Path resolution and PATH injection happen
+        synchronously here so any ``FileNotFoundError`` surfaces at the
+        call site, before the ``async with`` block.
+        """
         command = str(server_cfg.get("command"))
         # Windows compatibility: prefer npx.cmd when requested
         if os.name == "nt" and command.lower() == "npx":
@@ -124,7 +163,16 @@ class MCPClient:
         # from polluting the daemon's log output.
         # Must use a real file (not StringIO) because the subprocess needs fileno().
         devnull = open(os.devnull, "w")
-        return stdio_client(params, errlog=devnull)
+        # Build the underlying transport CM eagerly so any synchronous
+        # construction error closes devnull instead of leaking it. The
+        # wrapper guarantees the handle is also closed on every async
+        # exit path — this is the actual leak fix.
+        try:
+            inner = stdio_client(params, errlog=devnull)
+        except Exception:
+            devnull.close()
+            raise
+        return _StdioConnection(inner, errlog=devnull)
 
     @asynccontextmanager
     async def _session(self, server_name: str):

--- a/tests/test_dialogue_memory_hot_cache.py
+++ b/tests/test_dialogue_memory_hot_cache.py
@@ -64,6 +64,49 @@ class TestHotCachePrimitives:
 
 
 @pytest.mark.unit
+class TestHotCacheLRUCap:
+    """The hot cache must not grow without bound. Per-query keys (router
+    output, enrichment extractor output) are unique per turn, so a long
+    session would otherwise accumulate one entry per unique query.
+    """
+
+    def test_size_never_exceeds_cap(self):
+        dm = DialogueMemory()
+        cap = dm.HOT_CACHE_MAX_ENTRIES
+        for i in range(cap + 50):
+            dm.hot_cache_put(f"key:{i}", i)
+        assert len(dm._hot_cache) == cap
+
+    def test_least_recently_used_entry_evicted_first(self):
+        dm = DialogueMemory()
+        cap = dm.HOT_CACHE_MAX_ENTRIES
+        # Fill exactly to cap.
+        for i in range(cap):
+            dm.hot_cache_put(f"k{i}", i)
+        # Touch the oldest entry so it becomes most-recently-used.
+        assert dm.hot_cache_get("k0") == 0
+        # Inserting one more entry should evict the next-oldest (k1),
+        # NOT k0 since we just touched it.
+        dm.hot_cache_put("new", "v")
+        assert dm.hot_cache_get("k0") == 0
+        assert dm.hot_cache_get("k1") is None
+        assert dm.hot_cache_get("new") == "v"
+
+    def test_overwriting_existing_key_does_not_evict(self):
+        dm = DialogueMemory()
+        cap = dm.HOT_CACHE_MAX_ENTRIES
+        for i in range(cap):
+            dm.hot_cache_put(f"k{i}", i)
+        # Overwrite an existing entry — size should stay at cap, no
+        # entry should disappear.
+        dm.hot_cache_put("k0", "updated")
+        assert len(dm._hot_cache) == cap
+        assert dm.hot_cache_get("k0") == "updated"
+        # The other keys are still present.
+        assert dm.hot_cache_get(f"k{cap - 1}") == cap - 1
+
+
+@pytest.mark.unit
 class TestNextTsMonotonic:
     """``_next_ts`` exists because ``time.time()`` has ~16ms granularity
     on Windows and consecutive calls can return identical values. Without

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -203,7 +203,15 @@ def test_fetch_web_page_success(monkeypatch):
         
         def raise_for_status(self):
             pass
-    
+
+        # The production tool wraps the response in ``with requests.get(...)``
+        # so the connection is released deterministically — mirror that here.
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
     def mock_requests_get(url, **kwargs):
         return MockResponse()
     

--- a/tests/tools/builtin/test_fetch_web_page.py
+++ b/tests/tools/builtin/test_fetch_web_page.py
@@ -9,6 +9,17 @@ from src.jarvis.tools.base import ToolContext
 from src.jarvis.tools.types import ToolExecutionResult
 
 
+def _make_response_mock(**attrs) -> Mock:
+    """Build a Mock that doubles as both the requests response and a context
+    manager (the production code uses ``with requests.get(...) as resp`` so
+    the connection is released deterministically).
+    """
+    resp = Mock(**attrs)
+    resp.__enter__ = Mock(return_value=resp)
+    resp.__exit__ = Mock(return_value=False)
+    return resp
+
+
 class TestFetchWebPageTool:
     """Test fetch web page tool functionality."""
 
@@ -45,12 +56,13 @@ class TestFetchWebPageTool:
     @patch('requests.get')
     def test_run_success(self, mock_get):
         """Test successful web page fetch."""
-        mock_response = Mock()
-        mock_response.status_code = 200
-        mock_response.text = '<html><head><title>Test</title></head><body><p>Content</p></body></html>'
-        mock_response.content = b'<html><head><title>Test</title></head><body><p>Content</p></body></html>'
-        mock_response.headers = {'content-type': 'text/html'}
-        mock_response.raise_for_status = Mock()  # Add this to prevent errors
+        mock_response = _make_response_mock(
+            status_code=200,
+            text='<html><head><title>Test</title></head><body><p>Content</p></body></html>',
+            content=b'<html><head><title>Test</title></head><body><p>Content</p></body></html>',
+            headers={'content-type': 'text/html'},
+            raise_for_status=Mock(),
+        )
         mock_get.return_value = mock_response
 
         args = {"url": "https://example.com"}
@@ -64,11 +76,13 @@ class TestFetchWebPageTool:
     @patch('requests.get')
     def test_run_success_without_beautifulsoup(self, mock_get):
         """Test successful web page fetch without BeautifulSoup."""
-        mock_response = Mock()
-        mock_response.status_code = 200
-        mock_response.text = '<html><body>Raw content</body></html>'
-        mock_response.headers = {'content-type': 'text/html'}
-        mock_response.raise_for_status = Mock()
+        mock_response = _make_response_mock(
+            status_code=200,
+            text='<html><body>Raw content</body></html>',
+            content=b'<html><body>Raw content</body></html>',
+            headers={'content-type': 'text/html'},
+            raise_for_status=Mock(),
+        )
         mock_get.return_value = mock_response
 
         with patch('builtins.__import__', side_effect=ImportError):
@@ -82,8 +96,7 @@ class TestFetchWebPageTool:
     @patch('requests.get')
     def test_run_http_error(self, mock_get):
         """Test fetch web page with HTTP error."""
-        mock_response = Mock()
-        mock_response.status_code = 404
+        mock_response = _make_response_mock(status_code=404)
         mock_response.raise_for_status.side_effect = requests.exceptions.HTTPError("404 Not Found")
         mock_get.return_value = mock_response
 
@@ -125,11 +138,12 @@ class TestFetchWebPageTool:
             '<a href="mailto:test@example.com">Mail</a>'
             '</body></html>'
         )
-        mock_response = Mock()
-        mock_response.status_code = 200
-        mock_response.text = html
-        mock_response.content = html.encode()
-        mock_response.raise_for_status = Mock()
+        mock_response = _make_response_mock(
+            status_code=200,
+            text=html,
+            content=html.encode(),
+            raise_for_status=Mock(),
+        )
         mock_get.return_value = mock_response
 
         args = {"url": "https://example.com", "include_links": True}


### PR DESCRIPTION
## Summary

Audit of long-running daemon hot paths surfaced four real memory/FD growth paths. Each fix is small and mechanical:

- **`mcp_client._connect_stdio`** — `open(os.devnull, "w")` was passed to `stdio_client(..., errlog=...)` but never closed. Wrapped the transport in a small async context manager that owns the file and closes it on every exit path. Per-MCP-call FD leak.
- **`llm.call_llm_streaming` (and siblings)** — `requests.post(..., stream=True)` was not in a `with`, so an aborted `iter_lines` pinned the TCP connection until GC. All three `requests.post` callsites in this module now use `with`.
- **`fetch_web_page.run`** — same pattern, `requests.get(...)` is now `with requests.get(...)` so a BeautifulSoup or link-extraction exception doesn't strand the connection.
- **`DialogueMemory._hot_cache`** — keys are query-dependent (e.g. `router:<redacted>|...|`, `enrichment:<...>`), so unique queries in one long conversation accumulated forever. Switched to an LRU-bounded `OrderedDict` capped at 128 entries with access-bumping on read; existing invalidation hooks (`clear_hot_cache`, `invalidate_warm_profile`, new-conversation reset) are unchanged.

False positives from the initial audit that I verified are **not** leaks and were intentionally left alone:
- `_mcp_tools_cache` is fully reassigned (not appended to) on each refresh.
- The desktop_app Flask thread is `daemon=True`, reaped by the OS on exit.
- `transcript_buffer` already prunes by `max_duration_sec`.
- `dictation_history`'s QTimer is properly start/stop'd in `showEvent` / `hideEvent`.
- `_MUTATION_LISTENERS` dedupes registration; `daemon.py` already unregisters on re-entry.

## Test plan

- [x] New `TestHotCacheLRUCap` (3 tests): size cap, LRU eviction (touched key survives), overwrite doesn't evict.
- [x] Updated mocks in `test_fetch_web_page.py` and `test_tools.py` to support the context-manager protocol the production code now uses.
- [x] 136 targeted tests across `test_dialogue_memory_hot_cache`, `test_mcp_client`, `tools/builtin/test_fetch_web_page`, `test_tools`, `test_settings_window`, `test_setup_wizard` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)