### PR TITLE
fix(web_search): print DDG failure reason before fallback fires

### DIFF
--- a/src/jarvis/tools/builtin/web_search.py
+++ b/src/jarvis/tools/builtin/web_search.py
@@ -704,6 +704,21 @@ class WebSearchTool(Tool):
             except Exception as ddg_error:
                 debug_log(f"DuckDuckGo search failed: {ddg_error}", "web")
 
+            # Log DDG outcome immediately — field-triage must see why we're
+            # falling back regardless of whether a subsequent provider rescues
+            # the query. The spec requires the 🚧 bot-challenge line to fire
+            # even when Wikipedia then succeeds (spec §Progress messages).
+            # The ⚠️ no-results line fills the equivalent gap for the zero-
+            # result case, which previously produced no output between
+            # "🌐 Searching…" and "📚 Searching Wikipedia…".
+            if ddg_rate_limited and not instant_results:
+                context.user_print(
+                    "🚧 DuckDuckGo served a bot-challenge page — "
+                    "search blocked, no results retrieved."
+                )
+            elif not result_urls and not instant_results:
+                context.user_print("⚠️ No DuckDuckGo results found.")
+
             # Auto-fetch content from top results to provide actual data.
             # Cascade through the first 3 results in PARALLEL under a shared
             # wall-clock cap. The original serial 3 × 8s design could block
@@ -1001,18 +1016,6 @@ class WebSearchTool(Tool):
                 elif used_source == "wikipedia":
                     context.user_print(
                         "✅ Answered via Wikipedia fallback."
-                    )
-                elif ddg_rate_limited and not instant_results:
-                    # A rate-limit page occasionally has a header link that
-                    # slips past the result filter; printing "Found 1 result"
-                    # over a bot-challenge page is actively misleading during
-                    # field triage. Surface the block directly instead.
-                    # (If we still got an instant answer from api.ddg.com —
-                    # a separate endpoint — we prefer the normal success
-                    # line below, since the user got a useful reply.)
-                    context.user_print(
-                        "🚧 DuckDuckGo served a bot-challenge page — "
-                        "search blocked, no results retrieved."
                     )
                 elif count_results > 0:
                     context.user_print(f"✅ Found {count_results} results.")

--- a/src/jarvis/tools/builtin/web_search.spec.md
+++ b/src/jarvis/tools/builtin/web_search.spec.md
@@ -179,10 +179,14 @@ field-triage which provider actually carried the reply.
 
 ### Progress messages
 
-The tool prints a progress line to the terminal before each provider attempt:
+The tool prints progress lines to the terminal as the pipeline advances:
 
-- DuckDuckGo: `🌐 Searching the web for '<query>'…`
-- Wikipedia: `📚 Searching Wikipedia (<lang>) for '<query>'…`
+- DuckDuckGo attempt start: `🌐 Searching the web for '<query>'…`
+- DDG returned a bot-challenge page: `🚧 DuckDuckGo served a bot-challenge page — search blocked, no results retrieved.`
+- DDG returned zero results (not rate-limited): `⚠️ No DuckDuckGo results found.`
+- Wikipedia fallback attempt: `📚 Searching Wikipedia (<lang>) for '<query>'…`
+
+The DDG failure lines (`🚧` / `⚠️`) are printed **immediately after the DDG block**, before fallbacks run, so field-triage can always see why the tool fell back regardless of whether a subsequent provider rescues the query. This is distinct from the final status line (`✅ Answered via Wikipedia fallback.`) which only fires when a provider succeeds.
 
 These are ephemeral stdout prints (`context.user_print`). They are not persisted, not logged to file, and not included in the tool result returned to the LLM.
 

--- a/tests/tools/builtin/test_web_search.py
+++ b/tests/tools/builtin/test_web_search.py
@@ -514,6 +514,91 @@ class TestWebSearchTool:
 
     @patch('src.jarvis.tools.builtin.web_search._wikipedia_summary')
     @patch('requests.get')
