### PR TITLE
fix(planner): normalise URL-shaped tool args before dispatch

### DIFF
--- a/src/jarvis/reply/engine.py
+++ b/src/jarvis/reply/engine.py
@@ -1795,9 +1795,19 @@ def run_reply_engine(db: "Database", cfg, tts: Optional[Any],
                                 f"{_name}({_args!r})",
                                 "planning",
                             )
+                            try:
+                                _plan_args_preview = json.dumps(
+                                    _args or {}, ensure_ascii=False
+                                )
+                            except Exception:
+                                _plan_args_preview = str(_args)
+                            if len(_plan_args_preview) > 160:
+                                _plan_args_preview = (
+                                    _plan_args_preview[:157] + "..."
+                                )
                             print(
                                 f"    🗺️ Plan step {_tool_results_so_far + 1} "
-                                f"→ direct-exec {_name}",
+                                f"→ direct-exec {_name} {_plan_args_preview}",
                                 flush=True,
                             )
                             _plan_call_id = (
@@ -1836,10 +1846,19 @@ def run_reply_engine(db: "Database", cfg, tts: Optional[Any],
                                     raw_tool_result=_plan_result.reply_text,
                                 )
                             else:
-                                _plan_text = (
-                                    f"Error: "
-                                    f"{_plan_result.error_message or '(no result)'}"
+                                _plan_err = (
+                                    _plan_result.error_message or "(no result)"
                                 )
+                                _plan_err_preview = (
+                                    _plan_err
+                                    if len(_plan_err) <= 240
+                                    else _plan_err[:237] + "..."
+                                )
+                                print(
+                                    f"    ❌ {_name} error: {_plan_err_preview}",
+                                    flush=True,
+                                )
+                                _plan_text = f"Error: {_plan_err}"
                             _plan_tool_results_after = _tool_results_so_far + 1
                             if action_plan:
                                 _plan_hint = progress_nudge(
@@ -2011,7 +2030,13 @@ def run_reply_engine(db: "Database", cfg, tts: Optional[Any],
         if t_name:
             tool_name, tool_args, tool_call_id = t_name, t_args, t_call_id
             debug_log(f"🛠️ tool requested: {tool_name}", "planning")
-            print(f"    🛠️ Agent → {tool_name}", flush=True)
+            try:
+                _args_preview = json.dumps(tool_args or {}, ensure_ascii=False)
+            except Exception:
+                _args_preview = str(tool_args)
+            if len(_args_preview) > 160:
+                _args_preview = _args_preview[:157] + "..."
+            print(f"    🛠️ Agent → {tool_name} {_args_preview}", flush=True)
 
             # Check if tool is not allowed - respond with tool error
             if tool_name not in allowed_tools:
@@ -2297,6 +2322,8 @@ def run_reply_engine(db: "Database", cfg, tts: Optional[Any],
                     pass
             else:
                 err = result.error_message or "(no result)"
+                _err_preview = err if len(err) <= 240 else err[:237] + "..."
+                print(f"    ❌ {tool_name} error: {_err_preview}", flush=True)
                 if use_text_tools:
                     messages.append({
                         "role": "user",

--- a/src/jarvis/reply/planner.py
+++ b/src/jarvis/reply/planner.py
@@ -64,6 +64,76 @@ MIN_QUERY_CHARS = 4
 SEARCH_MEMORY_DIRECTIVE = "searchMemory"
 
 
+# URL hygiene applied to resolved tool arguments.
+#
+# Background (2026-05 field trace, chrome-devtools__navigate_page):
+# the planner LLM emitted `page='[youtube.com](http://youtube.com)'`
+# (markdown link syntax leaked from training priors) and even when the
+# resolver remapped the key to `url` the value retained the wrapper.
+# Puppeteer's Page.navigate then rejected with "Cannot navigate to
+# invalid URL". A separate failure mode is bare-domain values like
+# `youtube.com` with no scheme — Page.navigate rejects those too.
+#
+# Two-stage normalisation closes both holes in one place:
+#   1. Strip `[text](url)` markdown wrappers, keeping only the URL
+#      portion. Tools should never receive markdown — it's never a
+#      valid tool argument.
+#   2. Prepend `https://` to scheme-less bare domains so URL-shaped
+#      arguments always reach the tool as a fully-qualified URL.
+#
+# Scoped to keys whose name suggests a URL value to avoid stomping on
+# unrelated string args (a `query='youtube.com tutorials'` step must
+# stay literal). Keys are matched against a small allow-list of common
+# URL-ish parameter names; this is generic enough to cover every MCP
+# server we ship with and every tool we plan to add.
+_MARKDOWN_LINK_RE = re.compile(r"^\s*\[([^\]]*)\]\((https?://[^\s)]+)\)\s*$")
+_BARE_DOMAIN_RE = re.compile(
+    r"^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?"
+    r"(?:\.[a-z0-9](?:[a-z0-9-]*[a-z0-9])?)+"
+    r"(?:[/?#][^\s]*)?$",
+    re.IGNORECASE,
+)
+_URL_KEY_RE = re.compile(
+    r"^(?:url|uri|href|link|address|target_?url|page_?url|location)$",
+    re.IGNORECASE,
+)
+
+
+def _normalise_url_value(value: str) -> str:
+    """Coerce a string tool argument into a valid URL when it's URL-shaped.
+
+    See module-level commentary above ``_MARKDOWN_LINK_RE`` for the
+    motivating field trace. Returns the input unchanged if it doesn't
+    look like a URL (so unrelated string args pass through untouched).
+    """
+    if not isinstance(value, str):
+        return value
+    s = value.strip()
+    if not s:
+        return value
+    m = _MARKDOWN_LINK_RE.match(s)
+    if m:
+        s = m.group(2).strip()
+    if "://" not in s and _BARE_DOMAIN_RE.match(s):
+        s = "https://" + s
+    return s
+
+
+def _normalise_url_args(args: dict) -> dict:
+    """Apply :func:`_normalise_url_value` to every URL-keyed string arg.
+
+    Returns a new dict; non-URL keys and non-string values pass through
+    unchanged. Safe to call on any resolver output.
+    """
+    if not isinstance(args, dict) or not args:
+        return args
+    out = dict(args)
+    for k, v in args.items():
+        if isinstance(v, str) and _URL_KEY_RE.match(str(k)):
+            out[k] = _normalise_url_value(v)
+    return out
+
+
 def resolve_planner_model(cfg) -> str:
     """Pick the LLM for planning.
 
@@ -552,7 +622,7 @@ def _parse_plan_step_concrete(
             # The planner used key names that don't match the tool's
             # schema — surface to the LLM resolver which can remap them.
             return None
-    return name, args
+    return name, _normalise_url_args(args)
 
 
 def resolve_next_tool_call(
@@ -711,7 +781,7 @@ def resolve_next_tool_call(
                 "planning",
             )
         args = filtered
-    return name, args
+    return name, _normalise_url_args(args)
 
 
 __all__ = [

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -501,6 +501,139 @@ class TestResolveNextToolCall:
         assert result == ("freeform", {"anything": "goes"})
 
 
+class TestUrlArgNormalisation:
+    """The resolver must hand chrome/browser MCP tools a fully-qualified
+    URL.
+
+    Field trace (2026-05): the planner emitted
+    ``page='[youtube.com](http://youtube.com)'`` for the user query
+    "navigate to youtube.com". The slow-path resolver remapped the key
+    to ``url`` (the schema's actual property) but preserved the markdown
+    wrapper as the value, so chrome-devtools-mcp received
+    ``{"url": "[youtube.com](http://youtube.com)"}`` and Puppeteer's
+    Page.navigate rejected with "Cannot navigate to invalid URL".
+    A scheme-less bare ``youtube.com`` value fails the same way.
+
+    The fix is generic: any URL-keyed string value gets
+    markdown-stripped and scheme-prepended before it leaves the planner.
+    """
+
+    def _navigate_schema(self):
+        return [
+            {
+                "type": "function",
+                "function": {
+                    "name": "chrome-devtools__navigate_page",
+                    "description": "Navigate to a URL.",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "url": {"type": "string"},
+                        },
+                    },
+                },
+            }
+        ]
+
+    def test_strips_markdown_link_wrapper_in_slow_path(self):
+        cfg = _cfg()
+        raw = (
+            '{"name": "chrome-devtools__navigate_page", "arguments": '
+            '{"url": "[youtube.com](http://youtube.com)"}}'
+        )
+        with patch.object(planner_mod, "call_llm_direct", return_value=raw):
+            result = resolve_next_tool_call(
+                cfg,
+                "chrome-devtools__navigate_page page='[youtube.com](http://youtube.com)'",
+                [],
+                self._navigate_schema(),
+            )
+        assert result == (
+            "chrome-devtools__navigate_page",
+            {"url": "http://youtube.com"},
+        )
+
+    def test_prepends_scheme_to_bare_domain_in_slow_path(self):
+        cfg = _cfg()
+        raw = (
+            '{"name": "chrome-devtools__navigate_page", "arguments": '
+            '{"url": "youtube.com"}}'
+        )
+        with patch.object(planner_mod, "call_llm_direct", return_value=raw):
+            result = resolve_next_tool_call(
+                cfg,
+                "chrome-devtools__navigate_page page='youtube.com'",
+                [],
+                self._navigate_schema(),
+            )
+        assert result == (
+            "chrome-devtools__navigate_page",
+            {"url": "https://youtube.com"},
+        )
+
+    def test_prepends_scheme_to_bare_domain_in_fast_path(self):
+        """Fast path parses ``url='youtube.com'`` deterministically; the
+        normalisation must apply there too so we don't regress on the
+        common case where the planner uses the right key name."""
+        cfg = _cfg()
+        with patch.object(planner_mod, "call_llm_direct", return_value="null") as spy:
+            result = resolve_next_tool_call(
+                cfg,
+                "chrome-devtools__navigate_page url='youtube.com'",
+                [],
+                self._navigate_schema(),
+            )
+        assert result == (
+            "chrome-devtools__navigate_page",
+            {"url": "https://youtube.com"},
+        )
+        assert spy.call_count == 0, "fast path must not call the LLM resolver"
+
+    def test_preserves_already_qualified_url(self):
+        cfg = _cfg()
+        with patch.object(planner_mod, "call_llm_direct", return_value="null"):
+            result = resolve_next_tool_call(
+                cfg,
+                "chrome-devtools__navigate_page url='https://youtube.com/feed/trending'",
+                [],
+                self._navigate_schema(),
+            )
+        assert result == (
+            "chrome-devtools__navigate_page",
+            {"url": "https://youtube.com/feed/trending"},
+        )
+
+    def test_does_not_touch_unrelated_string_args(self):
+        """A ``query='youtube.com tutorials'`` arg on webSearch must stay
+        literal — we only normalise values keyed as URLs."""
+        cfg = _cfg()
+        schema = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "webSearch",
+                    "description": "Search.",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"query": {"type": "string"}},
+                    },
+                },
+            }
+        ]
+        raw = (
+            '{"name": "webSearch", "arguments": '
+            '{"query": "youtube.com tutorials"}}'
+        )
+        with patch.object(planner_mod, "call_llm_direct", return_value=raw):
+            result = resolve_next_tool_call(
+                cfg,
+                "webSearch find tutorials",
+                [],
+                schema,
+            )
+        assert result == ("webSearch", {"query": "youtube.com tutorials"})
+
+
 class TestToolStepsOf:
     def test_multi_step_drops_final_synthesis_step(self):
         assert tool_steps_of(["a", "b", "reply"]) == ["a", "b"]


### PR DESCRIPTION
## Summary

- Resolver was handing `chrome-devtools__navigate_page` values like `[youtube.com](http://youtube.com)` (markdown wrapper bleeding in from gemma4:e2b's training priors) and bare `youtube.com` (no scheme). Puppeteer's `Page.navigate` rejects both with "Cannot navigate to invalid URL", which the chat model paraphrased back as "the protocol encountered an error".
- Added `_normalise_url_args` in `src/jarvis/reply/planner.py`, applied at both the fast-path and slow-path return sites of `resolve_next_tool_call`. It strips `[text](url)` markdown wrappers and prepends `https://` to scheme-less bare domains. Scoped to URL-shaped keys (`url`, `uri`, `href`, `link`, `address`, `target_url`, `page_url`, `location`) so unrelated string args (e.g. `webSearch query='youtube.com tutorials'`) stay literal.
- Surfaced resolved args JSON and tool errors on the planner direct-exec path in `src/jarvis/reply/engine.py`, so future "tool ran but did nothing" regressions are diagnosable from the log alone.

## Why

Field trace this session: the user said "Navigate to youtube.com, Jarvis", Chrome opened, the page never loaded. Diagnosis flow:

1. Added an args print on the direct-exec path. Next run showed `{"url": "[youtube.com](http://youtube.com)"}`.
2. Pulled the live MCP schema for `navigate_page`, ran it directly with `{"url": "https://youtube.com"}` (success), `{"url": "youtube.com"}` (fails: "Cannot navigate to invalid URL"), and the markdown-wrapped value (same failure).
3. The planner's slow-path resolver remaps the planner LLM's invented `page=` key to the schema's real `url` key but preserves the value verbatim, so any wrapper/missing-scheme bug in the value survives.

Fixing this in the resolver covers every URL-taking MCP tool we ship today and any new ones that follow the convention.

## Test plan

- [x] 5 new unit tests in `TestUrlArgNormalisation` (markdown stripping on slow path, scheme-prepending on slow & fast paths, qualified-URL passthrough, unrelated string args untouched). 73/73 planner tests pass.
- [x] End-to-end against the live `chrome-devtools-mcp` server: previously-failing args (`{"url": "[youtube.com](http://youtube.com)"}`) become `{"url": "http://youtube.com"}` after normalisation and produce a successful navigation.
- [ ] Manual: speak "Navigate to youtube.com, Jarvis" and confirm the page loads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)