### PR TITLE
fix(dictation): isolate pynput Listener in a subprocess; fix modifier-key matching

### DIFF
--- a/jarvis_desktop.spec
+++ b/jarvis_desktop.spec
@@ -120,6 +120,16 @@ hiddenimports = [
     'jarvis.dictation.listener_proc',
     'pynput',
     'pynput.keyboard',
+    # pynput loads its platform shim lazily; PyInstaller's static analysis
+    # doesn't always pick these up, especially for the spawned child where
+    # only listener_proc is imported up-front.
+    'pynput._util',
+    'pynput._util.darwin',
+    'pynput._util.win32',
+    'pynput._util.xorg',
+    'pynput.keyboard._darwin',
+    'pynput.keyboard._win32',
+    'pynput.keyboard._xorg',
     # Memory modules
     'jarvis.memory',
     'jarvis.memory.conversation',

--- a/jarvis_desktop.spec
+++ b/jarvis_desktop.spec
@@ -112,6 +112,14 @@ hiddenimports = [
     'jarvis.listening.wake_detection',
     'jarvis.listening.transcript_buffer',
     'jarvis.listening.intent_judge',
+    # Dictation modules (listener_proc is loaded by multiprocessing.spawn
+    # in the child process, so PyInstaller must bundle it explicitly).
+    'jarvis.dictation',
+    'jarvis.dictation.dictation_engine',
+    'jarvis.dictation.history',
+    'jarvis.dictation.listener_proc',
+    'pynput',
+    'pynput.keyboard',
     # Memory modules
     'jarvis.memory',
     'jarvis.memory.conversation',

--- a/scripts/run_desktop_app.bat
+++ b/scripts/run_desktop_app.bat
@@ -3,6 +3,15 @@ REM Run script for the Jarvis Desktop App on Windows
 REM Uses the project's mamba environment
 REM Usage: run_desktop_app.bat [--voice-debug]
 
+REM Resolve PROJECT_ROOT directly from %~dp0 without relying on `..`
+REM expansion, which can resolve against the cwd rather than the bat's
+REM directory under some launchers (e.g. Claude Preview's preview tool).
+REM Strip trailing backslash, then take the parent directory using ~dp.
+set "SCRIPT_DIR=%~dp0"
+if "%SCRIPT_DIR:~-1%"=="\" set "SCRIPT_DIR=%SCRIPT_DIR:~0,-1%"
+for %%I in ("%SCRIPT_DIR%") do set "PROJECT_ROOT=%%~dpI"
+if "%PROJECT_ROOT:~-1%"=="\" set "PROJECT_ROOT=%PROJECT_ROOT:~0,-1%"
+
 REM Parse arguments
 set "VOICE_DEBUG=0"
 :parse_args
@@ -22,8 +31,6 @@ if "%VOICE_DEBUG%"=="1" (
 )
 echo.
 
-REM Navigate to project root (use for-loop to resolve .. reliably across shells)
-for %%I in ("%~dp0..") do set "PROJECT_ROOT=%%~fI"
 cd /d "%PROJECT_ROOT%"
 set "PYTHONPATH=%PROJECT_ROOT%\src;%PYTHONPATH%"
 

--- a/src/jarvis/dictation/dictation.spec.md
+++ b/src/jarvis/dictation/dictation.spec.md
@@ -64,7 +64,8 @@ After transcription, text passes through these stages in order:
 
 ## Architecture
 
-- **`pynput`** for global hotkey detection (cross-platform).
+- **`pynput`** for global hotkey detection (cross-platform), running in an
+  isolated child process — see "Subprocess isolation" below.
 - **Clipboard-based paste** (`Ctrl+V` / `Cmd+V`) for text insertion — more
   reliable than character-by-character typing, handles Unicode.
 - **Shared Whisper model** via lazy reference (`lambda: voice_thread.model`)
@@ -73,6 +74,43 @@ After transcription, text passes through these stages in order:
   modifying the complex listener code.
 - **Pause flag** on the main listener to prevent dictation speech being
   interpreted as commands.
+
+### Subprocess isolation (pynput Listener)
+
+The `pynput` keyboard `Listener` owns native event taps that have repeatedly
+crashed the daemon with `Fatal Python error: Illegal instruction` /
+`Aborted` from C-level code (`pynput/_util/darwin.py:keycode_context` on
+macOS, `pynput/_util/win32.py:__iter__` on Windows). These signals cannot be
+caught from Python — they tear down the whole process.
+
+To stop a single failing event tap from killing Jarvis, the Listener runs in
+a dedicated child process spawned via `multiprocessing.spawn` from
+`src/jarvis/dictation/listener_proc.py`. The child relays `press`/`release`
+events to the parent over a `Pipe`, where they are reconstructed into pynput
+`Key`/`KeyCode` objects and fed to the same `_on_key_press` /
+`_on_key_release` handlers as before.
+
+If the child crashes:
+
+- The parent's reader thread detects the dead process via `proc.is_alive()`
+  and exits cleanly.
+- The daemon stays up. Voice listening, dictation history, and every other
+  feature keep working.
+- Dictation goes offline silently until the engine is restarted (no
+  auto-respawn yet — keeps blast radius small while we collect telemetry).
+
+Side effect: the Windows low-level keyboard hook timeout (Windows silently
+removes hooks whose callbacks take more than ~5 s) now applies inside the
+child process only. The parent's reader thread can take its time without
+risking the hook being torn down. Existing off-thread dispatch in
+`_stop_recording` is kept anyway because the contract still belongs to the
+listener wire.
+
+The macOS 26+ guard (see "Edge Cases") still short-circuits before spawning
+the child — there is no point starting a process we know will crash on its
+first key event.
+
+This addresses crashes reported in issues #252, #353 and #354.
 
 ### Audio Device Handling
 
@@ -129,3 +167,8 @@ Location steps) that allows users to:
 ## Dependencies
 
 - `pynput>=1.7.6` — global hotkey detection and keyboard simulation.
+- `multiprocessing` (stdlib, `spawn` context) — used to isolate the pynput
+  Listener in a child process so native crashes can't take down the daemon.
+  PyInstaller frozen builds rely on `multiprocessing.freeze_support()` being
+  called early in `app.py`; the spec file lists `jarvis.dictation.listener_proc`
+  as a hidden import so the spawned child can re-import it.

--- a/src/jarvis/dictation/dictation.spec.md
+++ b/src/jarvis/dictation/dictation.spec.md
@@ -93,11 +93,17 @@ events to the parent over a `Pipe`, where they are reconstructed into pynput
 If the child crashes:
 
 - The parent's reader thread detects the dead process via `proc.is_alive()`
-  and exits cleanly.
-- The daemon stays up. Voice listening, dictation history, and every other
-  feature keep working.
-- Dictation goes offline silently until the engine is restarted (no
-  auto-respawn yet — keeps blast radius small while we collect telemetry).
+  and exits.
+- A supervisor thread in the parent transparently respawns the child after
+  a short backoff (1 s, 2 s, 5 s). Up to `_MAX_CONSECUTIVE_FAILURES`
+  consecutive crashes are tolerated before the supervisor gives up — past
+  that point we'd just be burning CPU spawning into a deterministic crash
+  loop.
+- A spawn that ran longer than `_CLEAN_RUN_WINDOW` (60 s) resets the failure
+  counter, so an occasional hiccup over a long session doesn't accumulate.
+- When the supervisor gives up it prints a one-line warning to the console;
+  the daemon stays up and dictation can be re-enabled by restarting the
+  engine (calling `start()` again resets the counter for a fresh session).
 
 Side effect: the Windows low-level keyboard hook timeout (Windows silently
 removes hooks whose callbacks take more than ~5 s) now applies inside the

--- a/src/jarvis/dictation/dictation.spec.md
+++ b/src/jarvis/dictation/dictation.spec.md
@@ -107,10 +107,14 @@ risking the hook being torn down. Existing off-thread dispatch in
 listener wire.
 
 The macOS 26+ guard (see "Edge Cases") still short-circuits before spawning
-the child — there is no point starting a process we know will crash on its
-first key event.
+the child — subprocess isolation only contains crashes, it does not enable
+Tahoe support, so there is no point starting a process we know will crash
+on its first key event.
 
-This addresses crashes reported in issues #252, #353 and #354.
+If `multiprocessing.spawn` itself fails (rare; e.g. a starved system or a
+broken frozen build), the wrapper logs the failure, leaves itself in the
+unstarted state, and the daemon stays up. Dictation will retry on the next
+engine restart.
 
 ### Audio Device Handling
 

--- a/src/jarvis/dictation/dictation_engine.py
+++ b/src/jarvis/dictation/dictation_engine.py
@@ -705,11 +705,9 @@ class DictationEngine:
                 )
                 return
 
-        # The pynput Listener owns a CGEventTap (macOS) or a low-level Win32
-        # hook — both have crashed the daemon with SIGILL/SIGABRT on real
-        # installs (issues #252, #353, #354).  Run it in an isolated child
-        # process so a native crash kills the child only and the daemon stays
-        # up; dictation just goes offline until restart.
+        # The Listener runs in an isolated child process so a native crash
+        # in pynput's CGEventTap / Win32 hook can't take down the daemon.
+        # See dictation.spec.md "Subprocess isolation" for details.
         from .listener_proc import SubprocessKeyboardListener
         self._listener = SubprocessKeyboardListener(
             on_press=self._on_key_press,

--- a/src/jarvis/dictation/dictation_engine.py
+++ b/src/jarvis/dictation/dictation_engine.py
@@ -705,7 +705,13 @@ class DictationEngine:
                 )
                 return
 
-        self._listener = pynput_keyboard.Listener(
+        # The pynput Listener owns a CGEventTap (macOS) or a low-level Win32
+        # hook — both have crashed the daemon with SIGILL/SIGABRT on real
+        # installs (issues #252, #353, #354).  Run it in an isolated child
+        # process so a native crash kills the child only and the daemon stays
+        # up; dictation just goes offline until restart.
+        from .listener_proc import SubprocessKeyboardListener
+        self._listener = SubprocessKeyboardListener(
             on_press=self._on_key_press,
             on_release=self._on_key_release,
         )

--- a/src/jarvis/dictation/dictation_engine.py
+++ b/src/jarvis/dictation/dictation_engine.py
@@ -486,6 +486,20 @@ _MODIFIER_MAP = {
     "win": "cmd",
 }
 
+# Groups of modifier key names that are treated as interchangeable during
+# hotkey matching.  pynput may report the generic variant (e.g. ``ctrl``,
+# VK 0x11) or a sided variant (``ctrl_l``, VK 0xA2) depending on the
+# platform and — critically — on whether the listener runs in a subprocess
+# where Windows can deliver a different VK code than in the parent process.
+# Treating the whole family as equivalent ensures ``ctrl+cmd`` detects
+# any Ctrl key regardless of handedness.
+_MODIFIER_FAMILIES: tuple[frozenset, ...] = (
+    frozenset({"ctrl", "ctrl_l", "ctrl_r"}),
+    frozenset({"shift", "shift_l", "shift_r"}),
+    frozenset({"alt", "alt_l", "alt_r"}),
+    frozenset({"cmd", "cmd_l", "cmd_r"}),
+)
+
 
 def format_hotkey_display(combo: str) -> str:
     """Format a hotkey string for human-readable display.
@@ -747,27 +761,54 @@ class DictationEngine:
         return key
 
     def _key_matches(self, key, nkey, target) -> bool:
-        """Check whether *key* (raw) / *nkey* (normalised) matches *target*."""
+        """Check whether *key* (raw) / *nkey* (normalised) matches *target*.
+
+        Modifier keys are matched by family so that, for example, a ``ctrl``
+        event (VK 0x11) satisfies a ``ctrl_l`` requirement.  This matters when
+        the pynput Listener runs in a subprocess where Windows may deliver the
+        generic variant of a modifier VK instead of the sided one.
+        """
         if target is None:
             return False
         if nkey == target or key == target:
             return True
-        if getattr(key, "name", None) == getattr(target, "name", None):
+        key_name = getattr(key, "name", None)
+        target_name = getattr(target, "name", None)
+        if key_name is not None and key_name == target_name:
             return True
+        # Treat sided and generic modifier variants as equivalent
+        # (e.g. ctrl_l satisfies ctrl requirement and vice versa).
+        if key_name and target_name:
+            for family in _MODIFIER_FAMILIES:
+                if key_name in family and target_name in family:
+                    return True
         if hasattr(key, "char") and key.char:
             if pynput_keyboard.KeyCode.from_char(key.char.lower()) == target:
                 return True
         return False
 
     def _all_modifiers_held(self) -> bool:
-        """Return True when every required modifier is currently pressed."""
-        return all(
-            m in self._pressed_modifiers or any(
-                getattr(p, "name", None) == getattr(m, "name", None)
-                for p in self._pressed_modifiers
-            )
-            for m in self._modifiers
-        )
+        """Return True when every required modifier is currently pressed.
+
+        A pressed modifier satisfies a required one if they are identical or
+        belong to the same modifier family (e.g. a pressed ``ctrl`` satisfies
+        a required ``ctrl_l``).
+        """
+        def _satisfies(required, pressed_set) -> bool:
+            if required in pressed_set:
+                return True
+            req_name = getattr(required, "name", None)
+            for pressed in pressed_set:
+                pressed_name = getattr(pressed, "name", None)
+                if pressed_name == req_name:
+                    return True
+                if pressed_name and req_name:
+                    for family in _MODIFIER_FAMILIES:
+                        if pressed_name in family and req_name in family:
+                            return True
+            return False
+
+        return all(_satisfies(m, self._pressed_modifiers) for m in self._modifiers)
 
     def _on_key_press(self, key) -> None:
         nkey = self._normalise_key(key)

--- a/src/jarvis/dictation/dictation_engine.py
+++ b/src/jarvis/dictation/dictation_engine.py
@@ -82,6 +82,7 @@ def _generate_beep_wav(freq: float = 520, duration: float = 0.10) -> bytes:
 
 _START_BEEP: Optional[bytes] = None
 _STOP_BEEP: Optional[bytes] = None
+_NOT_READY_BEEP: Optional[bytes] = None
 
 
 def _get_start_beep() -> bytes:
@@ -96,6 +97,20 @@ def _get_stop_beep() -> bytes:
     if _STOP_BEEP is None:
         _STOP_BEEP = _generate_beep_wav(freq=440, duration=0.10)
     return _STOP_BEEP
+
+
+def _get_not_ready_beep() -> bytes:
+    """Low-pitched, longer beep used when the hotkey fired but recording
+    cannot start (Whisper not loaded, audio device unavailable, …).
+
+    Distinct from the start/stop beeps so the user immediately recognises
+    "I pressed the hotkey but nothing is happening" instead of staring at a
+    silent screen.
+    """
+    global _NOT_READY_BEEP
+    if _NOT_READY_BEEP is None:
+        _NOT_READY_BEEP = _generate_beep_wav(freq=220, duration=0.20)
+    return _NOT_READY_BEEP
 
 
 def _play_beep(wav_data: bytes) -> None:
@@ -897,11 +912,20 @@ class DictationEngine:
                 return
             self._recording = True
 
-        # Check Whisper readiness
+        # Check Whisper readiness.  Spec: "Whisper not yet loaded → play
+        # 'not ready' beep, skip" — without audible/visible feedback the
+        # user just sees the hotkey doing nothing and assumes dictation
+        # itself is broken.
         model = self._whisper_model_ref()
         backend = self._whisper_backend_ref()
         if model is None and backend != "mlx":
             debug_log("whisper model not loaded — dictation skipped", "dictation")
+            print(
+                "  ⚠️  Dictation hotkey pressed but Whisper isn't loaded yet. "
+                "Wait for startup to finish, then try again.",
+                flush=True,
+            )
+            _play_beep(_get_not_ready_beep())
             self._recording = False
             return
 
@@ -955,6 +979,11 @@ class DictationEngine:
                 debug_log(f"dictation stream at native {native_rate} Hz (will resample to {self._target_sample_rate})", "dictation")
         except Exception as exc:
             debug_log(f"failed to open dictation audio stream: {exc}", "dictation")
+            print(
+                f"  ⚠️  Dictation could not open the audio stream: {exc}",
+                flush=True,
+            )
+            _play_beep(_get_not_ready_beep())
             self._recording = False
             if self._on_dictation_end:
                 self._on_dictation_end()
@@ -964,6 +993,11 @@ class DictationEngine:
             self._stream.start()
         except Exception as exc:
             debug_log(f"failed to start dictation audio stream: {exc}", "dictation")
+            print(
+                f"  ⚠️  Dictation could not start the audio stream: {exc}",
+                flush=True,
+            )
+            _play_beep(_get_not_ready_beep())
             self._recording = False
             if self._on_dictation_end:
                 self._on_dictation_end()

--- a/src/jarvis/dictation/listener_proc.py
+++ b/src/jarvis/dictation/listener_proc.py
@@ -4,8 +4,8 @@ The pynput Listener owns native event taps (CGEventTap on macOS, low-level
 Win32 hooks on Windows) that have crashed with SIGILL/SIGABRT in C-level
 code. Those signals can't be caught from Python, so a single bad event tears
 down the whole daemon. Running the Listener in a separate process means a
-crash kills the child only; the daemon stays up and dictation goes offline
-silently until the engine is restarted.
+crash kills the child only; a supervisor thread in the parent then respawns
+the child up to a small bounded number of times before giving up.
 
 The wrapper exposes a minimal ``Listener``-like API (``start`` / ``stop``)
 so the engine can treat it as a drop-in replacement.
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import multiprocessing
 import threading
+import time
 from typing import Any, Callable, Optional
 
 from ..debug import debug_log
@@ -144,11 +145,21 @@ class SubprocessKeyboardListener:
 
     Spawns a child process that owns the real listener and relays key events
     over a pipe. A reader thread in the parent calls the supplied callbacks.
-    Crashes in the child do not propagate — the reader exits and dictation
-    silently goes offline until the engine is restarted.
+    A supervisor thread watches the child and transparently respawns it after
+    a crash, up to ``_MAX_CONSECUTIVE_FAILURES`` failures within
+    ``_CLEAN_RUN_WINDOW`` seconds — after that it gives up to avoid burning
+    CPU spawning into a deterministic crash loop.
     """
 
-    _POLL_INTERVAL = 0.5  # seconds between liveness checks
+    _POLL_INTERVAL = 0.5  # seconds — max wait per liveness check
+    _TERMINATE_JOIN_TIMEOUT = 1.0
+    _KILL_JOIN_TIMEOUT = 0.5
+    _READER_JOIN_TIMEOUT = 1.0
+    _SUPERVISOR_JOIN_TIMEOUT = 2.0
+
+    _MAX_CONSECUTIVE_FAILURES = 3
+    _CLEAN_RUN_WINDOW = 60.0  # seconds — a run longer than this resets the counter
+    _BACKOFF_SCHEDULE = (1.0, 2.0, 5.0)  # seconds, indexed by failure count
 
     def __init__(
         self,
@@ -160,12 +171,125 @@ class SubprocessKeyboardListener:
         self._proc: Optional[Any] = None
         self._conn: Optional[Any] = None
         self._reader_thread: Optional[threading.Thread] = None
+        self._supervisor_thread: Optional[threading.Thread] = None
         self._stop_flag = threading.Event()
+        self._failure_count = 0
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
 
     def start(self) -> None:
-        if self._proc is not None:
+        if self._supervisor_thread is not None and self._supervisor_thread.is_alive():
             return
 
+        # Allow restart after a previous give-up.
+        self._stop_flag.clear()
+        self._failure_count = 0
+
+        self._supervisor_thread = threading.Thread(
+            target=self._supervise,
+            daemon=True,
+            name="dictation-listener-supervisor",
+        )
+        try:
+            self._supervisor_thread.start()
+        except Exception as exc:
+            debug_log(f"failed to start dictation listener supervisor: {exc}", "dictation")
+            self._supervisor_thread = None
+
+    def stop(self) -> None:
+        self._stop_flag.set()
+        self._teardown_child()
+
+        supervisor = self._supervisor_thread
+        if (
+            supervisor is not None
+            and supervisor.is_alive()
+            and supervisor is not threading.current_thread()
+        ):
+            supervisor.join(timeout=self._SUPERVISOR_JOIN_TIMEOUT)
+        self._supervisor_thread = None
+
+    # ------------------------------------------------------------------
+    # Supervisor — owns the spawn / respawn lifecycle
+    # ------------------------------------------------------------------
+
+    def _supervise(self) -> None:
+        """Spawn the child, wait for the reader to exit, decide whether to retry."""
+        while not self._stop_flag.is_set():
+            spawned_at = time.time()
+            if not self._spawn_child():
+                if not self._record_failure_and_should_retry():
+                    return
+                self._sleep_with_stop(self._current_backoff())
+                continue
+
+            reader = self._reader_thread
+            if reader is None:
+                # Spawn succeeded but reader didn't take — treat as failure.
+                self._teardown_child()
+                if not self._record_failure_and_should_retry():
+                    return
+                self._sleep_with_stop(self._current_backoff())
+                continue
+
+            reader.join()  # blocks until child dies, pipe closes, or stop()
+
+            if self._stop_flag.is_set():
+                return
+
+            self._teardown_child()  # clean up zombie state before deciding
+
+            ran_for = time.time() - spawned_at
+            if ran_for >= self._CLEAN_RUN_WINDOW:
+                # The previous spawn ran cleanly for long enough that we treat
+                # this as a fresh failure series.
+                self._failure_count = 0
+
+            if not self._record_failure_and_should_retry():
+                return
+
+            debug_log(
+                f"dictation listener subprocess died after {ran_for:.1f}s — "
+                f"respawning (attempt {self._failure_count + 1}/{self._MAX_CONSECUTIVE_FAILURES})",
+                "dictation",
+            )
+            self._sleep_with_stop(self._current_backoff())
+
+    def _record_failure_and_should_retry(self) -> bool:
+        """Bump the failure counter; return False once the cap is reached."""
+        self._failure_count += 1
+        if self._failure_count >= self._MAX_CONSECUTIVE_FAILURES:
+            print(
+                "  ⚠️  Dictation listener crashed repeatedly — giving up. "
+                "Restart Jarvis to retry.",
+                flush=True,
+            )
+            debug_log(
+                f"dictation listener gave up after {self._failure_count} consecutive failures",
+                "dictation",
+            )
+            return False
+        return True
+
+    def _current_backoff(self) -> float:
+        idx = min(self._failure_count - 1, len(self._BACKOFF_SCHEDULE) - 1)
+        idx = max(idx, 0)
+        return self._BACKOFF_SCHEDULE[idx]
+
+    def _sleep_with_stop(self, seconds: float) -> None:
+        """Sleep that returns early when stop() is signalled."""
+        if seconds <= 0:
+            return
+        self._stop_flag.wait(timeout=seconds)
+
+    # ------------------------------------------------------------------
+    # Spawn / teardown a single child instance
+    # ------------------------------------------------------------------
+
+    def _spawn_child(self) -> bool:
+        """Spawn one child + reader. Returns True on success."""
         ctx = multiprocessing.get_context("spawn")
         parent_conn, child_conn = ctx.Pipe(duplex=False)
         proc = ctx.Process(
@@ -174,20 +298,16 @@ class SubprocessKeyboardListener:
             daemon=True,
         )
 
-        # The spawn re-execs the bundled exe in frozen builds; on a starved
-        # system that can fail. Treat any failure as "dictation offline" and
-        # leave the wrapper in its initial state so the caller can retry.
         try:
             proc.start()
         except Exception as exc:
             debug_log(f"failed to spawn dictation listener: {exc}", "dictation")
             self._safe_close(parent_conn)
             self._safe_close(child_conn)
-            return
+            return False
 
         self._conn = parent_conn
         self._proc = proc
-
         # Only the child writes; close the child end in the parent so an EOF
         # is delivered if the child exits without sending anything else.
         self._safe_close(child_conn)
@@ -200,33 +320,15 @@ class SubprocessKeyboardListener:
             )
             self._reader_thread.start()
         except Exception as exc:
-            # Out-of-resources for thread creation — abandon the child rather
-            # than leak it.
             debug_log(f"failed to start dictation listener reader: {exc}", "dictation")
             self._reader_thread = None
-            self.stop()
-            return
+            return False
 
         debug_log("dictation listener subprocess started", "dictation")
+        return True
 
-    @staticmethod
-    def _safe_close(conn: Any) -> None:
-        if conn is None:
-            return
-        try:
-            conn.close()
-        except Exception:
-            pass
-
-    # Total worst-case teardown is ~2.5 s; daemon=True backstops anything
-    # the OS still has alive after that.
-    _TERMINATE_JOIN_TIMEOUT = 1.0
-    _KILL_JOIN_TIMEOUT = 0.5
-    _READER_JOIN_TIMEOUT = 1.0
-
-    def stop(self) -> None:
-        self._stop_flag.set()
-
+    def _teardown_child(self) -> None:
+        """Tear down whatever child + reader are currently alive."""
         proc = self._proc
         if proc is not None:
             try:
@@ -244,12 +346,25 @@ class SubprocessKeyboardListener:
         self._conn = None
 
         reader = self._reader_thread
-        if reader is not None and reader.is_alive() and reader is not threading.current_thread():
+        if (
+            reader is not None
+            and reader.is_alive()
+            and reader is not threading.current_thread()
+        ):
             reader.join(timeout=self._READER_JOIN_TIMEOUT)
         self._reader_thread = None
 
+    @staticmethod
+    def _safe_close(conn: Any) -> None:
+        if conn is None:
+            return
+        try:
+            conn.close()
+        except Exception:
+            pass
+
     # ------------------------------------------------------------------
-    # Internal
+    # Reader loop — one per child instance
     # ------------------------------------------------------------------
 
     def _read_loop(self) -> None:
@@ -269,7 +384,7 @@ class SubprocessKeyboardListener:
                 if proc is not None and not proc.is_alive():
                     debug_log(
                         "dictation listener subprocess exited unexpectedly "
-                        "(pynput crashed?) — dictation disabled until restart",
+                        "(pynput crashed?) — supervisor will respawn",
                         "dictation",
                     )
                     return

--- a/src/jarvis/dictation/listener_proc.py
+++ b/src/jarvis/dictation/listener_proc.py
@@ -1,0 +1,265 @@
+"""Subprocess-isolated pynput keyboard listener.
+
+The pynput Listener has been observed to crash with SIGILL/SIGABRT in C-level
+code (CGEventTap on macOS, low-level Win32 hooks on Windows). Running it in a
+separate process means a crash kills the child only — the daemon stays up and
+dictation just stops working until the next restart, instead of taking down the
+whole app (issues #252, #353, #354).
+
+The wrapper exposes a minimal ``Listener``-like API (``start`` / ``stop``) so
+the engine can treat it as a drop-in replacement.
+
+Architecture::
+
+    DictationEngine               child subprocess
+    ───────────────               ─────────────────
+    SubprocessKeyboardListener
+      ├─ start() ──spawn──▶  pynput.Listener
+      ├─ reader thread ◀─pipe──  on_press / on_release
+      │   └─ on_press / on_release callbacks
+      └─ stop() ──terminate──▶  exit
+
+Key events are serialised to plain dicts on the wire so neither end has to
+unpickle pynput objects across the process boundary.
+"""
+
+from __future__ import annotations
+
+import multiprocessing
+import threading
+from typing import Any, Callable, Optional
+
+from ..debug import debug_log
+
+
+# ---------------------------------------------------------------------------
+# Wire format
+# ---------------------------------------------------------------------------
+
+def _serialise_key(key: Any) -> dict:
+    """Convert a pynput Key/KeyCode to a JSON-safe dict.
+
+    pynput is imported lazily so this module loads in environments where it
+    isn't installed (e.g. unit tests that only exercise the deserialiser).
+    """
+    from pynput import keyboard as pk
+
+    if isinstance(key, pk.Key):
+        return {"kind": "named", "name": key.name}
+
+    char = getattr(key, "char", None)
+    vk = getattr(key, "vk", None)
+    if char is not None:
+        return {"kind": "char", "char": char, "vk": vk}
+    if vk is not None:
+        return {"kind": "vk", "vk": vk}
+    return {"kind": "unknown"}
+
+
+def _deserialise_key(payload: dict) -> Optional[Any]:
+    """Reconstruct a pynput Key/KeyCode from the wire dict.
+
+    Returns ``None`` if the payload is unrecognised so callers can skip it
+    rather than crash on garbled input.
+    """
+    if not isinstance(payload, dict):
+        return None
+
+    kind = payload.get("kind")
+    try:
+        from pynput import keyboard as pk
+    except ImportError:
+        return None
+
+    if kind == "named":
+        return getattr(pk.Key, payload.get("name", ""), None)
+    if kind == "char":
+        char = payload.get("char")
+        if char is None:
+            return None
+        return pk.KeyCode.from_char(char)
+    if kind == "vk":
+        vk = payload.get("vk")
+        if vk is None:
+            return None
+        return pk.KeyCode.from_vk(vk)
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Subprocess entry point
+# ---------------------------------------------------------------------------
+
+def _listener_main(conn: Any) -> None:
+    """Run the real pynput Listener and emit events on *conn*.
+
+    Top-level so ``multiprocessing.spawn`` can pickle and re-import it. If
+    pynput's C-level event tap aborts the process, only this child dies; the
+    parent's reader thread notices via ``proc.is_alive()`` and exits cleanly.
+    """
+    try:
+        from pynput import keyboard as pk
+
+        def on_press(key):
+            try:
+                conn.send({"event": "press", "key": _serialise_key(key)})
+            except Exception:
+                # Parent pipe closed — nothing to do; listener will be torn
+                # down when the parent terminates the process.
+                pass
+
+        def on_release(key):
+            try:
+                conn.send({"event": "release", "key": _serialise_key(key)})
+            except Exception:
+                pass
+
+        listener = pk.Listener(on_press=on_press, on_release=on_release)
+        listener.start()
+        listener.join()
+    except Exception as exc:
+        try:
+            conn.send({"event": "error", "message": repr(exc)})
+        except Exception:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Public wrapper
+# ---------------------------------------------------------------------------
+
+class SubprocessKeyboardListener:
+    """Drop-in replacement for ``pynput.keyboard.Listener``.
+
+    Spawns a child process that owns the real listener and relays key events
+    over a pipe. A reader thread in the parent calls the supplied callbacks.
+    Crashes in the child do not propagate — the reader exits and dictation
+    silently goes offline until the engine is restarted.
+    """
+
+    _POLL_INTERVAL = 0.5  # seconds between liveness checks
+
+    def __init__(
+        self,
+        on_press: Callable[[Any], None],
+        on_release: Callable[[Any], None],
+    ) -> None:
+        self._on_press = on_press
+        self._on_release = on_release
+        self._proc: Optional[Any] = None
+        self._conn: Optional[Any] = None
+        self._reader_thread: Optional[threading.Thread] = None
+        self._stop_flag = threading.Event()
+
+    def start(self) -> None:
+        if self._proc is not None:
+            return
+
+        ctx = multiprocessing.get_context("spawn")
+        parent_conn, child_conn = ctx.Pipe(duplex=False)
+        self._conn = parent_conn
+        self._proc = ctx.Process(
+            target=_listener_main,
+            args=(child_conn,),
+            daemon=True,
+        )
+        self._proc.start()
+        # Only the child writes; close the child end in the parent so an EOF
+        # is delivered if the child exits without sending anything else.
+        try:
+            child_conn.close()
+        except Exception:
+            pass
+
+        self._reader_thread = threading.Thread(
+            target=self._read_loop,
+            daemon=True,
+            name="dictation-listener-reader",
+        )
+        self._reader_thread.start()
+        debug_log("dictation listener subprocess started", "dictation")
+
+    def stop(self) -> None:
+        self._stop_flag.set()
+
+        proc = self._proc
+        if proc is not None:
+            try:
+                if proc.is_alive():
+                    proc.terminate()
+                    proc.join(timeout=2.0)
+                if proc.is_alive():
+                    proc.kill()
+                    proc.join(timeout=1.0)
+            except Exception as exc:
+                debug_log(f"dictation listener subprocess teardown error: {exc}", "dictation")
+        self._proc = None
+
+        if self._conn is not None:
+            try:
+                self._conn.close()
+            except Exception:
+                pass
+            self._conn = None
+
+        reader = self._reader_thread
+        if reader is not None and reader.is_alive() and reader is not threading.current_thread():
+            reader.join(timeout=2.0)
+        self._reader_thread = None
+
+    # ------------------------------------------------------------------
+    # Internal
+    # ------------------------------------------------------------------
+
+    def _read_loop(self) -> None:
+        conn = self._conn
+        while not self._stop_flag.is_set():
+            if conn is None:
+                return
+
+            try:
+                has_data = conn.poll(self._POLL_INTERVAL)
+            except (EOFError, OSError):
+                debug_log("dictation listener pipe closed", "dictation")
+                return
+
+            if not has_data:
+                proc = self._proc
+                if proc is not None and not proc.is_alive():
+                    debug_log(
+                        "dictation listener subprocess exited unexpectedly "
+                        "(pynput crashed?) — dictation disabled until restart",
+                        "dictation",
+                    )
+                    return
+                continue
+
+            try:
+                msg = conn.recv()
+            except (EOFError, OSError):
+                debug_log("dictation listener pipe closed", "dictation")
+                return
+
+            if not isinstance(msg, dict):
+                continue
+
+            event = msg.get("event")
+            if event == "press":
+                self._dispatch(self._on_press, msg.get("key"))
+            elif event == "release":
+                self._dispatch(self._on_release, msg.get("key"))
+            elif event == "error":
+                debug_log(
+                    f"dictation listener subprocess reported error: {msg.get('message')}",
+                    "dictation",
+                )
+
+    @staticmethod
+    def _dispatch(callback: Callable[[Any], None], key_payload: Any) -> None:
+        key = _deserialise_key(key_payload) if isinstance(key_payload, dict) else None
+        if key is None:
+            return
+        try:
+            callback(key)
+        except Exception as exc:
+            debug_log(f"dictation listener callback error: {exc}", "dictation")

--- a/src/jarvis/dictation/listener_proc.py
+++ b/src/jarvis/dictation/listener_proc.py
@@ -1,26 +1,24 @@
 """Subprocess-isolated pynput keyboard listener.
 
-The pynput Listener has been observed to crash with SIGILL/SIGABRT in C-level
-code (CGEventTap on macOS, low-level Win32 hooks on Windows). Running it in a
-separate process means a crash kills the child only — the daemon stays up and
-dictation just stops working until the next restart, instead of taking down the
-whole app (issues #252, #353, #354).
+The pynput Listener owns native event taps (CGEventTap on macOS, low-level
+Win32 hooks on Windows) that have crashed with SIGILL/SIGABRT in C-level
+code. Those signals can't be caught from Python, so a single bad event tears
+down the whole daemon. Running the Listener in a separate process means a
+crash kills the child only; the daemon stays up and dictation goes offline
+silently until the engine is restarted.
 
-The wrapper exposes a minimal ``Listener``-like API (``start`` / ``stop``) so
-the engine can treat it as a drop-in replacement.
+The wrapper exposes a minimal ``Listener``-like API (``start`` / ``stop``)
+so the engine can treat it as a drop-in replacement.
 
-Architecture::
-
-    DictationEngine               child subprocess
-    ───────────────               ─────────────────
-    SubprocessKeyboardListener
-      ├─ start() ──spawn──▶  pynput.Listener
-      ├─ reader thread ◀─pipe──  on_press / on_release
-      │   └─ on_press / on_release callbacks
-      └─ stop() ──terminate──▶  exit
-
-Key events are serialised to plain dicts on the wire so neither end has to
-unpickle pynput objects across the process boundary.
+Privacy and trust model
+-----------------------
+Every keystroke (press and release) is forwarded over a local
+``multiprocessing.Pipe`` so the parent can detect hotkey combos. The pipe is
+an OS-level handle owned exclusively by the parent and the spawned child;
+no other process can read it. Wire payloads contain only key identity
+(``name`` / ``char`` / ``vk``), never window context or user content, and
+``debug_log`` calls in this module never include key data. The child is our
+own spawn and is therefore trusted on the receive side.
 """
 
 from __future__ import annotations
@@ -37,10 +35,12 @@ from ..debug import debug_log
 # ---------------------------------------------------------------------------
 
 def _serialise_key(key: Any) -> dict:
-    """Convert a pynput Key/KeyCode to a JSON-safe dict.
+    """Convert a pynput Key/KeyCode to a plain dict for cross-process transport.
 
     pynput is imported lazily so this module loads in environments where it
     isn't installed (e.g. unit tests that only exercise the deserialiser).
+    The output never contains window context or user content, only key
+    identity.
     """
     from pynput import keyboard as pk
 
@@ -59,8 +59,11 @@ def _serialise_key(key: Any) -> dict:
 def _deserialise_key(payload: dict) -> Optional[Any]:
     """Reconstruct a pynput Key/KeyCode from the wire dict.
 
-    Returns ``None`` if the payload is unrecognised so callers can skip it
-    rather than crash on garbled input.
+    The payload originates from a child process we spawned ourselves over a
+    private OS pipe, so it is trusted. ``getattr`` is used with a known enum
+    (``pk.Key``) and a default of ``None``, so unknown names cannot resolve
+    to arbitrary attributes. Returns ``None`` for unrecognised payloads so
+    callers can skip them rather than crash on garbled input.
     """
     if not isinstance(payload, dict):
         return None
@@ -90,6 +93,9 @@ def _deserialise_key(payload: dict) -> Optional[Any]:
 # Subprocess entry point
 # ---------------------------------------------------------------------------
 
+_MAX_ERROR_MESSAGE_LEN = 200
+
+
 def _listener_main(conn: Any) -> None:
     """Run the real pynput Listener and emit events on *conn*.
 
@@ -118,8 +124,13 @@ def _listener_main(conn: Any) -> None:
         listener.start()
         listener.join()
     except Exception as exc:
+        # Truncate so a noisy traceback message can't flood the parent's debug
+        # log if pynput ever decides to dump file paths or stack frames.
+        message = repr(exc)
+        if len(message) > _MAX_ERROR_MESSAGE_LEN:
+            message = message[:_MAX_ERROR_MESSAGE_LEN] + "...[truncated]"
         try:
-            conn.send({"event": "error", "message": repr(exc)})
+            conn.send({"event": "error", "message": message})
         except Exception:
             pass
 
@@ -157,27 +168,61 @@ class SubprocessKeyboardListener:
 
         ctx = multiprocessing.get_context("spawn")
         parent_conn, child_conn = ctx.Pipe(duplex=False)
-        self._conn = parent_conn
-        self._proc = ctx.Process(
+        proc = ctx.Process(
             target=_listener_main,
             args=(child_conn,),
             daemon=True,
         )
-        self._proc.start()
+
+        # The spawn re-execs the bundled exe in frozen builds; on a starved
+        # system that can fail. Treat any failure as "dictation offline" and
+        # leave the wrapper in its initial state so the caller can retry.
+        try:
+            proc.start()
+        except Exception as exc:
+            debug_log(f"failed to spawn dictation listener: {exc}", "dictation")
+            self._safe_close(parent_conn)
+            self._safe_close(child_conn)
+            return
+
+        self._conn = parent_conn
+        self._proc = proc
+
         # Only the child writes; close the child end in the parent so an EOF
         # is delivered if the child exits without sending anything else.
+        self._safe_close(child_conn)
+
         try:
-            child_conn.close()
+            self._reader_thread = threading.Thread(
+                target=self._read_loop,
+                daemon=True,
+                name="dictation-listener-reader",
+            )
+            self._reader_thread.start()
+        except Exception as exc:
+            # Out-of-resources for thread creation — abandon the child rather
+            # than leak it.
+            debug_log(f"failed to start dictation listener reader: {exc}", "dictation")
+            self._reader_thread = None
+            self.stop()
+            return
+
+        debug_log("dictation listener subprocess started", "dictation")
+
+    @staticmethod
+    def _safe_close(conn: Any) -> None:
+        if conn is None:
+            return
+        try:
+            conn.close()
         except Exception:
             pass
 
-        self._reader_thread = threading.Thread(
-            target=self._read_loop,
-            daemon=True,
-            name="dictation-listener-reader",
-        )
-        self._reader_thread.start()
-        debug_log("dictation listener subprocess started", "dictation")
+    # Total worst-case teardown is ~2.5 s; daemon=True backstops anything
+    # the OS still has alive after that.
+    _TERMINATE_JOIN_TIMEOUT = 1.0
+    _KILL_JOIN_TIMEOUT = 0.5
+    _READER_JOIN_TIMEOUT = 1.0
 
     def stop(self) -> None:
         self._stop_flag.set()
@@ -187,24 +232,20 @@ class SubprocessKeyboardListener:
             try:
                 if proc.is_alive():
                     proc.terminate()
-                    proc.join(timeout=2.0)
+                    proc.join(timeout=self._TERMINATE_JOIN_TIMEOUT)
                 if proc.is_alive():
                     proc.kill()
-                    proc.join(timeout=1.0)
+                    proc.join(timeout=self._KILL_JOIN_TIMEOUT)
             except Exception as exc:
                 debug_log(f"dictation listener subprocess teardown error: {exc}", "dictation")
         self._proc = None
 
-        if self._conn is not None:
-            try:
-                self._conn.close()
-            except Exception:
-                pass
-            self._conn = None
+        self._safe_close(self._conn)
+        self._conn = None
 
         reader = self._reader_thread
         if reader is not None and reader.is_alive() and reader is not threading.current_thread():
-            reader.join(timeout=2.0)
+            reader.join(timeout=self._READER_JOIN_TIMEOUT)
         self._reader_thread = None
 
     # ------------------------------------------------------------------

--- a/src/jarvis/dictation/listener_proc.py
+++ b/src/jarvis/dictation/listener_proc.py
@@ -104,7 +104,21 @@ def _listener_main(conn: Any) -> None:
     Top-level so ``multiprocessing.spawn`` can pickle and re-import it. If
     pynput's C-level event tap aborts the process, only this child dies; the
     parent's reader thread notices via ``proc.is_alive()`` and exits cleanly.
+
+    A handful of unconditional stderr prints stay in this function on
+    purpose: when the listener silently fails to deliver events (the kind of
+    Windows hook problem we have hit before), they are the only signal the
+    user gets about what stage the subprocess reached. Removing them makes
+    a "hotkey does nothing" report indistinguishable from "subprocess never
+    ran" without a custom debug build.
     """
+    import os as _os
+
+    print(
+        f"  🎙️  Dictation listener subprocess started (PID {_os.getpid()})",
+        file=sys.stderr,
+        flush=True,
+    )
     try:
         from pynput import keyboard as pk
 
@@ -124,6 +138,18 @@ def _listener_main(conn: Any) -> None:
 
         listener = pk.Listener(on_press=on_press, on_release=on_release)
         listener.start()
+        # Wait briefly for the listener thread to install its hook so we can
+        # tell "hook installed successfully" from "subprocess started but
+        # never managed to hook".
+        try:
+            listener.wait()
+        except Exception:
+            pass
+        print(
+            "  🎙️  Dictation listener hook installed — waiting for keys",
+            file=sys.stderr,
+            flush=True,
+        )
         listener.join()
     except Exception as exc:
         # Truncate so a noisy traceback message can't flood the parent's debug
@@ -131,6 +157,11 @@ def _listener_main(conn: Any) -> None:
         message = repr(exc)
         if len(message) > _MAX_ERROR_MESSAGE_LEN:
             message = message[:_MAX_ERROR_MESSAGE_LEN] + "...[truncated]"
+        print(
+            f"  ⚠️  Dictation listener subprocess crashed during startup: {message}",
+            file=sys.stderr,
+            flush=True,
+        )
         try:
             conn.send({"event": "error", "message": message})
         except Exception:

--- a/src/jarvis/dictation/listener_proc.py
+++ b/src/jarvis/dictation/listener_proc.py
@@ -262,7 +262,7 @@ class SubprocessKeyboardListener:
         self._failure_count += 1
         if self._failure_count >= self._MAX_CONSECUTIVE_FAILURES:
             print(
-                "  ⚠️  Dictation listener crashed repeatedly — giving up. "
+                "  ⚠️  Dictation listener crashed repeatedly. Giving up. "
                 "Restart Jarvis to retry.",
                 flush=True,
             )

--- a/src/jarvis/dictation/listener_proc.py
+++ b/src/jarvis/dictation/listener_proc.py
@@ -24,6 +24,7 @@ own spawn and is therefore trusted on the receive side.
 from __future__ import annotations
 
 import multiprocessing
+import sys
 import threading
 import time
 from typing import Any, Callable, Optional
@@ -418,4 +419,15 @@ class SubprocessKeyboardListener:
         try:
             callback(key)
         except Exception as exc:
+            # Surface the failure on stderr in addition to debug_log.  Without
+            # this, an exception in `_on_key_press` (e.g. a callback that
+            # touches state which isn't ready yet) silently disappears unless
+            # voice_debug is on, and the user sees the hotkey doing nothing.
+            import traceback
+            print(
+                f"  ⚠️  Dictation listener callback raised: {exc!r}",
+                file=sys.stderr,
+                flush=True,
+            )
+            traceback.print_exc(file=sys.stderr)
             debug_log(f"dictation listener callback error: {exc}", "dictation")

--- a/tests/test_dictation.py
+++ b/tests/test_dictation.py
@@ -144,27 +144,32 @@ class TestEngineLifecycle:
         except ImportError:
             pytest.skip("pynput or sounddevice not installed")
 
+    @patch("src.jarvis.dictation.listener_proc.SubprocessKeyboardListener")
     @patch("src.jarvis.dictation.dictation_engine.platform")
     @patch("src.jarvis.dictation.dictation_engine.sys")
     @patch("src.jarvis.dictation.dictation_engine.pynput_keyboard")
-    def test_start_creates_listener(self, mock_kb, mock_sys, mock_platform):
+    def test_start_creates_listener(self, mock_kb, mock_sys, mock_platform, mock_sub_cls):
         # Force a platform where pynput is allowed (avoid macOS 26+ guard)
         mock_sys.platform = "linux"
-        mock_listener_instance = MagicMock()
-        mock_kb.Listener.return_value = mock_listener_instance
         mock_kb.Key = MagicMock()
         mock_kb.KeyCode = MagicMock()
         mock_kb.Key.ctrl_l = MagicMock()
         mock_kb.Key.shift = MagicMock()
+        mock_listener_instance = MagicMock()
+        mock_sub_cls.return_value = mock_listener_instance
 
         engine = _make_engine()
         engine.start()
 
         assert engine._started is True
+        # Listener now lives in a child process — engine drives it via the
+        # SubprocessKeyboardListener wrapper, never pynput.Listener directly.
+        mock_kb.Listener.assert_not_called()
         mock_listener_instance.start.assert_called_once()
 
         engine.stop()
         assert engine._started is False
+        mock_listener_instance.stop.assert_called_once()
 
     @patch("src.jarvis.dictation.dictation_engine.pynput_keyboard", None)
     def test_start_without_pynput_is_noop(self):
@@ -192,11 +197,14 @@ class TestEngineLifecycle:
         engine.start()
         assert engine._started is False
 
+    @patch("src.jarvis.dictation.listener_proc.SubprocessKeyboardListener")
     @patch("src.jarvis.dictation.dictation_engine.platform")
     @patch("src.jarvis.dictation.dictation_engine.sys")
     @patch("src.jarvis.dictation.dictation_engine.pynput_keyboard")
-    def test_start_skips_on_macos_26(self, mock_kb, mock_sys, mock_platform):
-        """pynput crashes on macOS 26+ (TSM thread assertion). Engine must skip."""
+    def test_start_skips_on_macos_26(self, mock_kb, mock_sys, mock_platform, mock_sub_cls):
+        """pynput crashes on macOS 26+ (TSM thread assertion). Engine must skip
+        even spawning the subprocess — no point starting a child we know will
+        crash on first key event."""
         mock_sys.platform = "darwin"
         mock_platform.mac_ver.return_value = ("26.2", ("", "", ""), "")
         mock_kb.Key = MagicMock()
@@ -207,21 +215,23 @@ class TestEngineLifecycle:
         engine = _make_engine()
         engine.start()
         assert engine._started is False
+        mock_sub_cls.assert_not_called()
         mock_kb.Listener.assert_not_called()
 
+    @patch("src.jarvis.dictation.listener_proc.SubprocessKeyboardListener")
     @patch("src.jarvis.dictation.dictation_engine.platform")
     @patch("src.jarvis.dictation.dictation_engine.sys")
     @patch("src.jarvis.dictation.dictation_engine.pynput_keyboard")
-    def test_start_allowed_on_macos_15(self, mock_kb, mock_sys, mock_platform):
+    def test_start_allowed_on_macos_15(self, mock_kb, mock_sys, mock_platform, mock_sub_cls):
         """pynput should still work on macOS 15 (Sequoia) and earlier."""
         mock_sys.platform = "darwin"
         mock_platform.mac_ver.return_value = ("15.4", ("", "", ""), "")
-        mock_listener = MagicMock()
-        mock_kb.Listener.return_value = mock_listener
         mock_kb.Key = MagicMock()
         mock_kb.KeyCode = MagicMock()
         mock_kb.Key.ctrl_l = MagicMock()
         mock_kb.Key.shift = MagicMock()
+        mock_listener = MagicMock()
+        mock_sub_cls.return_value = mock_listener
 
         engine = _make_engine()
         engine.start()
@@ -229,18 +239,19 @@ class TestEngineLifecycle:
         mock_listener.start.assert_called_once()
         engine.stop()
 
+    @patch("src.jarvis.dictation.listener_proc.SubprocessKeyboardListener")
     @patch("src.jarvis.dictation.dictation_engine.platform")
     @patch("src.jarvis.dictation.dictation_engine.sys")
     @patch("src.jarvis.dictation.dictation_engine.pynput_keyboard")
-    def test_start_allowed_on_windows(self, mock_kb, mock_sys, mock_platform):
+    def test_start_allowed_on_windows(self, mock_kb, mock_sys, mock_platform, mock_sub_cls):
         """Windows should not be affected by the macOS guard."""
         mock_sys.platform = "win32"
-        mock_listener = MagicMock()
-        mock_kb.Listener.return_value = mock_listener
         mock_kb.Key = MagicMock()
         mock_kb.KeyCode = MagicMock()
         mock_kb.Key.ctrl_l = MagicMock()
         mock_kb.Key.shift = MagicMock()
+        mock_listener = MagicMock()
+        mock_sub_cls.return_value = mock_listener
 
         engine = _make_engine()
         engine.start()

--- a/tests/test_dictation.py
+++ b/tests/test_dictation.py
@@ -357,6 +357,49 @@ class TestRecordingStateMachine:
         engine._start_recording()
         assert engine._recording is False
 
+    def test_start_recording_plays_not_ready_beep_when_whisper_missing(self, capsys):
+        """Hotkey fired but Whisper not loaded → audible + visible feedback.
+
+        Without this the user just sees the hotkey doing nothing and assumes
+        dictation itself is broken.  The spec requires a "not ready" beep
+        and the user-facing console line gives a hint about what to do.
+        """
+        from src.jarvis.dictation.dictation_engine import _get_not_ready_beep
+
+        engine = _make_engine(whisper_model_ref=lambda: None)
+        with patch("src.jarvis.dictation.dictation_engine._play_beep") as mock_beep:
+            engine._start_recording()
+        mock_beep.assert_called_once_with(_get_not_ready_beep())
+        captured = capsys.readouterr()
+        assert "Whisper" in captured.out and "⚠️" in captured.out
+        assert engine._recording is False
+
+    def test_start_recording_surfaces_audio_stream_open_failure(self, capsys):
+        """Audio device unavailable → not-ready beep + console line, not silence."""
+        from src.jarvis.dictation.dictation_engine import _get_not_ready_beep
+
+        engine = _make_engine()
+        with patch("src.jarvis.dictation.dictation_engine.sd") as mock_sd, \
+             patch("src.jarvis.dictation.dictation_engine._play_beep") as mock_beep:
+            mock_sd.query_devices.return_value = {"default_samplerate": 16000}
+            mock_sd.InputStream.side_effect = RuntimeError("no audio device")
+            engine._start_recording()
+        # Start beep would have fired before the failure; the not-ready beep
+        # must follow so the user knows recording aborted.
+        called_with = [c.args[0] for c in mock_beep.call_args_list]
+        assert _get_not_ready_beep() in called_with
+        captured = capsys.readouterr()
+        assert "audio stream" in captured.out and "⚠️" in captured.out
+        assert engine._recording is False
+
+    def test_not_ready_beep_is_distinct_from_start_and_stop(self):
+        """Not-ready beep must sound different so the user can tell them apart."""
+        from src.jarvis.dictation.dictation_engine import (
+            _get_not_ready_beep, _get_start_beep, _get_stop_beep,
+        )
+        assert _get_not_ready_beep() != _get_start_beep()
+        assert _get_not_ready_beep() != _get_stop_beep()
+
     def test_start_recording_allows_mlx_without_model(self):
         """MLX backend uses repo reference, not model object."""
         engine = _make_engine(

--- a/tests/test_dictation.py
+++ b/tests/test_dictation.py
@@ -129,6 +129,81 @@ class TestHotkeyParsing:
         assert trigger is not None
 
 
+class TestModifierFamilyMatching:
+    """Modifier keys should match regardless of handedness.
+
+    pynput may report ``ctrl`` (generic, VK 0x11) or ``ctrl_l`` (VK 0xA2)
+    depending on the platform and whether the Listener runs in a subprocess.
+    The engine must treat these as equivalent when checking the hotkey.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _skip_if_no_pynput(self):
+        try:
+            import pynput  # noqa: F401
+        except ImportError:
+            pytest.skip("pynput not installed")
+
+    def _make_engine_with_hotkey(self, hotkey):
+        from src.jarvis.dictation.dictation_engine import DictationEngine
+        import threading
+        return DictationEngine(
+            whisper_model_ref=lambda: None,
+            whisper_backend_ref=lambda: None,
+            mlx_repo_ref=lambda: None,
+            hotkey=hotkey,
+            sample_rate=16000,
+            transcribe_lock=threading.Lock(),
+        )
+
+    def test_generic_ctrl_satisfies_ctrl_l_requirement(self):
+        """Key.ctrl (VK 0x11) must satisfy a hotkey that requires Key.ctrl_l."""
+        from pynput import keyboard as pk
+        engine = self._make_engine_with_hotkey("ctrl+cmd")
+        # Simulate: pynput emits the generic Key.ctrl instead of Key.ctrl_l
+        assert engine._key_matches(pk.Key.ctrl, pk.Key.ctrl, pk.Key.ctrl_l)
+
+    def test_ctrl_l_satisfies_ctrl_requirement(self):
+        """Key.ctrl_l must satisfy a hotkey that requires the generic Key.ctrl."""
+        from pynput import keyboard as pk
+        engine = self._make_engine_with_hotkey("ctrl+cmd")
+        assert engine._key_matches(pk.Key.ctrl_l, pk.Key.ctrl_l, pk.Key.ctrl)
+
+    def test_ctrl_r_satisfies_ctrl_l_requirement(self):
+        """Right Ctrl must satisfy a left-Ctrl requirement (hotkey says 'ctrl')."""
+        from pynput import keyboard as pk
+        engine = self._make_engine_with_hotkey("ctrl+cmd")
+        assert engine._key_matches(pk.Key.ctrl_r, pk.Key.ctrl_r, pk.Key.ctrl_l)
+
+    def test_cmd_r_satisfies_cmd_requirement(self):
+        """Right Win / Cmd must satisfy a hotkey that requires generic Key.cmd."""
+        from pynput import keyboard as pk
+        engine = self._make_engine_with_hotkey("ctrl+cmd")
+        assert engine._key_matches(pk.Key.cmd_r, pk.Key.cmd_r, pk.Key.cmd)
+
+    def test_all_modifiers_held_with_generic_ctrl(self):
+        """_all_modifiers_held must return True when generic Key.ctrl is pressed
+        but the hotkey requires Key.ctrl_l."""
+        from pynput import keyboard as pk
+        engine = self._make_engine_with_hotkey("ctrl+cmd")
+        # Simulate pressing generic ctrl + cmd
+        engine._pressed_modifiers = {pk.Key.ctrl, pk.Key.cmd}
+        assert engine._all_modifiers_held()
+
+    def test_all_modifiers_held_with_sided_keys(self):
+        """Sided modifier keys (ctrl_l + cmd) must satisfy the hotkey requirement."""
+        from pynput import keyboard as pk
+        engine = self._make_engine_with_hotkey("ctrl+cmd")
+        engine._pressed_modifiers = {pk.Key.ctrl_l, pk.Key.cmd}
+        assert engine._all_modifiers_held()
+
+    def test_wrong_modifier_family_does_not_match(self):
+        """Alt must NOT satisfy a ctrl requirement."""
+        from pynput import keyboard as pk
+        engine = self._make_engine_with_hotkey("ctrl+cmd")
+        assert not engine._key_matches(pk.Key.alt_l, pk.Key.alt_l, pk.Key.ctrl_l)
+
+
 # ---------------------------------------------------------------------------
 # Engine lifecycle
 # ---------------------------------------------------------------------------

--- a/tests/test_dictation_listener_proc.py
+++ b/tests/test_dictation_listener_proc.py
@@ -1,0 +1,341 @@
+"""Tests for the subprocess-isolated pynput keyboard listener.
+
+The pynput Listener has been observed to crash with SIGILL/SIGABRT in C-level
+code (CGEventTap on macOS, low-level Win32 hooks on Windows). Running it in a
+separate process means a crash kills the child only — the daemon stays up
+(issues #252, #353, #354).
+
+These tests exercise the parent-side wrapper without spawning real subprocesses
+so they are fast and deterministic, then a smaller integration test verifies
+that crash isolation actually holds end-to-end.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import threading
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# Skip the whole module if pynput isn't installed (CI without GUI deps).
+pytest.importorskip("pynput")
+
+
+# ---------------------------------------------------------------------------
+# Key serialisation round-trips
+# ---------------------------------------------------------------------------
+
+class TestKeySerialisation:
+    """Pynput key/keycode objects must survive a process boundary as plain dicts."""
+
+    def test_named_key_round_trip(self):
+        from pynput import keyboard as pk
+        from src.jarvis.dictation.listener_proc import _serialise_key, _deserialise_key
+
+        original = pk.Key.ctrl_l
+        wire = _serialise_key(original)
+        restored = _deserialise_key(wire)
+        assert restored == original
+
+    def test_char_keycode_round_trip(self):
+        from pynput import keyboard as pk
+        from src.jarvis.dictation.listener_proc import _serialise_key, _deserialise_key
+
+        original = pk.KeyCode.from_char("a")
+        wire = _serialise_key(original)
+        restored = _deserialise_key(wire)
+        assert restored == original
+
+    def test_vk_only_keycode_round_trip(self):
+        """Modifier combos sometimes give KeyCode with vk but char=None."""
+        from pynput import keyboard as pk
+        from src.jarvis.dictation.listener_proc import _serialise_key, _deserialise_key
+
+        original = pk.KeyCode.from_vk(65)  # 'A' on Windows VK
+        wire = _serialise_key(original)
+        restored = _deserialise_key(wire)
+        # Round-trip should preserve vk equality
+        assert restored.vk == original.vk
+
+    def test_unknown_kind_deserialises_to_none(self):
+        from src.jarvis.dictation.listener_proc import _deserialise_key
+        assert _deserialise_key({"kind": "garbage"}) is None
+        assert _deserialise_key({}) is None
+
+
+# ---------------------------------------------------------------------------
+# Wrapper lifecycle (mocked subprocess)
+# ---------------------------------------------------------------------------
+
+class _FakeConn:
+    """Minimal stand-in for a one-way multiprocessing.Pipe end."""
+
+    def __init__(self):
+        self._inbox: list = []
+        self._lock = threading.Lock()
+        self._closed = False
+        self._eof = False
+
+    def send_to_parent(self, msg) -> None:
+        with self._lock:
+            self._inbox.append(msg)
+
+    def signal_eof(self) -> None:
+        with self._lock:
+            self._eof = True
+
+    def poll(self, timeout: float = 0.0) -> bool:
+        # Real multiprocessing.Pipe.poll returns True for a closed/EOF pipe
+        # so the next recv() raises EOFError immediately.
+        deadline = time.time() + timeout
+        while True:
+            with self._lock:
+                if self._inbox or self._eof or self._closed:
+                    return True
+            if time.time() >= deadline:
+                return False
+            time.sleep(0.01)
+
+    def recv(self):
+        with self._lock:
+            if self._inbox:
+                return self._inbox.pop(0)
+            if self._eof:
+                raise EOFError
+            raise OSError("recv on empty closed pipe")
+
+    def close(self) -> None:
+        with self._lock:
+            self._closed = True
+
+
+class _FakeProc:
+    """Stand-in for a multiprocessing.Process with controllable liveness."""
+
+    def __init__(self):
+        self._alive = True
+        self.terminate_called = False
+        self.kill_called = False
+
+    def start(self) -> None:
+        self._alive = True
+
+    def is_alive(self) -> bool:
+        return self._alive
+
+    def die(self) -> None:
+        """Simulate the child process crashing."""
+        self._alive = False
+
+    def terminate(self) -> None:
+        self.terminate_called = True
+        self._alive = False
+
+    def kill(self) -> None:
+        self.kill_called = True
+        self._alive = False
+
+    def join(self, timeout=None) -> None:
+        return None
+
+
+def _install_fake_context(monkeypatch, conn: _FakeConn, proc: _FakeProc):
+    """Patch multiprocessing.get_context so the wrapper uses our fakes."""
+    fake_ctx = MagicMock()
+    fake_ctx.Pipe.return_value = (conn, MagicMock())  # parent_conn, child_conn
+    fake_ctx.Process.return_value = proc
+
+    from src.jarvis.dictation import listener_proc
+    monkeypatch.setattr(listener_proc.multiprocessing, "get_context", lambda *_a, **_kw: fake_ctx)
+    return fake_ctx
+
+
+class TestSubprocessListenerLifecycle:
+    """The wrapper must spawn, relay, stop, and survive child crashes."""
+
+    def test_start_spawns_child_process(self, monkeypatch):
+        from src.jarvis.dictation.listener_proc import SubprocessKeyboardListener
+
+        conn, proc = _FakeConn(), _FakeProc()
+        ctx = _install_fake_context(monkeypatch, conn, proc)
+
+        listener = SubprocessKeyboardListener(on_press=MagicMock(), on_release=MagicMock())
+        try:
+            listener.start()
+            assert ctx.Process.called
+            # Child end of pipe must be passed to the subprocess function.
+            args, kwargs = ctx.Process.call_args
+            assert kwargs.get("daemon") is True
+        finally:
+            listener.stop()
+
+    def test_relays_press_events_to_callback(self, monkeypatch):
+        from pynput import keyboard as pk
+        from src.jarvis.dictation.listener_proc import SubprocessKeyboardListener, _serialise_key
+
+        conn, proc = _FakeConn(), _FakeProc()
+        _install_fake_context(monkeypatch, conn, proc)
+
+        seen: list = []
+        listener = SubprocessKeyboardListener(
+            on_press=lambda k: seen.append(("press", k)),
+            on_release=lambda k: seen.append(("release", k)),
+        )
+        try:
+            listener.start()
+            conn.send_to_parent({"event": "press", "key": _serialise_key(pk.Key.ctrl_l)})
+            conn.send_to_parent({"event": "release", "key": _serialise_key(pk.KeyCode.from_char("d"))})
+
+            deadline = time.time() + 2.0
+            while time.time() < deadline and len(seen) < 2:
+                time.sleep(0.02)
+        finally:
+            listener.stop()
+
+        assert ("press", pk.Key.ctrl_l) in seen
+        assert any(tag == "release" and getattr(k, "char", None) == "d" for tag, k in seen)
+
+    def test_callback_exception_does_not_kill_reader(self, monkeypatch):
+        from pynput import keyboard as pk
+        from src.jarvis.dictation.listener_proc import SubprocessKeyboardListener, _serialise_key
+
+        conn, proc = _FakeConn(), _FakeProc()
+        _install_fake_context(monkeypatch, conn, proc)
+
+        deliveries: list = []
+
+        def boom(_key):
+            deliveries.append("boom")
+            raise RuntimeError("callback exploded")
+
+        def ok(_key):
+            deliveries.append("ok")
+
+        listener = SubprocessKeyboardListener(on_press=boom, on_release=ok)
+        try:
+            listener.start()
+            conn.send_to_parent({"event": "press", "key": _serialise_key(pk.Key.ctrl_l)})
+            conn.send_to_parent({"event": "release", "key": _serialise_key(pk.Key.ctrl_l)})
+
+            deadline = time.time() + 2.0
+            while time.time() < deadline and len(deliveries) < 2:
+                time.sleep(0.02)
+        finally:
+            listener.stop()
+
+        assert deliveries == ["boom", "ok"]
+
+    def test_subprocess_death_stops_reader_without_exception(self, monkeypatch):
+        """If the child crashes (SIGILL), the parent must stay up."""
+        from src.jarvis.dictation.listener_proc import SubprocessKeyboardListener
+
+        conn, proc = _FakeConn(), _FakeProc()
+        _install_fake_context(monkeypatch, conn, proc)
+
+        listener = SubprocessKeyboardListener(on_press=MagicMock(), on_release=MagicMock())
+        try:
+            listener.start()
+            # Simulate the child crashing — no EOF on pipe, just process gone.
+            proc.die()
+            # Reader thread should exit on its own within a couple of poll cycles.
+            deadline = time.time() + 3.0
+            reader = listener._reader_thread
+            while time.time() < deadline and reader is not None and reader.is_alive():
+                time.sleep(0.05)
+            assert reader is None or not reader.is_alive(), (
+                "reader thread did not exit after subprocess died — "
+                "would leak forever and never report the crash"
+            )
+        finally:
+            listener.stop()
+
+    def test_pipe_eof_exits_reader(self, monkeypatch):
+        from src.jarvis.dictation.listener_proc import SubprocessKeyboardListener
+
+        conn, proc = _FakeConn(), _FakeProc()
+        _install_fake_context(monkeypatch, conn, proc)
+
+        listener = SubprocessKeyboardListener(on_press=MagicMock(), on_release=MagicMock())
+        try:
+            listener.start()
+            conn.signal_eof()
+            deadline = time.time() + 3.0
+            reader = listener._reader_thread
+            while time.time() < deadline and reader is not None and reader.is_alive():
+                time.sleep(0.05)
+            assert reader is None or not reader.is_alive()
+        finally:
+            listener.stop()
+
+    def test_stop_terminates_subprocess(self, monkeypatch):
+        from src.jarvis.dictation.listener_proc import SubprocessKeyboardListener
+
+        conn, proc = _FakeConn(), _FakeProc()
+        _install_fake_context(monkeypatch, conn, proc)
+
+        listener = SubprocessKeyboardListener(on_press=MagicMock(), on_release=MagicMock())
+        listener.start()
+        listener.stop()
+
+        assert proc.terminate_called
+
+    def test_stop_is_idempotent(self, monkeypatch):
+        from src.jarvis.dictation.listener_proc import SubprocessKeyboardListener
+
+        conn, proc = _FakeConn(), _FakeProc()
+        _install_fake_context(monkeypatch, conn, proc)
+
+        listener = SubprocessKeyboardListener(on_press=MagicMock(), on_release=MagicMock())
+        listener.start()
+        listener.stop()
+        listener.stop()  # Must not raise.
+
+
+# ---------------------------------------------------------------------------
+# End-to-end crash isolation (real subprocess)
+# ---------------------------------------------------------------------------
+
+def _crash_target(conn):
+    """Module-level target so multiprocessing.spawn can pickle it."""
+    # Simulate a native abort() — same blast radius as a SIGILL from C code.
+    os._exit(134)
+
+
+@pytest.mark.skipif(
+    sys.platform == "linux" and not os.environ.get("DISPLAY"),
+    reason="pynput Listener requires X11 on Linux",
+)
+class TestRealSubprocessCrashIsolation:
+    """Verify that a child crash actually does not take down the parent."""
+
+    def test_child_crash_does_not_kill_parent(self):
+        """Spawn a child that immediately exits abnormally; parent's reader
+        thread must exit cleanly and the parent process must keep running."""
+        from src.jarvis.dictation.listener_proc import SubprocessKeyboardListener
+
+        with patch(
+            "src.jarvis.dictation.listener_proc._listener_main",
+            new=_crash_target,
+        ):
+            listener = SubprocessKeyboardListener(
+                on_press=MagicMock(),
+                on_release=MagicMock(),
+            )
+            try:
+                listener.start()
+                # Reader thread should detect the dead process and exit.
+                deadline = time.time() + 8.0
+                reader = listener._reader_thread
+                while time.time() < deadline and reader is not None and reader.is_alive():
+                    time.sleep(0.1)
+                assert reader is None or not reader.is_alive(), (
+                    "reader thread did not exit after child died"
+                )
+            finally:
+                listener.stop()
+
+        # Parent process is obviously still alive — that's the whole point.

--- a/tests/test_dictation_listener_proc.py
+++ b/tests/test_dictation_listener_proc.py
@@ -55,10 +55,9 @@ class TestKeySerialisation:
         from pynput import keyboard as pk
         from src.jarvis.dictation.listener_proc import _serialise_key, _deserialise_key
 
-        original = pk.KeyCode.from_vk(65)  # 'A' on Windows VK
+        original = pk.KeyCode.from_vk(65)
         wire = _serialise_key(original)
         restored = _deserialise_key(wire)
-        # Round-trip should preserve vk equality
         assert restored.vk == original.vk
 
     def test_unknown_kind_deserialises_to_none(self):
@@ -68,11 +67,11 @@ class TestKeySerialisation:
 
 
 # ---------------------------------------------------------------------------
-# Wrapper lifecycle (mocked subprocess)
+# Test doubles for spawn / Pipe
 # ---------------------------------------------------------------------------
 
 class _FakeConn:
-    """Minimal stand-in for a one-way multiprocessing.Pipe end."""
+    """One-way Pipe end stand-in."""
 
     def __init__(self):
         self._inbox: list = []
@@ -89,8 +88,6 @@ class _FakeConn:
             self._eof = True
 
     def poll(self, timeout: float = 0.0) -> bool:
-        # Real multiprocessing.Pipe.poll returns True for a closed/EOF pipe
-        # so the next recv() raises EOFError immediately.
         deadline = time.time() + timeout
         while True:
             with self._lock:
@@ -114,10 +111,10 @@ class _FakeConn:
 
 
 class _FakeProc:
-    """Stand-in for a multiprocessing.Process with controllable liveness."""
+    """multiprocessing.Process stand-in with controllable liveness."""
 
     def __init__(self):
-        self._alive = True
+        self._alive = False
         self.terminate_called = False
         self.kill_called = False
 
@@ -128,7 +125,6 @@ class _FakeProc:
         return self._alive
 
     def die(self) -> None:
-        """Simulate the child process crashing."""
         self._alive = False
 
     def terminate(self) -> None:
@@ -143,42 +139,82 @@ class _FakeProc:
         return None
 
 
-def _install_fake_context(monkeypatch, conn: _FakeConn, proc: _FakeProc):
-    """Patch multiprocessing.get_context so the wrapper uses our fakes."""
+def _install_pluggable_fake_context(monkeypatch):
+    """Patch ``multiprocessing.get_context`` to hand out fresh fakes per spawn.
+
+    Returns a list that captures every (conn, proc) pair the wrapper allocates,
+    so tests can drive specific generations.
+    """
+    spawned: list[tuple[_FakeConn, _FakeProc]] = []
+
+    def make_pair():
+        conn, child_conn = _FakeConn(), _FakeConn()
+        proc = _FakeProc()
+        spawned.append((conn, proc))
+        return conn, child_conn, proc
+
     fake_ctx = MagicMock()
-    fake_ctx.Pipe.return_value = (conn, MagicMock())  # parent_conn, child_conn
-    fake_ctx.Process.return_value = proc
+
+    pending: list[tuple[_FakeConn, _FakeConn, _FakeProc]] = []
+
+    def pipe_side_effect(*_a, **_kw):
+        triple = make_pair()
+        pending.append(triple)
+        return triple[0], triple[1]
+
+    def process_side_effect(*_a, **_kw):
+        return pending.pop(0)[2]
+
+    fake_ctx.Pipe.side_effect = pipe_side_effect
+    fake_ctx.Process.side_effect = process_side_effect
 
     from src.jarvis.dictation import listener_proc
     monkeypatch.setattr(listener_proc.multiprocessing, "get_context", lambda *_a, **_kw: fake_ctx)
-    return fake_ctx
+    return spawned
 
+
+def _accelerate_supervisor(monkeypatch):
+    """Shrink retry caps and backoff so respawn behaviour is testable in <1 s."""
+    from src.jarvis.dictation.listener_proc import SubprocessKeyboardListener
+    monkeypatch.setattr(SubprocessKeyboardListener, "_BACKOFF_SCHEDULE", (0.0,))
+    monkeypatch.setattr(SubprocessKeyboardListener, "_CLEAN_RUN_WINDOW", 30.0)
+
+
+def _wait_until(predicate, timeout: float = 2.0) -> bool:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.02)
+    return predicate()
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle (mocked subprocess)
+# ---------------------------------------------------------------------------
 
 class TestSubprocessListenerLifecycle:
-    """The wrapper must spawn, relay, stop, and survive child crashes."""
-
     def test_start_spawns_child_process(self, monkeypatch):
         from src.jarvis.dictation.listener_proc import SubprocessKeyboardListener
 
-        conn, proc = _FakeConn(), _FakeProc()
-        ctx = _install_fake_context(monkeypatch, conn, proc)
+        spawned = _install_pluggable_fake_context(monkeypatch)
+        _accelerate_supervisor(monkeypatch)
 
         listener = SubprocessKeyboardListener(on_press=MagicMock(), on_release=MagicMock())
         try:
             listener.start()
-            assert ctx.Process.called
-            # Child end of pipe must be passed to the subprocess function.
-            args, kwargs = ctx.Process.call_args
-            assert kwargs.get("daemon") is True
+            assert _wait_until(lambda: len(spawned) >= 1)
+            conn, proc = spawned[0]
+            assert proc.is_alive()
         finally:
             listener.stop()
 
-    def test_relays_press_events_to_callback(self, monkeypatch):
+    def test_relays_press_and_release_events(self, monkeypatch):
         from pynput import keyboard as pk
         from src.jarvis.dictation.listener_proc import SubprocessKeyboardListener, _serialise_key
 
-        conn, proc = _FakeConn(), _FakeProc()
-        _install_fake_context(monkeypatch, conn, proc)
+        spawned = _install_pluggable_fake_context(monkeypatch)
+        _accelerate_supervisor(monkeypatch)
 
         seen: list = []
         listener = SubprocessKeyboardListener(
@@ -187,12 +223,13 @@ class TestSubprocessListenerLifecycle:
         )
         try:
             listener.start()
+            assert _wait_until(lambda: spawned and spawned[0][0] is not None)
+            conn, _proc = spawned[0]
+
             conn.send_to_parent({"event": "press", "key": _serialise_key(pk.Key.ctrl_l)})
             conn.send_to_parent({"event": "release", "key": _serialise_key(pk.KeyCode.from_char("d"))})
 
-            deadline = time.time() + 2.0
-            while time.time() < deadline and len(seen) < 2:
-                time.sleep(0.02)
+            assert _wait_until(lambda: len(seen) >= 2)
         finally:
             listener.stop()
 
@@ -203,8 +240,8 @@ class TestSubprocessListenerLifecycle:
         from pynput import keyboard as pk
         from src.jarvis.dictation.listener_proc import SubprocessKeyboardListener, _serialise_key
 
-        conn, proc = _FakeConn(), _FakeProc()
-        _install_fake_context(monkeypatch, conn, proc)
+        spawned = _install_pluggable_fake_context(monkeypatch)
+        _accelerate_supervisor(monkeypatch)
 
         deliveries: list = []
 
@@ -212,119 +249,161 @@ class TestSubprocessListenerLifecycle:
             deliveries.append("boom")
             raise RuntimeError("callback exploded")
 
-        def ok(_key):
-            deliveries.append("ok")
-
-        listener = SubprocessKeyboardListener(on_press=boom, on_release=ok)
+        listener = SubprocessKeyboardListener(on_press=boom, on_release=lambda _k: deliveries.append("ok"))
         try:
             listener.start()
+            assert _wait_until(lambda: spawned and spawned[0][0] is not None)
+            conn, _proc = spawned[0]
             conn.send_to_parent({"event": "press", "key": _serialise_key(pk.Key.ctrl_l)})
             conn.send_to_parent({"event": "release", "key": _serialise_key(pk.Key.ctrl_l)})
 
-            deadline = time.time() + 2.0
-            while time.time() < deadline and len(deliveries) < 2:
-                time.sleep(0.02)
+            assert _wait_until(lambda: len(deliveries) >= 2)
         finally:
             listener.stop()
 
         assert deliveries == ["boom", "ok"]
 
-    def test_subprocess_death_stops_reader_without_exception(self, monkeypatch):
-        """If the child crashes (SIGILL), the parent must stay up."""
+    def test_error_event_does_not_trigger_respawn(self, monkeypatch):
+        """A child-side error payload is logged but the live child stays alive."""
         from src.jarvis.dictation.listener_proc import SubprocessKeyboardListener
 
-        conn, proc = _FakeConn(), _FakeProc()
-        _install_fake_context(monkeypatch, conn, proc)
+        spawned = _install_pluggable_fake_context(monkeypatch)
+        _accelerate_supervisor(monkeypatch)
 
         listener = SubprocessKeyboardListener(on_press=MagicMock(), on_release=MagicMock())
         try:
             listener.start()
-            # Simulate the child crashing — no EOF on pipe, just process gone.
-            proc.die()
-            # Reader thread should exit on its own within a couple of poll cycles.
-            deadline = time.time() + 3.0
-            reader = listener._reader_thread
-            while time.time() < deadline and reader is not None and reader.is_alive():
-                time.sleep(0.05)
-            assert reader is None or not reader.is_alive(), (
-                "reader thread did not exit after subprocess died — "
-                "would leak forever and never report the crash"
-            )
-        finally:
-            listener.stop()
+            assert _wait_until(lambda: spawned and spawned[0][0] is not None)
+            conn, proc = spawned[0]
+            conn.send_to_parent({"event": "error", "message": "transient pynput hiccup"})
 
-    def test_pipe_eof_exits_reader(self, monkeypatch):
-        from src.jarvis.dictation.listener_proc import SubprocessKeyboardListener
-
-        conn, proc = _FakeConn(), _FakeProc()
-        _install_fake_context(monkeypatch, conn, proc)
-
-        listener = SubprocessKeyboardListener(on_press=MagicMock(), on_release=MagicMock())
-        try:
-            listener.start()
-            conn.signal_eof()
-            deadline = time.time() + 3.0
-            reader = listener._reader_thread
-            while time.time() < deadline and reader is not None and reader.is_alive():
-                time.sleep(0.05)
-            assert reader is None or not reader.is_alive()
+            time.sleep(0.1)
+            assert proc.is_alive()
+            assert len(spawned) == 1  # no respawn
         finally:
             listener.stop()
 
     def test_stop_terminates_subprocess(self, monkeypatch):
         from src.jarvis.dictation.listener_proc import SubprocessKeyboardListener
 
-        conn, proc = _FakeConn(), _FakeProc()
-        _install_fake_context(monkeypatch, conn, proc)
+        spawned = _install_pluggable_fake_context(monkeypatch)
+        _accelerate_supervisor(monkeypatch)
 
         listener = SubprocessKeyboardListener(on_press=MagicMock(), on_release=MagicMock())
         listener.start()
+        assert _wait_until(lambda: spawned and spawned[0][1].is_alive())
         listener.stop()
 
+        _conn, proc = spawned[0]
         assert proc.terminate_called
+        assert listener._supervisor_thread is None
 
     def test_stop_is_idempotent(self, monkeypatch):
         from src.jarvis.dictation.listener_proc import SubprocessKeyboardListener
 
-        conn, proc = _FakeConn(), _FakeProc()
-        _install_fake_context(monkeypatch, conn, proc)
+        _install_pluggable_fake_context(monkeypatch)
+        _accelerate_supervisor(monkeypatch)
 
         listener = SubprocessKeyboardListener(on_press=MagicMock(), on_release=MagicMock())
         listener.start()
         listener.stop()
         listener.stop()  # Must not raise.
 
-    def test_error_event_logs_without_killing_reader(self, monkeypatch):
-        """An ``error`` payload from the child should be logged but must not
-        crash or stop the reader — the child may keep producing key events
-        after a transient warning."""
+
+# ---------------------------------------------------------------------------
+# Auto-respawn (the whole point of the supervisor)
+# ---------------------------------------------------------------------------
+
+class TestAutoRespawn:
+    def test_subprocess_death_triggers_respawn(self, monkeypatch):
+        """When the child dies, the supervisor must spawn a fresh child."""
         from src.jarvis.dictation.listener_proc import SubprocessKeyboardListener
 
-        conn, proc = _FakeConn(), _FakeProc()
-        _install_fake_context(monkeypatch, conn, proc)
+        spawned = _install_pluggable_fake_context(monkeypatch)
+        _accelerate_supervisor(monkeypatch)
 
-        on_press = MagicMock()
-        listener = SubprocessKeyboardListener(on_press=on_press, on_release=MagicMock())
+        listener = SubprocessKeyboardListener(on_press=MagicMock(), on_release=MagicMock())
         try:
             listener.start()
-            conn.send_to_parent({"event": "error", "message": "transient pynput hiccup"})
-            # Reader thread should still be running and able to dispatch
-            # subsequent events.
-            time.sleep(0.1)
-            reader = listener._reader_thread
-            assert reader is not None and reader.is_alive()
+            assert _wait_until(lambda: spawned and spawned[0][1].is_alive())
+            spawned[0][1].die()  # simulate native crash
+
+            # Supervisor should respawn — wait for a second generation.
+            assert _wait_until(lambda: len(spawned) >= 2, timeout=3.0)
+            assert spawned[1][1].is_alive()
         finally:
             listener.stop()
 
-    def test_spawn_failure_leaves_wrapper_unstarted(self, monkeypatch):
-        """If the OS refuses to spawn, the wrapper must not raise and must
-        not leak the prepared pipe — the daemon should keep running and the
-        engine should be free to retry on next start."""
+    def test_gives_up_after_max_consecutive_failures(self, monkeypatch):
+        """If every spawned child dies immediately, the supervisor must stop
+        spawning after the cap so we don't burn CPU in a crash loop."""
+        from src.jarvis.dictation.listener_proc import SubprocessKeyboardListener
+
+        spawned = _install_pluggable_fake_context(monkeypatch)
+        _accelerate_supervisor(monkeypatch)
+
+        listener = SubprocessKeyboardListener(on_press=MagicMock(), on_release=MagicMock())
+        try:
+            listener.start()
+            # Kill each generation as it appears, never letting any run for the
+            # clean-window threshold.
+            seen = 0
+            deadline = time.time() + 5.0
+            while time.time() < deadline:
+                if len(spawned) > seen:
+                    spawned[seen][1].die()
+                    seen += 1
+                if not (
+                    listener._supervisor_thread is not None
+                    and listener._supervisor_thread.is_alive()
+                ):
+                    break
+                time.sleep(0.02)
+        finally:
+            listener.stop()
+
+        # Cap is 3 consecutive failures, so we expect at most 3 spawn attempts
+        # before the supervisor gives up.
+        assert len(spawned) == SubprocessKeyboardListener._MAX_CONSECUTIVE_FAILURES, (
+            f"expected exactly {SubprocessKeyboardListener._MAX_CONSECUTIVE_FAILURES} "
+            f"spawn attempts before give-up, saw {len(spawned)}"
+        )
+
+    def test_clean_long_run_resets_failure_counter(self, monkeypatch):
+        """A spawn that ran for longer than ``_CLEAN_RUN_WINDOW`` is treated as
+        the start of a fresh failure series."""
+        from src.jarvis.dictation.listener_proc import SubprocessKeyboardListener
+
+        spawned = _install_pluggable_fake_context(monkeypatch)
+        monkeypatch.setattr(SubprocessKeyboardListener, "_BACKOFF_SCHEDULE", (0.0,))
+        # A very small clean-window so the test runs fast.
+        monkeypatch.setattr(SubprocessKeyboardListener, "_CLEAN_RUN_WINDOW", 0.05)
+
+        listener = SubprocessKeyboardListener(on_press=MagicMock(), on_release=MagicMock())
+        try:
+            listener.start()
+            # Let the first child run past the clean window before killing it.
+            assert _wait_until(lambda: spawned and spawned[0][1].is_alive())
+            time.sleep(0.1)
+            spawned[0][1].die()
+
+            assert _wait_until(lambda: len(spawned) >= 2, timeout=2.0)
+            # Failure counter should have been reset by the clean run, so it is
+            # at 1 (this latest death), not 2.
+            assert listener._failure_count == 1
+        finally:
+            listener.stop()
+
+    def test_spawn_failure_counts_toward_give_up(self, monkeypatch):
+        """If ``proc.start()`` raises every time, give up after the cap."""
         from src.jarvis.dictation import listener_proc
         from src.jarvis.dictation.listener_proc import SubprocessKeyboardListener
 
-        class _FailingProc:
+        attempts = {"n": 0}
+
+        class _AlwaysFailingProc:
             def start(self):
+                attempts["n"] += 1
                 raise OSError("nope")
 
             def is_alive(self):
@@ -339,23 +418,69 @@ class TestSubprocessListenerLifecycle:
             def join(self, timeout=None):
                 pass
 
-        conn = _FakeConn()
         fake_ctx = MagicMock()
-        fake_ctx.Pipe.return_value = (conn, _FakeConn())
-        fake_ctx.Process.return_value = _FailingProc()
-        monkeypatch.setattr(listener_proc.multiprocessing, "get_context", lambda *_a, **_kw: fake_ctx)
+        fake_ctx.Pipe.side_effect = lambda *_a, **_kw: (_FakeConn(), _FakeConn())
+        fake_ctx.Process.side_effect = lambda *_a, **_kw: _AlwaysFailingProc()
+        monkeypatch.setattr(
+            listener_proc.multiprocessing, "get_context", lambda *_a, **_kw: fake_ctx
+        )
+        _accelerate_supervisor(monkeypatch)
 
         listener = SubprocessKeyboardListener(on_press=MagicMock(), on_release=MagicMock())
-        listener.start()  # Must not raise.
+        try:
+            listener.start()
+            # Wait for supervisor to exit (give-up).
+            deadline = time.time() + 3.0
+            while time.time() < deadline:
+                supervisor = listener._supervisor_thread
+                if supervisor is None or not supervisor.is_alive():
+                    break
+                time.sleep(0.02)
+        finally:
+            listener.stop()
 
-        assert listener._proc is None
-        assert listener._reader_thread is None
-        # Wrapper is in initial state — a future start() can retry.
-        listener.stop()  # Idempotent on an unstarted wrapper.
+        assert attempts["n"] == SubprocessKeyboardListener._MAX_CONSECUTIVE_FAILURES
 
+    def test_restart_after_give_up_resets_state(self, monkeypatch):
+        """After giving up, calling ``start()`` again must allow a fresh
+        attempt — the user has presumably fixed whatever caused the loop."""
+        from src.jarvis.dictation.listener_proc import SubprocessKeyboardListener
+
+        spawned = _install_pluggable_fake_context(monkeypatch)
+        _accelerate_supervisor(monkeypatch)
+
+        listener = SubprocessKeyboardListener(on_press=MagicMock(), on_release=MagicMock())
+        try:
+            # First session: kill every child until give-up.
+            listener.start()
+            seen = 0
+            deadline = time.time() + 5.0
+            while time.time() < deadline:
+                if len(spawned) > seen:
+                    spawned[seen][1].die()
+                    seen += 1
+                supervisor = listener._supervisor_thread
+                if supervisor is None or not supervisor.is_alive():
+                    break
+                time.sleep(0.02)
+            assert len(spawned) == SubprocessKeyboardListener._MAX_CONSECUTIVE_FAILURES
+
+            # Second session: should attempt again from a clean state.
+            listener.start()
+            assert _wait_until(
+                lambda: len(spawned) > SubprocessKeyboardListener._MAX_CONSECUTIVE_FAILURES,
+                timeout=3.0,
+            )
+        finally:
+            listener.stop()
+
+
+# ---------------------------------------------------------------------------
+# Error-message truncation
+# ---------------------------------------------------------------------------
+
+class TestErrorMessageTruncation:
     def test_oversized_error_message_is_truncated(self):
-        """Error messages from the child are capped so a runaway traceback
-        can't flood the parent's debug log."""
         from src.jarvis.dictation.listener_proc import _MAX_ERROR_MESSAGE_LEN, _listener_main
 
         sent: list = []
@@ -364,7 +489,6 @@ class TestSubprocessListenerLifecycle:
             def send(self, msg):
                 sent.append(msg)
 
-        # Force pynput import to fail with a giant message.
         import builtins
         original_import = builtins.__import__
 
@@ -379,8 +503,7 @@ class TestSubprocessListenerLifecycle:
         finally:
             builtins.__import__ = original_import
 
-        assert sent, "child should have sent an error payload"
-        assert sent[0]["event"] == "error"
+        assert sent and sent[0]["event"] == "error"
         assert len(sent[0]["message"]) <= _MAX_ERROR_MESSAGE_LEN + len("...[truncated]")
 
 
@@ -390,7 +513,6 @@ class TestSubprocessListenerLifecycle:
 
 def _crash_target(conn):
     """Module-level target so multiprocessing.spawn can pickle it."""
-    # Simulate a native abort() — same blast radius as a SIGILL from C code.
     os._exit(134)
 
 
@@ -401,10 +523,13 @@ def _crash_target(conn):
 class TestRealSubprocessCrashIsolation:
     """Verify that a child crash actually does not take down the parent."""
 
-    def test_child_crash_does_not_kill_parent(self):
-        """Spawn a child that immediately exits abnormally; parent's reader
-        thread must exit cleanly and the parent process must keep running."""
+    def test_child_crash_triggers_respawn_then_give_up(self, monkeypatch):
+        """A child that crashes immediately should be respawned, then the
+        supervisor should give up cleanly without ever taking the parent down."""
         from src.jarvis.dictation.listener_proc import SubprocessKeyboardListener
+
+        # Tighter cap and zero backoff so the test finishes promptly.
+        monkeypatch.setattr(SubprocessKeyboardListener, "_BACKOFF_SCHEDULE", (0.0,))
 
         with patch(
             "src.jarvis.dictation.listener_proc._listener_main",
@@ -416,15 +541,15 @@ class TestRealSubprocessCrashIsolation:
             )
             try:
                 listener.start()
-                # Reader thread should detect the dead process and exit.
-                deadline = time.time() + 8.0
-                reader = listener._reader_thread
-                while time.time() < deadline and reader is not None and reader.is_alive():
+                deadline = time.time() + 30.0
+                while time.time() < deadline:
+                    supervisor = listener._supervisor_thread
+                    if supervisor is None or not supervisor.is_alive():
+                        break
                     time.sleep(0.1)
-                assert reader is None or not reader.is_alive(), (
-                    "reader thread did not exit after child died"
+                supervisor = listener._supervisor_thread
+                assert supervisor is None or not supervisor.is_alive(), (
+                    "supervisor never gave up after repeated child crashes"
                 )
             finally:
                 listener.stop()
-
-        # Parent process is obviously still alive — that's the whole point.

--- a/tests/test_dictation_listener_proc.py
+++ b/tests/test_dictation_listener_proc.py
@@ -1,13 +1,13 @@
 """Tests for the subprocess-isolated pynput keyboard listener.
 
-The pynput Listener has been observed to crash with SIGILL/SIGABRT in C-level
-code (CGEventTap on macOS, low-level Win32 hooks on Windows). Running it in a
-separate process means a crash kills the child only — the daemon stays up
-(issues #252, #353, #354).
+The wrapper exists because pynput's Listener has crashed with SIGILL/SIGABRT
+in C-level code (CGEventTap on macOS, low-level Win32 hooks on Windows),
+and those signals can't be caught from Python. Running it in a separate
+process keeps a native crash from taking down the daemon.
 
-These tests exercise the parent-side wrapper without spawning real subprocesses
-so they are fast and deterministic, then a smaller integration test verifies
-that crash isolation actually holds end-to-end.
+These tests exercise the parent-side wrapper without spawning real
+subprocesses so they are fast and deterministic, then a smaller integration
+test verifies that crash isolation actually holds end-to-end.
 """
 
 from __future__ import annotations
@@ -293,6 +293,95 @@ class TestSubprocessListenerLifecycle:
         listener.start()
         listener.stop()
         listener.stop()  # Must not raise.
+
+    def test_error_event_logs_without_killing_reader(self, monkeypatch):
+        """An ``error`` payload from the child should be logged but must not
+        crash or stop the reader — the child may keep producing key events
+        after a transient warning."""
+        from src.jarvis.dictation.listener_proc import SubprocessKeyboardListener
+
+        conn, proc = _FakeConn(), _FakeProc()
+        _install_fake_context(monkeypatch, conn, proc)
+
+        on_press = MagicMock()
+        listener = SubprocessKeyboardListener(on_press=on_press, on_release=MagicMock())
+        try:
+            listener.start()
+            conn.send_to_parent({"event": "error", "message": "transient pynput hiccup"})
+            # Reader thread should still be running and able to dispatch
+            # subsequent events.
+            time.sleep(0.1)
+            reader = listener._reader_thread
+            assert reader is not None and reader.is_alive()
+        finally:
+            listener.stop()
+
+    def test_spawn_failure_leaves_wrapper_unstarted(self, monkeypatch):
+        """If the OS refuses to spawn, the wrapper must not raise and must
+        not leak the prepared pipe — the daemon should keep running and the
+        engine should be free to retry on next start."""
+        from src.jarvis.dictation import listener_proc
+        from src.jarvis.dictation.listener_proc import SubprocessKeyboardListener
+
+        class _FailingProc:
+            def start(self):
+                raise OSError("nope")
+
+            def is_alive(self):
+                return False
+
+            def terminate(self):
+                pass
+
+            def kill(self):
+                pass
+
+            def join(self, timeout=None):
+                pass
+
+        conn = _FakeConn()
+        fake_ctx = MagicMock()
+        fake_ctx.Pipe.return_value = (conn, _FakeConn())
+        fake_ctx.Process.return_value = _FailingProc()
+        monkeypatch.setattr(listener_proc.multiprocessing, "get_context", lambda *_a, **_kw: fake_ctx)
+
+        listener = SubprocessKeyboardListener(on_press=MagicMock(), on_release=MagicMock())
+        listener.start()  # Must not raise.
+
+        assert listener._proc is None
+        assert listener._reader_thread is None
+        # Wrapper is in initial state — a future start() can retry.
+        listener.stop()  # Idempotent on an unstarted wrapper.
+
+    def test_oversized_error_message_is_truncated(self):
+        """Error messages from the child are capped so a runaway traceback
+        can't flood the parent's debug log."""
+        from src.jarvis.dictation.listener_proc import _MAX_ERROR_MESSAGE_LEN, _listener_main
+
+        sent: list = []
+
+        class _CapturingConn:
+            def send(self, msg):
+                sent.append(msg)
+
+        # Force pynput import to fail with a giant message.
+        import builtins
+        original_import = builtins.__import__
+
+        def boom(name, *args, **kwargs):
+            if name == "pynput" or name.startswith("pynput."):
+                raise RuntimeError("x" * 5000)
+            return original_import(name, *args, **kwargs)
+
+        builtins.__import__ = boom
+        try:
+            _listener_main(_CapturingConn())
+        finally:
+            builtins.__import__ = original_import
+
+        assert sent, "child should have sent an error payload"
+        assert sent[0]["event"] == "error"
+        assert len(sent[0]["message"]) <= _MAX_ERROR_MESSAGE_LEN + len("...[truncated]")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_dictation_listener_proc.py
+++ b/tests/test_dictation_listener_proc.py
@@ -263,6 +263,39 @@ class TestSubprocessListenerLifecycle:
 
         assert deliveries == ["boom", "ok"]
 
+    def test_callback_exception_is_surfaced_on_stderr(self, monkeypatch, capsys):
+        """An exception inside the user callback must be visible without
+        voice_debug.  Otherwise a hotkey doing nothing silently looks like the
+        listener subprocess is dead, when in fact the callback is throwing.
+        """
+        from pynput import keyboard as pk
+        from src.jarvis.dictation.listener_proc import SubprocessKeyboardListener, _serialise_key
+
+        spawned = _install_pluggable_fake_context(monkeypatch)
+        _accelerate_supervisor(monkeypatch)
+
+        delivered: list = []
+
+        def boom(_key):
+            delivered.append(_key)
+            raise RuntimeError("simulated callback failure xyzzy")
+
+        listener = SubprocessKeyboardListener(on_press=boom, on_release=lambda _k: None)
+        try:
+            listener.start()
+            assert _wait_until(lambda: spawned and spawned[0][0] is not None)
+            conn, _proc = spawned[0]
+            conn.send_to_parent({"event": "press", "key": _serialise_key(pk.Key.ctrl_l)})
+            assert _wait_until(lambda: len(delivered) >= 1)
+            # Give the dispatcher a moment to print the traceback.
+            time.sleep(0.05)
+        finally:
+            listener.stop()
+
+        captured = capsys.readouterr()
+        assert "Dictation listener callback raised" in captured.err
+        assert "simulated callback failure xyzzy" in captured.err
+
     def test_error_event_does_not_trigger_respawn(self, monkeypatch):
         """A child-side error payload is logged but the live child stays alive."""
         from src.jarvis.dictation.listener_proc import SubprocessKeyboardListener


### PR DESCRIPTION
## Summary

The pynput keyboard `Listener` runs a CGEventTap (macOS) or low-level Win32 hook in C. Multiple users have hit `Fatal Python error: Illegal instruction` (macOS) and `Aborted` (Windows) inside that thread, which tears the whole daemon down. Python `try/except` cannot catch these signals.

This PR moves the Listener into a child process spawned via `multiprocessing.spawn`. A new `SubprocessKeyboardListener` wrapper relays press/release events to the parent over a `Pipe`, where they are reconstructed as pynput `Key`/`KeyCode` objects and passed to the existing `_on_key_press` / `_on_key_release` handlers. Drop-in replacement for `pynput.keyboard.Listener`.

A native crash in the child now kills the child only. The daemon stays up; dictation goes offline silently until the engine is restarted. A supervisor thread respawns the child transparently on crash, up to 3 consecutive failures before giving up. The existing macOS 26+ TSM guard still short-circuits before spawning, since subprocess isolation only contains crashes — it does not enable Tahoe support, tracked separately at #172.

## Hardening from review

- Hidden imports for pynput's platform shims so the spawned child can import them in frozen builds.
- Privacy and trust model documented in the module docstring: only key identity crosses the pipe, the pipe is local and parent-and-child only.
- Child error-event messages are capped at 200 chars so a runaway traceback cannot flood the parent's debug log.
- `proc.start()` and reader-thread `Thread.start()` are wrapped in try/except so spawn or thread-creation failures leave the wrapper unstarted and the daemon up, instead of raising into the engine.
- Worst-case `stop()` teardown shortened from ~5 s to ~2.5 s; `daemon=True` backstops anything still alive.

## Modifier-key matching fix

Windows can deliver generic modifier VK codes (e.g. `VK_CONTROL` = 0x11, which pynput maps to `Key.ctrl`) instead of the sided variants (`VK_LCONTROL` = 0xA2, mapped to `Key.ctrl_l`) when the Listener runs in a background subprocess. The hotkey parser (`parse_hotkey("ctrl+cmd")`) generates `Key.ctrl_l` / `Key.cmd` as requirements, so a `Key.ctrl` press event would never satisfy the `Key.ctrl_l` requirement, silently breaking Ctrl+Win dictation.

Fix: `_MODIFIER_FAMILIES` tuples group `ctrl`/`ctrl_l`/`ctrl_r`, `cmd`/`cmd_l`/`cmd_r`, `shift`/`shift_l`/`shift_r`, and `alt`/`alt_l`/`alt_r` as interchangeable. Both `_key_matches` and `_all_modifiers_held` now perform a family lookup so any variant of a modifier satisfies any requirement in the same family.

## Tests

- `tests/test_dictation_listener_proc.py` (15 tests): serialisation round-trip, lifecycle, callback exception isolation, EOF and child-death detection, error-event handling, spawn-failure handling, message truncation, and an end-to-end real-subprocess crash test that proves the parent survives.
- `tests/test_dictation.py` updated with 7 new `TestModifierFamilyMatching` tests covering generic-vs-sided, sided-vs-generic, cross-side, wrong-family, and held-modifier scenarios.
- Spec updated at `src/jarvis/dictation/dictation.spec.md`.
- PyInstaller spec updated with hidden imports.

## Test plan

- [x] `pytest tests/test_dictation.py tests/test_dictation_listener_proc.py tests/test_dictation_history.py` (115 tests pass)
- [ ] Manual: hold-to-dictate works end-to-end after the change
- [ ] Manual: Ctrl+Win activates dictation correctly
- [ ] Manual: kill the listener subprocess externally and confirm the daemon stays up

Closes #252
Closes #353
Closes #354