### PR TITLE
test(web_search): tighten assertions on DDG failure console lines

### DIFF
--- a/tests/tools/builtin/test_web_search.py
+++ b/tests/tools/builtin/test_web_search.py
@@ -511,6 +511,11 @@ class TestWebSearchTool:
         # Block envelope must NOT fire — we rescued the query.
         lowered = result.reply_text.lower()
         assert "blocked by duckduckgo" not in lowered
+        # The 🚧 bot-challenge console line MUST fire even though Brave rescued —
+        # spec §Progress messages: "Rate-limit detection fires regardless of
+        # fallback availability."
+        printed = "\n".join(call.args[0] for call in self.context.user_print.call_args_list)
+        assert "🚧 DuckDuckGo served a bot-challenge page" in printed
 
     @patch('src.jarvis.tools.builtin.web_search._wikipedia_summary')
     @patch('requests.get')
@@ -590,10 +595,8 @@ class TestWebSearchTool:
 
         assert result.success is True
         printed = "\n".join(call.args[0] for call in self.context.user_print.call_args_list)
-        # Must log that DDG returned nothing before Wikipedia fires.
-        assert "no" in printed.lower() and (
-            "result" in printed.lower() or "duckduckgo" in printed.lower()
-        )
+        # Must log the exact no-results message before Wikipedia fires.
+        assert "⚠️ No DuckDuckGo results found." in printed
         # Wikipedia success line must still appear.
         assert "wikipedia" in printed.lower()
 
@@ -664,6 +667,10 @@ class TestWebSearchTool:
         assert "blocked by duckduckgo" in lowered or "bot-protection" in lowered
         assert "you have failed" in lowered
         assert "must not contain any specific facts" in lowered
+        # The 🚧 console line must also fire — the reply envelope alone is
+        # insufficient to confirm the early-print contract is satisfied.
+        printed = "\n".join(call.args[0] for call in self.context.user_print.call_args_list)
+        assert "🚧 DuckDuckGo served a bot-challenge page" in printed
 
     @patch('requests.get')
     def test_run_network_failure_graceful(self, mock_get):


### PR DESCRIPTION
## Summary

Follow-up to #334. The adversarial PR review found three coverage gaps in the tests that were added:

- **`test_brave_fallback_runs_when_ddg_blocked`**: asserted the block envelope did not fire, but never checked that the `🚧` console line *did* fire before Brave was invoked. The spec requires this regardless of which fallback rescues the query.
- **`test_all_fallbacks_fail_emits_honest_block`**: checked the reply envelope thoroughly but left the early `🚧` console-print contract unverified.
- **`test_zero_ddg_results_logged_before_wikipedia_fallback`**: used a fragile multi-token check (`"no" in printed and ("result" in ... or "duckduckgo" in ...)`) that could pass spuriously from unrelated output lines such as `"⚠️ No web results found."`. Now asserts the exact string instead.

No production code changes.

## Test plan

- [x] All 54 web search tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)