### PR TITLE
fix: bundle mlx-whisper in macOS app

### DIFF
--- a/jarvis_desktop.spec
+++ b/jarvis_desktop.spec
@@ -83,6 +83,45 @@ except Exception as e:
 # Note: Qt WebEngine resources are handled by PyInstaller's hook-PyQt6.QtWebEngineWidgets.py
 # Manual collection can conflict with the hook and cause crashes
 
+# On macOS Apple Silicon, collect mlx_whisper and its dependency submodules/data.
+# These are conditionally imported in listener.py and PyInstaller can't detect them.
+# IMPORTANT: Do NOT use collect_submodules('mlx') — it causes nanobind types in
+# mlx.core to be registered twice (Fatal Python error: Aborted).  Instead, list
+# just the mlx submodules that mlx_whisper actually imports and let PyInstaller
+# resolve the native extension naturally.
+if sys.platform == 'darwin':
+    try:
+        hiddenimports_mlx = (
+            collect_submodules('mlx_whisper')
+            + collect_submodules('tiktoken')
+            + collect_submodules('tiktoken_ext')
+            + collect_submodules('numba')
+        )
+        # Exclude torch_whisper — it's a PyTorch implementation not used by the MLX path
+        hiddenimports_mlx = [m for m in hiddenimports_mlx if 'torch_whisper' not in m]
+        # Add only the specific mlx submodules that mlx_whisper imports.
+        # IMPORTANT: mlx._reprlib_fix is required by the mlx.core native extension
+        # during initialisation — without it the import fails silently.
+        hiddenimports_mlx += [
+            'mlx', 'mlx.core', 'mlx._reprlib_fix', 'mlx.nn', 'mlx.utils',
+        ]
+        # Bundle the Metal shader library (mlx.metallib) required by mlx.core.
+        # mlx is a namespace package (__file__ is None), so use __path__ instead.
+        import mlx as _mlx_pkg
+        _mlx_base = Path(_mlx_pkg.__path__[0])
+        _metallib = _mlx_base / 'lib' / 'mlx.metallib'
+        if _metallib.exists():
+            datas.append((str(_metallib), 'mlx/lib'))
+            print(f"Bundling MLX metallib ({_metallib.stat().st_size / 1024 / 1024:.0f} MB)")
+        datas += collect_data_files('mlx_whisper')
+        datas += collect_data_files('tiktoken')
+        print(f"Collected {len(hiddenimports_mlx)} mlx_whisper submodules (incl. deps)")
+    except Exception as e:
+        hiddenimports_mlx = []
+        print(f"Info: mlx/mlx_whisper not installed, skipping: {e}")
+else:
+    hiddenimports_mlx = []
+
 # Hidden imports that PyInstaller might miss
 hiddenimports = [
     # Jarvis core modules
@@ -187,6 +226,8 @@ hiddenimports = [
     'huggingface_hub.hf_api',
     'huggingface_hub.utils',
     'tokenizers',
+    # Speech recognition (mlx-whisper backend for Apple Silicon)
+    'mlx_whisper',
     # Third-party dependencies
     'dotenv',
     'psutil',
@@ -226,7 +267,32 @@ hiddenimports = [
     'itsdangerous',
     'click',
     'blinker',
+] + hiddenimports_mlx
+
+# Build the excludes list — scipy is kept on macOS (required by mlx_whisper)
+_excludes = [
+    # Exclude heavy packages to keep bundle size reasonable
+    'psycopg2',  # Not used and causes OpenSSL conflicts
+    'torch',  # PyTorch is 1.5-2GB - chatterbox TTS is optional
+    'torchaudio',
+    'torchvision',
+    'chatterbox',  # Optional TTS engine (uses PyTorch)
+    'transformers',  # Heavy ML library (not needed, faster_whisper uses ctranslate2)
+    'safetensors',
+    'accelerate',
+    'cv2',  # OpenCV - not needed for core functionality
+    'opencv-python',
+    'matplotlib',  # Not needed for core app
+    'notebook',
+    'jupyter',
+    'IPython',
+    'sklearn',
+    'scikit-learn',
+    # Note: Keep huggingface_hub - needed by faster_whisper for model downloads
 ]
+# scipy is needed by mlx_whisper on macOS — only exclude on other platforms
+if sys.platform != 'darwin':
+    _excludes.append('scipy')
 
 a = Analysis(
     ['src/desktop_app/app.py'],
@@ -237,27 +303,7 @@ a = Analysis(
     hookspath=[],
     hooksconfig={},
     runtime_hooks=['src/desktop_app/rthook_onnxruntime.py'],
-    excludes=[
-        # Exclude heavy packages to keep bundle size reasonable
-        'psycopg2',  # Not used and causes OpenSSL conflicts
-        'torch',  # PyTorch is 1.5-2GB - chatterbox TTS is optional
-        'torchaudio',
-        'torchvision',
-        'chatterbox',  # Optional TTS engine (uses PyTorch)
-        'transformers',  # Heavy ML library (not needed, faster_whisper uses ctranslate2)
-        'safetensors',
-        'accelerate',
-        'cv2',  # OpenCV - not needed for core functionality
-        'opencv-python',
-        'matplotlib',  # Not needed for core app
-        'notebook',
-        'jupyter',
-        'IPython',
-        'scipy',  # Large, only used by optional features
-        'sklearn',
-        'scikit-learn',
-        # Note: Keep huggingface_hub - needed by faster_whisper for model downloads
-    ],
+    excludes=_excludes,
     win_no_prefer_redirects=False,
     win_private_assemblies=False,
     cipher=block_cipher,

--- a/src/jarvis/listening/listener.py
+++ b/src/jarvis/listening/listener.py
@@ -252,8 +252,11 @@ try:
     if _is_apple_silicon():
         import mlx_whisper
         MLX_WHISPER_AVAILABLE = True
-except Exception:
+        debug_log("mlx-whisper loaded successfully", "voice")
+except Exception as _mlx_err:
     mlx_whisper = None
+    if _is_apple_silicon():
+        debug_log(f"mlx-whisper unavailable, falling back to faster-whisper: {_mlx_err}", "voice")
 
 try:
     from faster_whisper import WhisperModel

--- a/tests/test_pyinstaller_spec.py
+++ b/tests/test_pyinstaller_spec.py
@@ -1,0 +1,107 @@
+"""
+Tests for the PyInstaller spec file (jarvis_desktop.spec).
+
+Verifies that the bundling configuration includes all required modules
+so the packaged app works correctly on all platforms.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+# Read the spec file once for all tests
+SPEC_PATH = Path(__file__).parent.parent / "jarvis_desktop.spec"
+SPEC_CONTENT = SPEC_PATH.read_text()
+
+
+def _code_lines_only(content: str) -> str:
+    """Return spec file content with comment lines stripped."""
+    return '\n'.join(
+        l for l in content.splitlines() if not l.strip().startswith('#')
+    )
+
+
+class TestMLXWhisperBundling:
+    """Ensure mlx-whisper is bundled on macOS so Apple Silicon gets the fast backend."""
+
+    def test_spec_does_not_collect_all_mlx_submodules(self):
+        """collect_submodules('mlx') must NOT be used — it causes nanobind double-registration."""
+        code_only = _code_lines_only(SPEC_CONTENT)
+        matches = re.findall(r"collect_submodules\('mlx'\)", code_only)
+        assert len(matches) == 0, "collect_submodules('mlx') found — use specific mlx submodules instead"
+
+    def test_spec_lists_specific_mlx_submodules(self):
+        """Only the specific mlx submodules used by mlx_whisper should be listed."""
+        for mod in ["'mlx'", "'mlx.core'", "'mlx._reprlib_fix'", "'mlx.nn'", "'mlx.utils'"]:
+            assert mod in SPEC_CONTENT, f"Missing mlx submodule: {mod}"
+
+    def test_spec_collects_mlx_whisper_submodules_on_darwin(self):
+        """The spec should use collect_submodules for mlx_whisper on macOS."""
+        assert "collect_submodules('mlx_whisper')" in SPEC_CONTENT
+
+    def test_spec_collects_mlx_whisper_data_files_on_darwin(self):
+        """The spec should use collect_data_files for mlx_whisper on macOS."""
+        assert "collect_data_files('mlx_whisper')" in SPEC_CONTENT
+
+    def test_mlx_whisper_in_hiddenimports(self):
+        """mlx_whisper should appear in hiddenimports as a static entry."""
+        assert "'mlx_whisper'" in SPEC_CONTENT
+
+    def test_mlx_collection_guarded_by_darwin(self):
+        """MLX collection should only run on macOS (sys.platform == 'darwin')."""
+        darwin_block_start = SPEC_CONTENT.index("if sys.platform == 'darwin':")
+        mlx_whisper_collect = SPEC_CONTENT.index("collect_submodules('mlx_whisper')")
+        else_block = SPEC_CONTENT.index("else:\n    hiddenimports_mlx = []")
+        assert darwin_block_start < mlx_whisper_collect < else_block
+
+    def test_mlx_collection_has_fallback(self):
+        """If mlx is not installed, the spec should gracefully set an empty list."""
+        assert "hiddenimports_mlx = []" in SPEC_CONTENT
+
+    def test_mlx_not_in_excludes(self):
+        """mlx should not appear in the excludes list."""
+        excludes_start = SPEC_CONTENT.index("_excludes = [")
+        excludes_end = SPEC_CONTENT.index("]", excludes_start) + 1
+        excludes_block = SPEC_CONTENT[excludes_start:excludes_end]
+        assert "mlx" not in excludes_block.lower()
+
+    def test_mlx_not_in_excluded_binary_patterns(self):
+        """mlx should not be caught by excluded binary patterns."""
+        patterns_start = SPEC_CONTENT.index("excluded_binary_patterns = [")
+        patterns_end = SPEC_CONTENT.index("]", patterns_start) + 1
+        patterns_block = SPEC_CONTENT[patterns_start:patterns_end]
+        assert "mlx" not in patterns_block.lower()
+
+    def test_torch_whisper_excluded_from_mlx_submodules(self):
+        """torch_whisper should be filtered out — it needs PyTorch which is excluded."""
+        assert "torch_whisper" in SPEC_CONTENT
+        assert "'torch_whisper' not in m" in SPEC_CONTENT
+
+
+class TestMLXWhisperDependencies:
+    """Ensure mlx-whisper's runtime deps (scipy, numba, tiktoken) are bundled."""
+
+    def test_scipy_not_excluded_on_darwin(self):
+        """scipy should NOT be in the excludes on macOS — mlx_whisper needs it."""
+        assert "if sys.platform != 'darwin'" in SPEC_CONTENT
+        assert "_excludes.append('scipy')" in SPEC_CONTENT
+        # Verify scipy is NOT in the main excludes list (only appended conditionally)
+        excludes_start = SPEC_CONTENT.index("_excludes = [")
+        excludes_end = SPEC_CONTENT.index("]", excludes_start) + 1
+        excludes_block = SPEC_CONTENT[excludes_start:excludes_end]
+        assert "'scipy'" not in excludes_block
+
+    def test_tiktoken_collected(self):
+        """tiktoken submodules should be collected for mlx_whisper's tokeniser."""
+        assert "collect_submodules('tiktoken')" in SPEC_CONTENT
+        assert "collect_data_files('tiktoken')" in SPEC_CONTENT
+
+    def test_numba_collected(self):
+        """numba submodules should be collected for mlx_whisper's timing module."""
+        assert "collect_submodules('numba')" in SPEC_CONTENT
+
+    def test_metallib_bundled(self):
+        """The Metal shader library must be bundled for mlx.core to initialise."""
+        assert "mlx.metallib" in SPEC_CONTENT
+        assert "'mlx/lib'" in SPEC_CONTENT


### PR DESCRIPTION
PyInstaller couldn't detect mlx_whisper and mlx because they're conditionally imported only on Apple Silicon.  This adds the necessary hidden imports, submodule collection, and data files so the bundled .app no longer silently falls back to the slower faster-whisper engine.

Key changes to jarvis_desktop.spec:
- collect_submodules for mlx_whisper, tiktoken, and numba (runtime deps)
- List specific mlx submodules (mlx, mlx.core, mlx._reprlib_fix, mlx.nn, mlx.utils) instead of collect_submodules('mlx') which causes nanobind to double-register native types and abort
- Filter out mlx_whisper.torch_whisper (needs PyTorch, which is excluded)
- Keep scipy on macOS (remove from excludes) since mlx_whisper needs it
- Bundle mlx.metallib (128 MB Metal shader library) required by mlx.core
- Collect data files for mlx_whisper and tiktoken

Closes #122