### PR TITLE
fix(memory): atomic _last_ts snapshot prevents diary skipping concurrent messages

### DIFF
--- a/src/jarvis/daemon.py
+++ b/src/jarvis/daemon.py
@@ -93,7 +93,13 @@ def set_diary_update_callbacks(
 
 
 def get_pending_diary_chunks() -> list:
-    """Get pending conversation chunks from dialogue memory (for UI display)."""
+    """Get pending conversation chunks from dialogue memory (for UI display only).
+
+    Uses ``get_pending_chunks()`` which discards the atomic snapshot timestamp.
+    Do not use the result of this function to drive diary saves — the actual
+    save path goes through ``update_diary_from_dialogue_memory``, which calls
+    ``get_pending_chunks_with_snapshot()`` internally.
+    """
     global _global_dialogue_memory
     if _global_dialogue_memory is None:
         return []
@@ -199,6 +205,9 @@ def _check_and_update_diary(
         debug_log(f"diary update: should_update={should_update}, force={force}", "memory")
 
         if should_update:
+            # Display-only: get a snapshot of pending chunks to notify the UI.
+            # The atomic snapshot for the actual save is captured inside
+            # update_diary_from_dialogue_memory via get_pending_chunks_with_snapshot().
             pending_chunks = _global_dialogue_memory.get_pending_chunks()
             debug_log(f"diary update: found {len(pending_chunks)} pending chunks", "memory")
 
@@ -609,6 +618,7 @@ def main() -> None:
         if _global_dialogue_memory is None:
             print("⚠️ Dialogue memory is None - nothing to save", flush=True)
         else:
+            # Display-only count; actual save uses the atomic snapshot path.
             pending = _global_dialogue_memory.get_pending_chunks()
             print(f"💬 Found {len(pending)} pending conversation chunks", flush=True)
 

--- a/src/jarvis/memory/conversation.py
+++ b/src/jarvis/memory/conversation.py
@@ -928,12 +928,30 @@ class DialogueMemory:
         Thread-safe.
         """
         with self._lock:
-            # Get messages that haven't been saved yet
             unsaved_messages = [
                 (ts, role, content) for ts, role, content in self._messages
                 if ts > self._last_saved_timestamp
             ]
             return [f"{role.title()}: {content}" for _, role, content in unsaved_messages]
+
+    def get_pending_chunks_with_snapshot(self) -> Tuple[List[str], float]:
+        """Return (pending_chunks, snapshot_timestamp) atomically.
+
+        The snapshot is ``_last_ts`` — the highest timestamp assigned by
+        ``_next_ts`` so far. Because ``_next_ts`` is strictly monotonic,
+        every ``add_message`` call after this lock is released will produce
+        a timestamp strictly greater than the snapshot. Callers should pass
+        the returned snapshot to ``mark_saved_up_to`` rather than computing
+        their own ``time.time()`` snapshot, which can collide with ``_next_ts``
+        on low-resolution clocks (Windows ~16ms tick).
+        """
+        with self._lock:
+            unsaved_messages = [
+                (ts, role, content) for ts, role, content in self._messages
+                if ts > self._last_saved_timestamp
+            ]
+            chunks = [f"{role.title()}: {content}" for _, role, content in unsaved_messages]
+            return chunks, self._last_ts
 
     def has_pending_chunks(self) -> bool:
         """Check if there are unsaved messages. Thread-safe."""
@@ -1556,13 +1574,19 @@ def update_diary_from_dialogue_memory(
         return None
 
     try:
-        # CRITICAL: Capture the current timestamp BEFORE getting chunks
-        # This ensures that any new messages arriving during LLM summarization
-        # (which can take 30-45 seconds) won't be incorrectly marked as saved.
-        snapshot_timestamp = time.time()
-
-        # Get pending chunks from dialogue memory
-        pending_chunks = dialogue_memory.get_pending_chunks()
+        # Atomically capture pending chunks AND the snapshot timestamp.
+        # Using ``_last_ts`` (via get_pending_chunks_with_snapshot) rather
+        # than a bare ``time.time()`` call guarantees that the snapshot is
+        # strictly before any future ``add_message`` call, regardless of
+        # OS clock granularity. On Windows ``time.time()`` has ~16ms
+        # resolution, so a separate ``time.time()`` snapshot and the
+        # ``_next_ts`` call inside a concurrent ``add_message`` can both
+        # land on the same tick, producing identical timestamps. The new
+        # message then fails the ``ts > snapshot`` test in
+        # ``get_pending_chunks`` and is wrongly treated as already saved.
+        pending_chunks, snapshot_timestamp = (
+            dialogue_memory.get_pending_chunks_with_snapshot()
+        )
         debug_log(f"diary update: got {len(pending_chunks)} pending chunks from dialogue_memory", "memory")
 
         if not pending_chunks:

--- a/src/jarvis/memory/conversation.py
+++ b/src/jarvis/memory/conversation.py
@@ -924,15 +924,16 @@ class DialogueMemory:
     def get_pending_chunks(self) -> List[str]:
         """Get unsaved messages as formatted chunks for diary update.
 
-        Returns messages that haven't been saved to diary yet (timestamp > _last_saved_timestamp).
-        Thread-safe.
+        Returns messages that haven't been saved to diary yet
+        (timestamp > _last_saved_timestamp). Thread-safe.
+
+        For diary flush callers that need an atomic snapshot timestamp,
+        use ``get_pending_chunks_with_snapshot()`` instead — this method
+        discards the snapshot and is intended for display/notification
+        purposes only.
         """
-        with self._lock:
-            unsaved_messages = [
-                (ts, role, content) for ts, role, content in self._messages
-                if ts > self._last_saved_timestamp
-            ]
-            return [f"{role.title()}: {content}" for _, role, content in unsaved_messages]
+        chunks, _ = self.get_pending_chunks_with_snapshot()
+        return chunks
 
     def get_pending_chunks_with_snapshot(self) -> Tuple[List[str], float]:
         """Return (pending_chunks, snapshot_timestamp) atomically.

--- a/tests/test_dialogue_memory.py
+++ b/tests/test_dialogue_memory.py
@@ -514,6 +514,52 @@ class TestDialogueMemoryEdgeCases:
         time.sleep(0.15)
         assert not dm.should_update_diary()
 
+    def test_get_pending_chunks_with_snapshot_empty(self):
+        """Snapshot on a fresh DialogueMemory returns empty chunks and zero timestamp."""
+        dm = DialogueMemory()
+        chunks, ts = dm.get_pending_chunks_with_snapshot()
+        assert chunks == []
+        assert ts == 0.0
+
+    def test_get_pending_chunks_with_snapshot_returns_unsaved_messages(self):
+        """Snapshot returns chunks for unsaved messages in role.title() format."""
+        dm = DialogueMemory()
+        dm.add_message("user", "Hello")
+        dm.add_message("assistant", "Hi there")
+        chunks, _ = dm.get_pending_chunks_with_snapshot()
+        assert len(chunks) == 2
+        assert chunks[0] == "User: Hello"
+        assert chunks[1] == "Assistant: Hi there"
+
+    def test_get_pending_chunks_with_snapshot_excludes_saved_messages(self):
+        """Snapshot excludes messages already marked as saved."""
+        dm = DialogueMemory()
+        dm.add_message("user", "Old message")
+        dm.clear_pending_updates()
+        dm.add_message("user", "New message")
+        chunks, _ = dm.get_pending_chunks_with_snapshot()
+        assert len(chunks) == 1
+        assert "New message" in chunks[0]
+
+    def test_get_pending_chunks_with_snapshot_monotonicity(self):
+        """Snapshot timestamp is strictly less than any message added afterwards."""
+        dm = DialogueMemory()
+        dm.add_message("user", "Before snapshot")
+        _, snapshot_ts = dm.get_pending_chunks_with_snapshot()
+        dm.add_message("user", "After snapshot")
+        # The message added after the snapshot must have a strictly greater timestamp.
+        after_ts = dm._messages[-1][0]
+        assert after_ts > snapshot_ts
+
+    def test_get_pending_chunks_with_snapshot_consistent_with_get_pending_chunks(self):
+        """get_pending_chunks() is consistent with get_pending_chunks_with_snapshot()."""
+        dm = DialogueMemory()
+        dm.add_message("user", "Hello")
+        dm.add_message("assistant", "World")
+        chunks_simple = dm.get_pending_chunks()
+        chunks_snapshot, _ = dm.get_pending_chunks_with_snapshot()
+        assert chunks_simple == chunks_snapshot
+
     @patch('src.jarvis.memory.conversation.update_daily_conversation_summary')
     def test_update_diary_preserves_new_messages_during_slow_llm(self, mock_summary):
         """Integration test: messages arriving during slow LLM call are preserved."""


### PR DESCRIPTION
## Summary

- \`update_diary_from_dialogue_memory\` captured \`snapshot_timestamp\` via a bare \`time.time()\` call, then passed it to \`mark_saved_up_to\` after the LLM summarisation finished.
- On Windows, \`time.time()\` has ~16ms granularity. A concurrent \`add_message\` call uses \`_next_ts()\` which resolves to the same clock tick, giving the new message \`ts == snapshot_timestamp\`.
- \`get_pending_chunks()\` returns messages with \`ts > _last_saved_timestamp\`. When \`ts == snapshot_timestamp\`, that condition is \`False\` and the message is silently dropped from the next diary flush.

The fix adds \`get_pending_chunks_with_snapshot()\` which returns the pending chunks and \`_last_ts\` atomically under \`_lock\`. Because \`_next_ts\` is strictly monotonic, every \`add_message\` after the lock is released produces \`ts > snapshot\`, regardless of OS clock resolution. The existing test \`test_update_diary_preserves_new_messages_during_slow_llm\` was written to catch exactly this race and was already failing on \`develop\` and \`main\`.

A post-review pass also addressed:
- \`get_pending_chunks()\` now delegates to \`get_pending_chunks_with_snapshot()\`, eliminating the duplicated filter+format comprehension
- 5 direct unit tests added for \`get_pending_chunks_with_snapshot()\` (empty state, formatting, saved-exclusion, strict-monotonicity guarantee, consistency)
- Clarifying comments added to all three display-only \`get_pending_chunks()\` call sites in \`daemon.py\`

## Test plan

- [x] \`pytest tests/test_dialogue_memory.py\` — 30/30 green (was 29/30)
- [ ] \`pytest tests/\` full suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)