### PR TITLE
feat(updater): show full changelog since current version with accordion UI

### DIFF
--- a/src/desktop_app/update_dialog.py
+++ b/src/desktop_app/update_dialog.py
@@ -42,22 +42,22 @@ from .updater import (
 # Changelog parsing
 # ---------------------------------------------------------------------------
 
-_CATEGORY_MAP: dict[str, tuple[str, str, int]] = {
-    "feat":     ("✨", "New Features",  0),
-    "feature":  ("✨", "New Features",  0),
-    "fix":      ("🐛", "Bug Fixes",     1),
-    "perf":     ("⚡", "Performance",   2),
-    "refactor": ("♻️", "Improvements",  3),
-    "improve":  ("♻️", "Improvements",  3),
-    "security": ("🔒", "Security",      4),
-    "docs":     ("📝", "Documentation", 5),
-    "chore":    ("🔧", "Maintenance",   6),
-    "ci":       ("🔧", "Maintenance",   6),
-    "build":    ("🔧", "Maintenance",   6),
-    "deps":     ("🔧", "Maintenance",   6),
-    "test":     ("🧪", "Testing",       7),
-    "style":    ("🎨", "Style",         8),
-    "revert":   ("⏪", "Reverts",       9),
+_CATEGORY_MAP: dict[str, tuple[str, str]] = {
+    "feat":     ("✨", "New Features"),
+    "feature":  ("✨", "New Features"),
+    "fix":      ("🐛", "Bug Fixes"),
+    "perf":     ("⚡", "Performance"),
+    "refactor": ("♻️", "Improvements"),
+    "improve":  ("♻️", "Improvements"),
+    "security": ("🔒", "Security"),
+    "docs":     ("📝", "Documentation"),
+    "chore":    ("🔧", "Maintenance"),
+    "ci":       ("🔧", "Maintenance"),
+    "build":    ("🔧", "Maintenance"),
+    "deps":     ("🔧", "Maintenance"),
+    "test":     ("🧪", "Testing"),
+    "style":    ("🎨", "Style"),
+    "revert":   ("⏪", "Reverts"),
 }
 
 _CATEGORY_ORDER = [
@@ -66,7 +66,7 @@ _CATEGORY_ORDER = [
     "Reverts", "Changes",
 ]
 
-_DEFAULT_CATEGORY = ("📋", "Changes", 10)
+_DEFAULT_CATEGORY = ("📋", "Changes")
 
 
 @dataclass
@@ -84,7 +84,7 @@ def _detect_category(raw: str) -> tuple[str, str, str]:
         ctype = m.group(1).lower()
         clean = m.group(2).strip()
         if ctype in _CATEGORY_MAP:
-            emoji, name, _ = _CATEGORY_MAP[ctype]
+            emoji, name = _CATEGORY_MAP[ctype]
             return emoji, name, clean
     return _DEFAULT_CATEGORY[0], _DEFAULT_CATEGORY[1], raw.strip()
 
@@ -308,6 +308,7 @@ class _VersionCard(QFrame):
                     row.addWidget(bullet)
 
                     text_lbl = QLabel(entry.text)
+                    text_lbl.setTextFormat(Qt.TextFormat.PlainText)
                     text_lbl.setWordWrap(True)
                     text_lbl.setSizePolicy(
                         QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Preferred

--- a/src/desktop_app/update_dialog.py
+++ b/src/desktop_app/update_dialog.py
@@ -4,13 +4,16 @@ Update notification and download progress dialogs.
 
 from __future__ import annotations
 
+import re
 import shutil
 import tempfile
 import webbrowser
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
 
 from PyQt6.QtCore import Qt, QTimer
+from PyQt6.QtGui import QCursor
 from PyQt6.QtWidgets import (
     QDialog,
     QFrame,
@@ -19,8 +22,10 @@ from PyQt6.QtWidgets import (
     QMessageBox,
     QProgressBar,
     QPushButton,
-    QTextEdit,
+    QScrollArea,
+    QSizePolicy,
     QVBoxLayout,
+    QWidget,
 )
 
 from .themes import COLORS, JARVIS_THEME_STYLESHEET
@@ -33,6 +38,352 @@ from .updater import (
     save_installed_asset_id,
 )
 
+# ---------------------------------------------------------------------------
+# Changelog parsing
+# ---------------------------------------------------------------------------
+
+_CATEGORY_MAP: dict[str, tuple[str, str, int]] = {
+    "feat":     ("✨", "New Features",  0),
+    "feature":  ("✨", "New Features",  0),
+    "fix":      ("🐛", "Bug Fixes",     1),
+    "perf":     ("⚡", "Performance",   2),
+    "refactor": ("♻️", "Improvements",  3),
+    "improve":  ("♻️", "Improvements",  3),
+    "security": ("🔒", "Security",      4),
+    "docs":     ("📝", "Documentation", 5),
+    "chore":    ("🔧", "Maintenance",   6),
+    "ci":       ("🔧", "Maintenance",   6),
+    "build":    ("🔧", "Maintenance",   6),
+    "deps":     ("🔧", "Maintenance",   6),
+    "test":     ("🧪", "Testing",       7),
+    "style":    ("🎨", "Style",         8),
+    "revert":   ("⏪", "Reverts",       9),
+}
+
+_CATEGORY_ORDER = [
+    "New Features", "Bug Fixes", "Performance", "Improvements",
+    "Security", "Documentation", "Maintenance", "Testing", "Style",
+    "Reverts", "Changes",
+]
+
+_DEFAULT_CATEGORY = ("📋", "Changes", 10)
+
+
+@dataclass
+class ChangelogEntry:
+    text: str
+    pr_number: Optional[int]
+    category_emoji: str
+    category_name: str
+
+
+def _detect_category(raw: str) -> tuple[str, str, str]:
+    """Return (emoji, category_name, cleaned_text) for a raw change line."""
+    m = re.match(r'^(\w+)(?:\([^)]+\))?!?\s*:\s*(.+)$', raw.strip(), re.IGNORECASE)
+    if m:
+        ctype = m.group(1).lower()
+        clean = m.group(2).strip()
+        if ctype in _CATEGORY_MAP:
+            emoji, name, _ = _CATEGORY_MAP[ctype]
+            return emoji, name, clean
+    return _DEFAULT_CATEGORY[0], _DEFAULT_CATEGORY[1], raw.strip()
+
+
+def parse_release_notes(notes: str) -> dict[str, list[ChangelogEntry]]:
+    """Parse GitHub release markdown into categorised changelog entries.
+
+    Handles both GitHub's auto-generated format
+    (``* fix(x): desc by @user in https://.../pull/NNN``) and manually
+    written conventional-commit bullets.  Returns an ordered dict keyed by
+    category name.
+    """
+    # Strip "Full Changelog" footer
+    notes = re.sub(r'\*\*Full Changelog\*\*.*$', '', notes, flags=re.MULTILINE).strip()
+
+    entries: list[ChangelogEntry] = []
+    for line in notes.splitlines():
+        line = line.strip()
+        if not re.match(r'^[*\-+]\s', line):
+            continue
+
+        text = line[2:].strip()
+
+        # GitHub auto-generated: "... by @user in https://.../pull/NNN"
+        m_gh = re.search(r'\s+by\s+@\w+\s+in\s+https?://\S+/pull/(\d+)\s*$', text)
+        if m_gh:
+            pr_number: Optional[int] = int(m_gh.group(1))
+            text = text[: m_gh.start()].strip()
+        else:
+            pr_number = None
+            # Plain attribution: "... by @user"
+            text = re.sub(r'\s+by\s+@\w+\s*$', '', text).strip()
+            # Inline PR ref: "... (#NNN)"
+            m_pr = re.search(r'\s*\(#(\d+)\)\s*$', text)
+            if m_pr:
+                pr_number = int(m_pr.group(1))
+                text = text[: m_pr.start()].strip()
+
+        if not text:
+            continue
+
+        emoji, cat_name, clean_text = _detect_category(text)
+        entries.append(ChangelogEntry(
+            text=clean_text,
+            pr_number=pr_number,
+            category_emoji=emoji,
+            category_name=cat_name,
+        ))
+
+    # Group preserving priority order
+    buckets: dict[str, list[ChangelogEntry]] = {}
+    for entry in entries:
+        buckets.setdefault(entry.category_name, []).append(entry)
+
+    return {name: buckets[name] for name in _CATEGORY_ORDER if name in buckets}
+
+
+# ---------------------------------------------------------------------------
+# Changelog widget
+# ---------------------------------------------------------------------------
+
+class _ClickableFrame(QFrame):
+    """QFrame that calls a Python callable on left-click."""
+
+    def __init__(self, on_click, parent=None):
+        super().__init__(parent)
+        self._on_click = on_click
+        self.setCursor(QCursor(Qt.CursorShape.PointingHandCursor))
+
+    def mousePressEvent(self, event):
+        if event.button() == Qt.MouseButton.LeftButton:
+            self._on_click()
+        super().mousePressEvent(event)
+
+
+class _VersionCard(QFrame):
+    """Collapsible card showing the changelog for one release version."""
+
+    def __init__(
+        self,
+        release: ReleaseInfo,
+        is_latest: bool,
+        expanded: bool,
+        parent=None,
+    ):
+        super().__init__(parent)
+        self._release = release
+        self._expanded = expanded
+        self._parsed = parse_release_notes(release.release_notes or "")
+        self._setup_ui(is_latest)
+
+    def _setup_ui(self, is_latest: bool) -> None:
+        self.setObjectName("card")
+        outer = QVBoxLayout(self)
+        outer.setSpacing(0)
+        outer.setContentsMargins(0, 0, 0, 0)
+
+        # Clickable header
+        header = _ClickableFrame(self._toggle)
+        header.setStyleSheet(f"""
+            QFrame {{
+                background-color: {COLORS['bg_card']};
+                border: 1px solid {COLORS['border']};
+                border-radius: 10px;
+            }}
+            QFrame:hover {{
+                background-color: {COLORS['bg_hover']};
+                border-color: {COLORS['border_glow']};
+            }}
+        """)
+        h_layout = QHBoxLayout(header)
+        h_layout.setContentsMargins(14, 10, 14, 10)
+        h_layout.setSpacing(8)
+
+        version_badge = QLabel(f" v{self._release.version} ")
+        version_badge.setStyleSheet(f"""
+            background-color: {COLORS['accent_glow']};
+            color: {COLORS['accent_secondary']};
+            border: 1px solid {COLORS['border_glow']};
+            border-radius: 4px;
+            font-size: 12px;
+            font-weight: 600;
+            padding: 2px 6px;
+        """)
+        h_layout.addWidget(version_badge)
+
+        name = self._release.name or ""
+        redundant = {self._release.tag_name, f"v{self._release.version}", self._release.version}
+        if name and name not in redundant:
+            name_label = QLabel(name)
+            name_label.setStyleSheet(
+                f"color: {COLORS['text_primary']}; font-size: 13px; background: transparent;"
+            )
+            h_layout.addWidget(name_label)
+
+        h_layout.addStretch()
+
+        if is_latest:
+            latest_badge = QLabel("  LATEST  ")
+            latest_badge.setStyleSheet(f"""
+                background-color: rgba(34, 197, 94, 0.12);
+                color: {COLORS['success']};
+                border: 1px solid rgba(34, 197, 94, 0.3);
+                border-radius: 4px;
+                font-size: 10px;
+                font-weight: 700;
+                padding: 2px 6px;
+            """)
+            h_layout.addWidget(latest_badge)
+
+        if self._release.prerelease:
+            dev_badge = QLabel("  DEV  ")
+            dev_badge.setStyleSheet(f"""
+                background-color: {COLORS['accent_glow']};
+                color: {COLORS['warning']};
+                border: 1px solid {COLORS['border_glow']};
+                border-radius: 4px;
+                font-size: 10px;
+                font-weight: 700;
+                padding: 2px 6px;
+            """)
+            h_layout.addWidget(dev_badge)
+
+        self._arrow = QLabel("▾" if self._expanded else "▸")
+        self._arrow.setStyleSheet(
+            f"color: {COLORS['text_muted']}; font-size: 14px; "
+            f"padding-left: 4px; background: transparent;"
+        )
+        h_layout.addWidget(self._arrow)
+
+        outer.addWidget(header)
+
+        # Collapsible content
+        self._content = QWidget()
+        self._content.setStyleSheet(f"""
+            QWidget {{
+                background-color: {COLORS['bg_secondary']};
+                border: 1px solid {COLORS['border']};
+                border-top: none;
+                border-bottom-left-radius: 10px;
+                border-bottom-right-radius: 10px;
+            }}
+        """)
+        c_layout = QVBoxLayout(self._content)
+        c_layout.setSpacing(4)
+        c_layout.setContentsMargins(16, 10, 16, 14)
+
+        if self._parsed:
+            first_cat = True
+            for cat_name, cat_entries in self._parsed.items():
+                if not cat_entries:
+                    continue
+
+                cat_row = QHBoxLayout()
+                cat_row.setContentsMargins(0, 0 if first_cat else 8, 0, 2)
+
+                emoji_lbl = QLabel(cat_entries[0].category_emoji)
+                emoji_lbl.setStyleSheet("font-size: 13px; background: transparent;")
+                cat_row.addWidget(emoji_lbl)
+
+                cat_lbl = QLabel(cat_name)
+                cat_lbl.setStyleSheet(
+                    f"color: {COLORS['text_primary']}; font-size: 12px; "
+                    f"font-weight: 600; background: transparent;"
+                )
+                cat_row.addWidget(cat_lbl)
+                cat_row.addStretch()
+                c_layout.addLayout(cat_row)
+                first_cat = False
+
+                for entry in cat_entries:
+                    row = QHBoxLayout()
+                    row.setContentsMargins(12, 0, 0, 0)
+                    row.setSpacing(6)
+
+                    bullet = QLabel("·")
+                    bullet.setFixedWidth(10)
+                    bullet.setStyleSheet(
+                        f"color: {COLORS['accent_muted']}; font-size: 14px; background: transparent;"
+                    )
+                    row.addWidget(bullet)
+
+                    text_lbl = QLabel(entry.text)
+                    text_lbl.setWordWrap(True)
+                    text_lbl.setSizePolicy(
+                        QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Preferred
+                    )
+                    text_lbl.setStyleSheet(
+                        f"color: {COLORS['text_secondary']}; font-size: 12px; background: transparent;"
+                    )
+                    row.addWidget(text_lbl, 1)
+
+                    if entry.pr_number:
+                        pr_lbl = QLabel(f"#{entry.pr_number}")
+                        pr_lbl.setStyleSheet(f"""
+                            color: {COLORS['text_muted']};
+                            background-color: {COLORS['bg_tertiary']};
+                            border-radius: 3px;
+                            font-size: 10px;
+                            padding: 1px 5px;
+                        """)
+                        row.addWidget(pr_lbl)
+
+                    c_layout.addLayout(row)
+        else:
+            placeholder = QLabel("No release notes available.")
+            placeholder.setStyleSheet(
+                f"color: {COLORS['text_muted']}; font-size: 12px; background: transparent;"
+            )
+            c_layout.addWidget(placeholder)
+
+        self._content.setVisible(self._expanded)
+        outer.addWidget(self._content)
+
+    def _toggle(self) -> None:
+        self._expanded = not self._expanded
+        self._content.setVisible(self._expanded)
+        self._arrow.setText("▾" if self._expanded else "▸")
+        # Tell the scroll-area container to recompute its size
+        p = self.parent()
+        while p:
+            if isinstance(p, QScrollArea):
+                p.widget().adjustSize()
+                break
+            p = p.parent()
+
+
+class ChangelogWidget(QScrollArea):
+    """Scrollable accordion list of version changelog cards."""
+
+    def __init__(self, releases: list[ReleaseInfo], parent=None):
+        super().__init__(parent)
+        self.setWidgetResizable(True)
+        self.setFrameShape(QFrame.Shape.NoFrame)
+        self.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+
+        container = QWidget()
+        container.setSizePolicy(
+            QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Preferred
+        )
+        layout = QVBoxLayout(container)
+        layout.setSpacing(6)
+        layout.setContentsMargins(0, 0, 4, 0)
+
+        for i, release in enumerate(releases):
+            card = _VersionCard(
+                release=release,
+                is_latest=(i == 0),
+                expanded=(i == 0),
+            )
+            layout.addWidget(card)
+
+        layout.addStretch()
+        self.setWidget(container)
+
+
+# ---------------------------------------------------------------------------
+# Main update dialog
+# ---------------------------------------------------------------------------
 
 class UpdateAvailableDialog(QDialog):
     """Dialog shown when an update is available."""
@@ -45,59 +396,71 @@ class UpdateAvailableDialog(QDialog):
 
     def _setup_ui(self):
         self.setWindowTitle("Update Available")
-        self.setMinimumSize(500, 450)
+        self.setMinimumSize(540, 520)
         self.setStyleSheet(JARVIS_THEME_STYLESHEET)
 
         layout = QVBoxLayout(self)
-        layout.setSpacing(16)
+        layout.setSpacing(14)
         layout.setContentsMargins(24, 24, 24, 24)
 
         # Title
         title = QLabel("Update Available")
         title.setObjectName("title")
         title.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        title.setStyleSheet(f"font-size: 20px; font-weight: 600; color: {COLORS['accent_secondary']};")
+        title.setStyleSheet(
+            f"font-size: 20px; font-weight: 600; color: {COLORS['accent_secondary']};"
+        )
         layout.addWidget(title)
 
-        # Version info card
-        version_frame = QFrame()
-        version_frame.setObjectName("card")
-        version_layout = QVBoxLayout(version_frame)
-        version_layout.setSpacing(8)
+        # Version + download-size row
+        info_frame = QFrame()
+        info_frame.setObjectName("card")
+        info_layout = QHBoxLayout(info_frame)
+        info_layout.setContentsMargins(14, 10, 14, 10)
 
-        current_label = QLabel(f"Current version: {self.status.current_version}")
-        current_label.setObjectName("subtitle")
-        version_layout.addWidget(current_label)
-
-        new_label = QLabel(f"New version: {self.release.version}")
-        new_label.setStyleSheet(f"color: {COLORS['success']}; font-weight: 500;")
-        version_layout.addWidget(new_label)
-
+        ver_col = QVBoxLayout()
+        ver_col.setSpacing(4)
+        current_lbl = QLabel(f"Current version:  {self.status.current_version}")
+        current_lbl.setObjectName("subtitle")
+        ver_col.addWidget(current_lbl)
+        new_lbl = QLabel(f"New version:  {self.release.version}")
+        new_lbl.setStyleSheet(f"color: {COLORS['success']}; font-weight: 500;")
+        ver_col.addWidget(new_lbl)
         if self.release.prerelease:
-            prerelease_label = QLabel("(Development Build)")
-            prerelease_label.setStyleSheet(f"color: {COLORS['warning']}; font-size: 11px;")
-            version_layout.addWidget(prerelease_label)
+            dev_lbl = QLabel("Development build")
+            dev_lbl.setStyleSheet(f"color: {COLORS['warning']}; font-size: 11px;")
+            ver_col.addWidget(dev_lbl)
+        info_layout.addLayout(ver_col)
 
-        layout.addWidget(version_frame)
+        info_layout.addStretch()
 
-        # Release notes section
-        notes_label = QLabel("What's New")
+        size_mb = self.release.asset_size / (1024 * 1024)
+        size_lbl = QLabel(f"{size_mb:.1f} MB")
+        size_lbl.setAlignment(Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignVCenter)
+        size_lbl.setStyleSheet(f"color: {COLORS['text_muted']}; font-size: 11px;")
+        info_layout.addWidget(size_lbl)
+
+        layout.addWidget(info_frame)
+
+        # Changelog section
+        releases = self.status.releases_since_current or (
+            [self.release] if self.release else []
+        )
+        section_title = (
+            f"Changes since v{self.status.current_version}"
+            if len(releases) > 1
+            else "What's New"
+        )
+        notes_label = QLabel(section_title)
         notes_label.setObjectName("section_title")
         layout.addWidget(notes_label)
 
-        notes_text = QTextEdit()
-        notes_text.setReadOnly(True)
-        notes_text.setMarkdown(self.release.release_notes or "No release notes available.")
-        notes_text.setMaximumHeight(180)
-        layout.addWidget(notes_text)
+        changelog = ChangelogWidget(releases)
+        changelog.setMinimumHeight(200)
+        changelog.setMaximumHeight(340)
+        layout.addWidget(changelog, 1)
 
-        # Size info
-        size_mb = self.release.asset_size / (1024 * 1024)
-        size_label = QLabel(f"Download size: {size_mb:.1f} MB")
-        size_label.setObjectName("subtitle")
-        layout.addWidget(size_label)
-
-        layout.addStretch()
+        layout.addStretch(0)
 
         # Buttons
         button_layout = QHBoxLayout()
@@ -123,11 +486,15 @@ class UpdateAvailableDialog(QDialog):
         webbrowser.open(self.release.html_url)
 
 
+# ---------------------------------------------------------------------------
+# Progress dialog
+# ---------------------------------------------------------------------------
+
 class UpdateProgressDialog(QDialog):
     """Dialog showing download and installation progress."""
 
     def __init__(self, release: ReleaseInfo, pre_install_callback=None, parent=None):
-        """Initialize the update progress dialog.
+        """Initialise the update progress dialog.
 
         Args:
             release: The release info to download and install.
@@ -161,20 +528,19 @@ class UpdateProgressDialog(QDialog):
         layout.setSpacing(16)
         layout.setContentsMargins(24, 24, 24, 24)
 
-        # Title
         self.title_label = QLabel("Downloading Update")
         self.title_label.setObjectName("title")
         self.title_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        self.title_label.setStyleSheet(f"font-size: 18px; font-weight: 600; color: {COLORS['accent_secondary']};")
+        self.title_label.setStyleSheet(
+            f"font-size: 18px; font-weight: 600; color: {COLORS['accent_secondary']};"
+        )
         layout.addWidget(self.title_label)
 
-        # Status
         self.status_label = QLabel("Preparing download...")
         self.status_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self.status_label.setObjectName("subtitle")
         layout.addWidget(self.status_label)
 
-        # Progress bar
         self.progress_bar = QProgressBar()
         self.progress_bar.setRange(0, 100)
         self.progress_bar.setValue(0)
@@ -184,7 +550,6 @@ class UpdateProgressDialog(QDialog):
 
         layout.addStretch()
 
-        # Cancel button
         self.cancel_btn = QPushButton("Cancel")
         self.cancel_btn.clicked.connect(self._cancel_download)
         layout.addWidget(self.cancel_btn, alignment=Qt.AlignmentFlag.AlignCenter)
@@ -207,7 +572,6 @@ class UpdateProgressDialog(QDialog):
         self.download_worker.start()
 
     def _cleanup_temp_dir(self):
-        """Clean up the temporary download directory."""
         if self._temp_dir and self._temp_dir.exists():
             try:
                 shutil.rmtree(self._temp_dir, ignore_errors=True)
@@ -219,41 +583,37 @@ class UpdateProgressDialog(QDialog):
         if total > 0:
             percent = int((downloaded / total) * 100)
             self.progress_bar.setValue(percent)
-
             downloaded_mb = downloaded / (1024 * 1024)
             total_mb = total / (1024 * 1024)
-            self.status_label.setText(f"Downloading: {downloaded_mb:.1f} / {total_mb:.1f} MB")
+            self.status_label.setText(
+                f"Downloading: {downloaded_mb:.1f} / {total_mb:.1f} MB"
+            )
 
     def _on_completed(self, path: str):
         self.cancel_btn.setEnabled(False)
 
-        # Run pre-install callback (e.g., save diary) before installing
         if self._pre_install_callback:
             self.title_label.setText("Preparing Update")
             self.status_label.setText("Saving your session...")
-            self.progress_bar.setRange(0, 0)  # Indeterminate
+            self.progress_bar.setRange(0, 0)
 
-            # Process events to show the status update
             from PyQt6.QtWidgets import QApplication
             QApplication.processEvents()
 
             try:
                 self._pre_install_callback()
             except Exception as e:
-                # Log but don't fail the update if diary save fails
                 from jarvis.debug import debug_log
                 debug_log(f"Pre-install callback failed: {e}", "updater")
 
         self.title_label.setText("Installing Update")
         self.status_label.setText("Installing update...")
-        self.progress_bar.setRange(0, 0)  # Indeterminate
+        self.progress_bar.setRange(0, 0)
 
-        # Short delay before install
         QTimer.singleShot(500, lambda: self._install(Path(path)))
 
     def _install(self, download_path: Path):
         if install_update(download_path):
-            # Save the asset ID so we don't prompt again for this version
             save_installed_asset_id(self.release.asset_id)
 
             self.title_label.setText("Update Complete")
@@ -262,7 +622,6 @@ class UpdateProgressDialog(QDialog):
             self.progress_bar.setRange(0, 100)
             self.progress_bar.setValue(100)
 
-            # App will be relaunched by installer, exit current
             QTimer.singleShot(1500, lambda: self.done(QDialog.DialogCode.Accepted))
         else:
             self._on_error("Installation failed. Please try again or update manually.")
@@ -275,14 +634,12 @@ class UpdateProgressDialog(QDialog):
         self.progress_bar.setValue(0)
         self.cancel_btn.setText("Close")
         self.cancel_btn.setEnabled(True)
-        # Clean up temp directory on error
         self._cleanup_temp_dir()
 
     def _cancel_download(self):
         if self.download_worker and self.download_worker.isRunning():
             self.download_worker.cancel()
             self.download_worker.wait()
-        # Clean up temp directory when cancelled
         self._cleanup_temp_dir()
         self.reject()
 
@@ -290,6 +647,10 @@ class UpdateProgressDialog(QDialog):
         self._cancel_download()
         event.accept()
 
+
+# ---------------------------------------------------------------------------
+# Utility dialogs
+# ---------------------------------------------------------------------------
 
 def show_no_update_dialog(current_version: str, parent=None) -> None:
     """Show a dialog indicating no updates are available."""

--- a/src/desktop_app/update_dialog.py
+++ b/src/desktop_app/update_dialog.py
@@ -259,8 +259,9 @@ class _VersionCard(QFrame):
 
         # Collapsible content
         self._content = QWidget()
+        self._content.setObjectName("version_content")
         self._content.setStyleSheet(f"""
-            QWidget {{
+            QWidget#version_content {{
                 background-color: {COLORS['bg_secondary']};
                 border: 1px solid {COLORS['border']};
                 border-top: none;

--- a/src/desktop_app/updater.py
+++ b/src/desktop_app/updater.py
@@ -243,6 +243,7 @@ def check_for_updates(channel: Optional[UpdateChannel] = None) -> UpdateStatus:
     try:
         response = requests.get(
             GITHUB_API_URL,
+            params={"per_page": 100},
             headers={"Accept": "application/vnd.github.v3+json"},
             timeout=10,
         )

--- a/src/desktop_app/updater.py
+++ b/src/desktop_app/updater.py
@@ -13,7 +13,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
 from typing import Optional
@@ -173,6 +173,7 @@ class UpdateStatus:
     current_version: str
     current_channel: str
     latest_release: Optional[ReleaseInfo]
+    releases_since_current: list[ReleaseInfo] = field(default_factory=list)
     error: Optional[str] = None
 
 
@@ -206,6 +207,21 @@ def parse_version(tag: str) -> tuple[int, ...]:
         return (0, 0, 0)
 
 
+def _make_release_info(release: dict, asset: dict) -> ReleaseInfo:
+    return ReleaseInfo(
+        asset_id=asset["id"],
+        tag_name=release["tag_name"],
+        version=release["tag_name"].lstrip("v"),
+        name=release.get("name", release["tag_name"]),
+        prerelease=release.get("prerelease", False),
+        html_url=release["html_url"],
+        download_url=asset["browser_download_url"],
+        asset_name=asset["name"],
+        asset_size=asset["size"],
+        release_notes=release.get("body", ""),
+    )
+
+
 def check_for_updates(channel: Optional[UpdateChannel] = None) -> UpdateStatus:
     """Check GitHub Releases for available updates.
 
@@ -233,41 +249,57 @@ def check_for_updates(channel: Optional[UpdateChannel] = None) -> UpdateStatus:
         response.raise_for_status()
         releases = response.json()
 
-        target_release = None
         platform_asset_name = get_platform_asset_name()
 
-        for release in releases:
-            if release.get("draft", False):
-                continue
-
-            if channel == UpdateChannel.STABLE and release.get("prerelease", False):
-                continue
-
-            if channel == UpdateChannel.DEVELOP:
+        if channel == UpdateChannel.DEVELOP:
+            target_release = None
+            for release in releases:
+                if release.get("draft", False):
+                    continue
                 if release.get("tag_name") != "latest":
                     continue
-
-            assets = release.get("assets", [])
-            for asset in assets:
-                if asset["name"] == platform_asset_name:
-                    target_release = ReleaseInfo(
-                        asset_id=asset["id"],
-                        tag_name=release["tag_name"],
-                        version=release["tag_name"].lstrip("v"),
-                        name=release.get("name", release["tag_name"]),
-                        prerelease=release.get("prerelease", False),
-                        html_url=release["html_url"],
-                        download_url=asset["browser_download_url"],
-                        asset_name=asset["name"],
-                        asset_size=asset["size"],
-                        release_notes=release.get("body", ""),
-                    )
+                for asset in release.get("assets", []):
+                    if asset["name"] == platform_asset_name:
+                        target_release = _make_release_info(release, asset)
+                        break
+                if target_release:
                     break
 
-            if target_release:
-                break
+            if not target_release:
+                return UpdateStatus(
+                    update_available=False,
+                    current_version=current_version,
+                    current_channel=current_channel,
+                    latest_release=None,
+                )
 
-        if not target_release:
+            last_installed_id = get_last_installed_asset_id()
+            update_available = (
+                last_installed_id is None
+                or target_release.asset_id != last_installed_id
+            )
+            return UpdateStatus(
+                update_available=update_available,
+                current_version=current_version,
+                current_channel=current_channel,
+                latest_release=target_release,
+                releases_since_current=[target_release] if update_available else [],
+            )
+
+        # STABLE: collect every release newer than the current version so the
+        # dialog can show a full changelog spanning multiple skipped versions.
+        current_tuple = parse_version(current_version)
+        newer_releases: list[ReleaseInfo] = []
+        for release in releases:
+            if release.get("draft", False) or release.get("prerelease", False):
+                continue
+            for asset in release.get("assets", []):
+                if asset["name"] == platform_asset_name:
+                    if parse_version(release["tag_name"]) > current_tuple:
+                        newer_releases.append(_make_release_info(release, asset))
+                    break  # found the platform asset for this release
+
+        if not newer_releases:
             return UpdateStatus(
                 update_available=False,
                 current_version=current_version,
@@ -275,24 +307,12 @@ def check_for_updates(channel: Optional[UpdateChannel] = None) -> UpdateStatus:
                 latest_release=None,
             )
 
-        if channel == UpdateChannel.DEVELOP:
-            # For develop channel, compare asset IDs to detect new builds
-            # (release ID stays the same when "latest" is updated, but asset IDs change)
-            last_installed_id = get_last_installed_asset_id()
-            update_available = (
-                last_installed_id is None
-                or target_release.asset_id != last_installed_id
-            )
-        else:
-            current_tuple = parse_version(current_version)
-            latest_tuple = parse_version(target_release.tag_name)
-            update_available = latest_tuple > current_tuple
-
         return UpdateStatus(
-            update_available=update_available,
+            update_available=True,
             current_version=current_version,
             current_channel=current_channel,
-            latest_release=target_release,
+            latest_release=newer_releases[0],
+            releases_since_current=newer_releases,
         )
 
     except requests.RequestException as e:

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -305,6 +305,7 @@ class TestCheckForUpdates:
                             status = check_for_updates()
                             assert status.update_available is True
                             assert status.latest_release.asset_id == 200001
+                            assert status.releases_since_current == [status.latest_release]
 
     @pytest.mark.unit
     def test_develop_channel_shows_update_when_asset_id_differs(self):

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -400,6 +400,178 @@ class TestUpdateStatus:
         assert status.current_version == "0.9.0"
         assert status.latest_release.version == "1.0.0"
 
+    @pytest.mark.unit
+    def test_releases_since_current_defaults_to_empty_list(self):
+        status = UpdateStatus(
+            update_available=False,
+            current_version="1.0.0",
+            current_channel="stable",
+            latest_release=None,
+        )
+        assert status.releases_since_current == []
+
+    @pytest.mark.unit
+    def test_collects_all_releases_since_current_version(self):
+        """Stable channel should return every release newer than the installed version."""
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json.return_value = [
+            {
+                "id": 3,
+                "tag_name": "v1.3.0",
+                "name": "v1.3.0",
+                "draft": False,
+                "prerelease": False,
+                "html_url": "https://example.com/v1.3.0",
+                "body": "* feat: feature three (#3)",
+                "assets": [{"id": 300, "name": "Jarvis-macOS-arm64.zip",
+                            "browser_download_url": "https://example.com/dl3", "size": 1000}],
+            },
+            {
+                "id": 2,
+                "tag_name": "v1.2.0",
+                "name": "v1.2.0",
+                "draft": False,
+                "prerelease": False,
+                "html_url": "https://example.com/v1.2.0",
+                "body": "* fix: bug two (#2)",
+                "assets": [{"id": 200, "name": "Jarvis-macOS-arm64.zip",
+                            "browser_download_url": "https://example.com/dl2", "size": 1000}],
+            },
+            {
+                "id": 1,
+                "tag_name": "v1.0.0",
+                "name": "v1.0.0",
+                "draft": False,
+                "prerelease": False,
+                "html_url": "https://example.com/v1.0.0",
+                "body": "* Initial release",
+                "assets": [{"id": 100, "name": "Jarvis-macOS-arm64.zip",
+                            "browser_download_url": "https://example.com/dl1", "size": 1000}],
+            },
+        ]
+
+        with patch("desktop_app.updater.get_version", return_value=("1.0.0", "stable")):
+            with patch("requests.get", return_value=mock_response):
+                with patch("sys.platform", "darwin"):
+                    with patch("platform.machine", return_value="arm64"):
+                        status = check_for_updates()
+                        assert status.update_available is True
+                        assert status.latest_release.version == "1.3.0"
+                        assert len(status.releases_since_current) == 2
+                        assert status.releases_since_current[0].version == "1.3.0"
+                        assert status.releases_since_current[1].version == "1.2.0"
+
+    @pytest.mark.unit
+    def test_releases_since_current_empty_when_no_update(self):
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json.return_value = [
+            {
+                "id": 1,
+                "tag_name": "v1.0.0",
+                "name": "v1.0.0",
+                "draft": False,
+                "prerelease": False,
+                "html_url": "https://example.com/v1.0.0",
+                "body": "",
+                "assets": [{"id": 100, "name": "Jarvis-macOS-arm64.zip",
+                            "browser_download_url": "https://example.com/dl1", "size": 1000}],
+            },
+        ]
+
+        with patch("desktop_app.updater.get_version", return_value=("1.0.0", "stable")):
+            with patch("requests.get", return_value=mock_response):
+                with patch("sys.platform", "darwin"):
+                    with patch("platform.machine", return_value="arm64"):
+                        status = check_for_updates()
+                        assert status.update_available is False
+                        assert status.releases_since_current == []
+
+
+class TestChangelogParsing:
+    """Tests for release notes parsing."""
+
+    @pytest.mark.unit
+    def test_parse_empty_notes_returns_empty_dict(self):
+        from desktop_app.update_dialog import parse_release_notes
+        assert parse_release_notes("") == {}
+
+    @pytest.mark.unit
+    def test_parse_feat_commit_goes_to_new_features(self):
+        from desktop_app.update_dialog import parse_release_notes
+        result = parse_release_notes("* feat(memory): add tag optimisation (#327)")
+        assert "New Features" in result
+        assert len(result["New Features"]) == 1
+        assert result["New Features"][0].text == "add tag optimisation"
+        assert result["New Features"][0].pr_number == 327
+
+    @pytest.mark.unit
+    def test_parse_fix_commit_goes_to_bug_fixes(self):
+        from desktop_app.update_dialog import parse_release_notes
+        result = parse_release_notes(
+            "* fix(listener): show city placeholder when GeoLite2 DB is missing (#331)"
+        )
+        assert "Bug Fixes" in result
+        assert "show city placeholder" in result["Bug Fixes"][0].text
+        assert result["Bug Fixes"][0].pr_number == 331
+
+    @pytest.mark.unit
+    def test_parse_strips_by_attribution(self):
+        from desktop_app.update_dialog import parse_release_notes
+        result = parse_release_notes("* fix: some fix by @someuser")
+        assert "Bug Fixes" in result
+        assert "@someuser" not in result["Bug Fixes"][0].text
+
+    @pytest.mark.unit
+    def test_parse_strips_full_changelog_footer(self):
+        from desktop_app.update_dialog import parse_release_notes
+        notes = (
+            "* feat: new feature (#1)\n\n"
+            "**Full Changelog**: https://github.com/owner/repo/compare/v1.0...v1.1"
+        )
+        result = parse_release_notes(notes)
+        total = sum(len(v) for v in result.values())
+        assert total == 1
+
+    @pytest.mark.unit
+    def test_parse_unknown_prefix_goes_to_changes(self):
+        from desktop_app.update_dialog import parse_release_notes
+        result = parse_release_notes("* Some change without prefix")
+        assert "Changes" in result
+
+    @pytest.mark.unit
+    def test_parse_categories_ordered_feat_before_fix_before_maintenance(self):
+        from desktop_app.update_dialog import parse_release_notes
+        notes = "* chore: update deps (#1)\n* feat: new thing (#2)\n* fix: bug fix (#3)"
+        result = parse_release_notes(notes)
+        keys = list(result.keys())
+        assert keys.index("New Features") < keys.index("Bug Fixes") < keys.index("Maintenance")
+
+    @pytest.mark.unit
+    def test_parse_github_auto_generated_format(self):
+        """GitHub auto-generated notes use 'by @user in https://.../pull/NNN' format."""
+        from desktop_app.update_dialog import parse_release_notes
+        notes = (
+            "## What's Changed\n"
+            "* fix(something): description by @contributor "
+            "in https://github.com/owner/repo/pull/123\n\n"
+            "**Full Changelog**: https://github.com/owner/repo/compare/v1.0...v1.1"
+        )
+        result = parse_release_notes(notes)
+        assert "Bug Fixes" in result
+        entry = result["Bug Fixes"][0]
+        assert "@contributor" not in entry.text
+        assert "https://" not in entry.text
+        assert entry.pr_number == 123
+
+    @pytest.mark.unit
+    def test_parse_dash_bullets(self):
+        from desktop_app.update_dialog import parse_release_notes
+        result = parse_release_notes("- feat: a feature\n- fix: a fix")
+        assert "New Features" in result
+        assert "Bug Fixes" in result
+
 
 class TestReleaseInfo:
     """Tests for ReleaseInfo dataclass."""


### PR DESCRIPTION
## Summary

- The update dialog now fetches **all stable releases** newer than the installed version (up to 100 via `per_page=100`), so users who skipped versions see everything they missed
- Introduces `parse_release_notes()` — an intelligent parser for GitHub release markdown that strips attributions, footers, and PR refs, then groups entries by conventional-commit category (✨ New Features, 🐛 Bug Fixes, ♻️ Improvements, etc.) with emoji headers and PR badges
- Replaces the raw `QTextEdit` dump with a beautiful **accordion `ChangelogWidget`**: each version is a collapsible card; the latest is expanded by default, older ones collapsed to save space; clicking the header toggles content
- When multiple versions are present the section heading changes from "What's New" to "Changes since v{current_version}"
- Changelog entry labels use `Qt.TextFormat.PlainText` to prevent cosmetic HTML rendering of untrusted release note text

## Test plan

- [x] All 12 new unit tests in `TestUpdateStatus` / `TestChangelogParsing` pass
- [x] `parse_release_notes` correctly handles GitHub auto-generated format (`by @user in https://.../pull/NNN`), plain conventional-commit bullets, `**Full Changelog**` footer stripping, and unknown prefixes (fall back to "Changes")
- [x] `check_for_updates()` on stable channel returns all releases newer than current in `releases_since_current`
- [x] `UpdateStatus.releases_since_current` defaults to `[]` (backwards compatible)
- [x] Develop channel populates `releases_since_current` correctly (asserted in test)
- [x] Dialog renders correctly with a single version (existing behaviour preserved)
- [x] Dialog renders correctly with multiple skipped versions (accordion with collapse/expand)

🤖 Generated with [Claude Code](https://claude.com/claude-code)