### PR TITLE
fix(scripts): detect existing venv/ on Linux and macOS, add venv/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 .env/
 .venv/
+venv/
 __pycache__/
 .pytest_cache/
 tests/performance/reports/

--- a/scripts/run_linux.sh
+++ b/scripts/run_linux.sh
@@ -5,13 +5,14 @@ REPO_ROOT="$(dirname "$SCRIPT_DIR")"
 cd "$REPO_ROOT"
 
 if [ -d venv ]; then
-  source venv/bin/activate
+  VENV_DIR="venv"
 elif [ -d .venv ]; then
-  source .venv/bin/activate
+  VENV_DIR=".venv"
 else
   python3 -m venv .venv
-  source .venv/bin/activate
+  VENV_DIR=".venv"
 fi
+source "$VENV_DIR/bin/activate"
 pip install -r requirements.txt
 
 export PYTHONPATH="$REPO_ROOT/src"

--- a/scripts/run_linux.sh
+++ b/scripts/run_linux.sh
@@ -4,10 +4,14 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(dirname "$SCRIPT_DIR")"
 cd "$REPO_ROOT"
 
-if [ ! -d .venv ]; then
+if [ -d venv ]; then
+  source venv/bin/activate
+elif [ -d .venv ]; then
+  source .venv/bin/activate
+else
   python3 -m venv .venv
+  source .venv/bin/activate
 fi
-source .venv/bin/activate
 pip install -r requirements.txt
 
 export PYTHONPATH="$REPO_ROOT/src"

--- a/scripts/run_macos.sh
+++ b/scripts/run_macos.sh
@@ -4,10 +4,15 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(dirname "$SCRIPT_DIR")"
 cd "$REPO_ROOT"
 
-if [ ! -d .venv ]; then
+if [ -d venv ]; then
+  VENV_DIR="venv"
+elif [ -d .venv ]; then
+  VENV_DIR=".venv"
+else
   python3 -m venv .venv
+  VENV_DIR=".venv"
 fi
-source .venv/bin/activate
+source "$VENV_DIR/bin/activate"
 pip install -r requirements.txt
 
 # Build Swift capture helper (scaffold)


### PR DESCRIPTION
## Summary

- `run_linux.sh` and `run_macos.sh` now check for an existing `venv/` or `.venv/` before creating a new virtualenv, so developers with a pre-existing `venv/` are not forced into a parallel `.venv/`
- `venv/` added to `.gitignore` alongside `.venv/` to prevent accidental commits of the venv directory
- Both scripts refactored to use a `VENV_DIR` variable, eliminating repeated `source` calls across branches
- Falls back to creating `.venv/` only when neither exists

## Test plan

- [ ] Run `bash scripts/run_linux.sh` in a repo with `venv/` — should activate it directly
- [ ] Run `bash scripts/run_macos.sh` in a repo with `venv/` — should activate it directly
- [ ] Run in a repo with `.venv/` — should activate `.venv/`
- [ ] Run in a fresh clone with neither — should create `.venv/` as before
- [ ] Confirm `venv/` does not appear in `git status` after running the script

🤖 Generated with [Claude Code](https://claude.com/claude-code)