+    def test_bot_challenge_log_fires_even_when_wikipedia_rescues(
+        self, mock_get, mock_wiki
+    ):
+        """When DDG is bot-challenged AND Wikipedia successfully rescues the
+        query, the console must still print the bot-challenge warning AND the
+        Wikipedia success line — both, not just the latter.
+
+        Spec says (web_search.spec.md line 175-178): "Rate-limit detection
+        fires regardless of fallback availability: the 🚧 … line is printed
+        … even if a fallback then rescues the query."
+
+        The bug: the status block used elif, so used_source == "wikipedia"
+        fired first and silently swallowed the bot-challenge message.
+        """
+        self.context.cfg.brave_search_api_key = ""
+        self.context.cfg.wikipedia_fallback_enabled = True
+        instant = Mock()
+        instant.status_code = 200
+        instant.json.return_value = {}
+        instant.raise_for_status = Mock()
+        challenge = Mock()
+        challenge.status_code = 400
+        challenge.content = b'<div class="anomaly-modal"></div>'
+        mock_get.side_effect = [instant, challenge]
+        mock_wiki.return_value = (
+            "Some Topic",
+            "https://en.wikipedia.org/wiki/Some_Topic",
+            "Some topic is a thing.",
+        )
+
+        result = self.tool.run({"search_query": "some topic"}, self.context)
+
+        assert result.success is True
+        printed = "\n".join(call.args[0] for call in self.context.user_print.call_args_list)
+        # Bot-challenge line must appear even though Wikipedia rescued.
+        assert "bot-challenge" in printed.lower() or "blocked" in printed.lower()
+        # Wikipedia success line must also appear.
+        assert "wikipedia" in printed.lower()
+
+    @patch('src.jarvis.tools.builtin.web_search._wikipedia_summary')
+    @patch('requests.get')
+    def test_zero_ddg_results_logged_before_wikipedia_fallback(
+        self, mock_get, mock_wiki
+    ):
+        """When DDG returns zero results (not rate-limited) and Wikipedia
+        rescues, the console must print a 'no results' warning before the
+        Wikipedia search line so field-triage can see why we fell back.
+
+        Without this, the log shows:
+          🌐 Searching the web for 'local events for tomorrow'…
+          📚 Searching Wikipedia (en) for 'local events for tomorrow'…
+          ✅ Answered via Wikipedia fallback.
+
+        With no indication of what DDG found (or didn't find).
+        """
+        self.context.cfg.brave_search_api_key = ""
+        self.context.cfg.wikipedia_fallback_enabled = True
+        instant = Mock()
+        instant.status_code = 200
+        instant.json.return_value = {}
+        instant.raise_for_status = Mock()
+        # DDG returns HTTP 200 with no usable links.
+        empty_ddg = Mock()
+        empty_ddg.status_code = 200
+        empty_ddg.content = b'<html><body><p>No results found.</p></body></html>'
+        mock_get.side_effect = [instant, empty_ddg]
+        mock_wiki.return_value = (
+            "Local Events",
+            "https://en.wikipedia.org/wiki/Local_Events",
+            "Local events are events that happen locally.",
+        )
+
+        result = self.tool.run({"search_query": "local events for tomorrow"}, self.context)
+
+        assert result.success is True
+        printed = "\n".join(call.args[0] for call in self.context.user_print.call_args_list)
+        # Must log that DDG returned nothing before Wikipedia fires.
+        assert "no" in printed.lower() and (
+            "result" in printed.lower() or "duckduckgo" in printed.lower()
+        )
+        # Wikipedia success line must still appear.
+        assert "wikipedia" in printed.lower()
+
+    @patch('src.jarvis.tools.builtin.web_search._wikipedia_summary')
+    @patch('requests.get')
     def test_wikipedia_fallback_uses_detected_language(self, mock_get, mock_wiki):
         """Wikipedia fallback must hit the host matching the Whisper-detected
         utterance language, and its extract must reach the fence.


### PR DESCRIPTION
## Summary

- The `🚧 DuckDuckGo served a bot-challenge page` message was in an `elif` branch of the final status block. When Wikipedia rescued the query, `used_source == "wikipedia"` matched first and the bot-challenge line was silently dropped, violating the spec that says both messages must fire even when a fallback succeeds.
- When DDG returned zero results (not rate-limited), there was no user-visible output between `🌐 Searching…` and `📚 Searching Wikipedia…`, making field-triage impossible.

**Root cause:** both messages were deferred to the final `if/elif` status chain instead of being printed immediately when the condition was known.

**Fix:** print DDG failure reasons (`🚧` bot-challenge, `⚠️` no results) immediately after the DDG block, before fallbacks run, so they always fire regardless of which fallback later rescues the query. Remove the now-redundant `elif ddg_rate_limited` branch from the status block.

After the fix the log for a bot-challenge+Wikipedia-rescue looks like:
```
🌐 Searching the web for 'local events for tomorrow'…
🚧 DuckDuckGo served a bot-challenge page — search blocked, no results retrieved.
📚 Searching Wikipedia (en) for 'local events for tomorrow'…
✅ Answered via Wikipedia fallback.
```

And for the zero-results case:
```
🌐 Searching the web for 'local events for tomorrow'…
⚠️ No DuckDuckGo results found.
📚 Searching Wikipedia (en) for 'local events for tomorrow'…
✅ Answered via Wikipedia fallback.
```

## Test plan

- [x] `test_bot_challenge_log_fires_even_when_wikipedia_rescues` — new regression test asserting both the `🚧` and `wikipedia` lines appear when DDG is challenged and Wikipedia rescues
- [x] `test_zero_ddg_results_logged_before_wikipedia_fallback` — new regression test for the zero-results case
- [x] All 54 existing web search tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)