### PR TITLE
fix(wizard): provider choice first, exclusive radios, clearer copy

### DIFF
--- a/src/desktop_app/setup_wizard.py
+++ b/src/desktop_app/setup_wizard.py
@@ -368,7 +368,7 @@ try:
         QApplication, QWizard, QWizardPage, QVBoxLayout, QHBoxLayout,
         QLabel, QPushButton, QProgressBar, QTextEdit, QWidget, QFrame,
         QSizePolicy, QScrollArea, QLineEdit, QSlider, QComboBox, QCheckBox,
-        QRadioButton
+        QRadioButton, QButtonGroup
     )
     from PyQt6.QtCore import Qt, QTimer, pyqtSignal, QThread, QObject
     from PyQt6.QtGui import QFont, QColor, QPalette, QPixmap, QPainter
@@ -519,6 +519,12 @@ class SetupWizard(QWizard):
         self.search_providers_page_id = self.addPage(self.search_providers_page)
         self.location_page_id = self.addPage(self.location_page)
         self.complete_page_id = self.addPage(self.complete_page)
+
+        # The provider choice is the first step: Ollama is optional now, so
+        # the wizard must ask which runtime the user wants before running any
+        # Ollama-specific checks. The Welcome/status page and the Ollama
+        # install/server/models pages are only reached on the Ollama branch.
+        self.setStartId(self.provider_choice_page_id)
 
         # Custom button labels
         self.setButtonText(QWizard.WizardButton.NextButton, "Next →")
@@ -819,12 +825,13 @@ class WelcomePage(QWizardPage):
         return True
 
     def nextId(self) -> int:
-        """Welcome always leads to the provider choice; the provider page
-        then branches to the Ollama flow or the OpenAI-compatible page."""
+        """The Welcome/status page is reached only on the Ollama branch (after
+        the provider choice), so it leads into the Ollama install/server/models
+        flow based on the detected status."""
         wizard = self.wizard()
         if not isinstance(wizard, SetupWizard):
             return super().nextId()
-        return wizard.provider_choice_page_id
+        return wizard.ollama_entry_page_id()
 
 
 class ProviderChoicePage(QWizardPage):
@@ -849,9 +856,9 @@ class ProviderChoicePage(QWizardPage):
         layout.addWidget(title)
 
         subtitle = QLabel(
-            "Jarvis runs entirely on local models by default via Ollama. "
-            "If you already run an OpenAI-compatible server, point Jarvis at "
-            "it instead — your data still never leaves the machines you control."
+            "Welcome to Jarvis. Choose how it runs its language model. Both "
+            "options keep everything on machines you control, never a "
+            "third-party cloud."
         )
         subtitle.setObjectName("subtitle")
         subtitle.setWordWrap(True)
@@ -859,21 +866,30 @@ class ProviderChoicePage(QWizardPage):
 
         layout.addSpacing(4)
 
-        self._ollama_radio = QRadioButton("  🦙  Ollama (local, recommended)")
+        # A QButtonGroup makes the radios mutually exclusive even though each
+        # lives in its own card (Qt's auto-exclusivity only applies to radios
+        # sharing a direct parent, which these do not).
+        self._button_group = QButtonGroup(self)
+
+        self._ollama_radio = QRadioButton("  🦙  Ollama (recommended)")
         self._ollama_radio.setChecked(True)
+        self._button_group.addButton(self._ollama_radio)
         ollama_card = self._provider_card(
             self._ollama_radio,
-            "Runs open models on this machine. Fully offline. The wizard will "
-            "help you install Ollama and download the models.",
+            "Runs open models locally on this machine. The wizard installs "
+            "Ollama and downloads the models for you. Best if you have no "
+            "model server already.",
         )
         layout.addWidget(ollama_card)
 
         self._openai_radio = QRadioButton("  🔗  OpenAI-compatible server")
+        self._button_group.addButton(self._openai_radio)
         openai_card = self._provider_card(
             self._openai_radio,
-            "LM Studio, oMLX, llama.cpp's llama-server, vLLM, LocalAI, or any "
-            "server speaking the OpenAI API. You'll enter its URL and the "
-            "model name on the next page.",
+            "Point Jarvis at a server that speaks the OpenAI API. This is "
+            "usually another local app (LM Studio, oMLX, llama.cpp, vLLM, "
+            "LocalAI) running on your own machine or network. You provide its "
+            "URL and model name on the next step.",
         )
         layout.addWidget(openai_card)
 
@@ -956,7 +972,10 @@ class ProviderChoicePage(QWizardPage):
             return super().nextId()
         if self._selected == "openai_compatible":
             return wizard.openai_compat_page_id
-        return wizard.ollama_entry_page_id()
+        # Ollama branch: show the Welcome/status dashboard first (it populates
+        # the detected Ollama status), which then leads into install/server/
+        # models. Status is only surfaced once the user has chosen Ollama.
+        return wizard.welcome_page_id
 
 
 class OpenAICompatiblePage(QWizardPage):

--- a/src/desktop_app/setup_wizard.spec.md
+++ b/src/desktop_app/setup_wizard.spec.md
@@ -21,21 +21,21 @@ An OpenAI-compatible user has opted out of the local Ollama stack, so `should_sh
 ## Page Flow
 
 ```
-Welcome → Provider Choice ─┬─ Ollama ───────→ [Ollama Install] → [Ollama Server] → Models ─┐
-                           └─ OpenAI-compat → OpenAI-compatible config ──────────────────────┤
-                                                                                              ▼
+Provider Choice ─┬─ Ollama ───────→ Welcome/Status → [Ollama Install] → [Ollama Server] → Models ─┐
+                 └─ OpenAI-compat → OpenAI-compatible config ───────────────────────────────────────┤
+                                                                                                      ▼
        [Whisper] → Dictation → MCP Servers → Search Providers → [Location] → Complete
 ```
 
-Pages in brackets are conditional — skipped when their prerequisite is already satisfied. The Provider Choice page branches the middle of the flow: the Ollama path keeps the install/server/models pages; the OpenAI-compatible path replaces them with a single connection-config page.
+The **Provider Choice page is the wizard's first step** (`setStartId`): Ollama is optional (recommended, not required), so the wizard asks which runtime the user wants before running any Ollama-specific checks. Pages in brackets are conditional — skipped when their prerequisite is already satisfied. The Ollama branch goes through the Welcome/Status dashboard (which surfaces Ollama readiness only after Ollama is chosen) and into install/server/models; the OpenAI-compatible branch replaces all of those with a single connection-config page.
 
 ### Pages
 
 | # | Page | Condition to show | Config written |
 |---|------|-------------------|----------------|
-| 1 | **Welcome** | Always | — |
-| 2 | **Provider Choice** | Always | `llm_provider` (Ollama clears the OpenAI-compatible overrides) |
-| 3 | **OpenAI-compatible** | Provider Choice = OpenAI-compatible | `llm_provider`, `llm_base_url`, `llm_chat_model`, `llm_api_key`?, `embedding_model`? |
+| 1 | **Provider Choice** (start) | Always | `llm_provider` (Ollama clears the OpenAI-compatible overrides) |
+| 2 | **OpenAI-compatible** | Provider Choice = OpenAI-compatible | `llm_provider`, `llm_base_url`, `llm_chat_model`, `llm_api_key`?, `embedding_model`? |
+| 3 | **Welcome / Status** | Ollama path | — |
 | 4 | **Ollama Install** | Ollama path + CLI not found | — |
 | 5 | **Ollama Server** | Ollama path + server not running | — |
 | 6 | **Models** | Ollama path | `ollama_chat_model` |
@@ -50,9 +50,9 @@ Fields suffixed `?` are written only when non-empty (minimal-config invariant).
 
 ### Page Details
 
-**WelcomePage** — Status dashboard showing CLI, server, models, location, and MLX Whisper (Apple Silicon) readiness. Refresh button triggers a background `StatusCheckWorker`. Always leads to the Provider Choice page.
+**ProviderChoicePage** (start page) — Two cards (radio buttons in a shared `QButtonGroup` so they are mutually exclusive across the separate card frames): Ollama (recommended) and OpenAI-compatible server. The copy makes clear both options are local: the OpenAI-compatible card describes pointing at another local app (LM Studio, oMLX, llama.cpp, vLLM, LocalAI) on your own machine or network, not a cloud service. Preselects from the current `llm_provider`. On validate, writes `llm_provider`; selecting Ollama omits the key and clears the OpenAI-compatible overrides (`llm_base_url`, `llm_api_key`, `llm_chat_model`, `embedding_*`) so the Ollama settings become authoritative again. `nextId` routes to the OpenAI-compatible page, or (Ollama) to the Welcome/Status page.
 
-**ProviderChoicePage** — Two cards (radio buttons): Ollama (local, recommended) and OpenAI-compatible server. Preselects from the current `llm_provider`. On validate, writes `llm_provider`; selecting Ollama omits the key and clears the OpenAI-compatible overrides (`llm_base_url`, `llm_api_key`, `llm_chat_model`, `embedding_*`) so the Ollama settings become authoritative again. `nextId` routes to the OpenAI-compatible page or to the first applicable Ollama page (`SetupWizard.ollama_entry_page_id()`).
+**WelcomePage / Status** — Reached only on the Ollama branch. Status dashboard showing CLI, server, models, location, and MLX Whisper (Apple Silicon) readiness; a background `StatusCheckWorker` populates `wizard.ollama_status`. Leads into the first applicable Ollama page via `SetupWizard.ollama_entry_page_id()` (install if the CLI is missing, server if it is not running, else models).
 
 **OpenAICompatiblePage** — Shown only on the OpenAI-compatible path. Form fields: base URL (required), chat model (required), API key (optional, password-masked), embedding model (optional). `isComplete` gates Next on base URL + chat model. On validate, writes `llm_provider="openai_compatible"`, `llm_base_url`, `llm_chat_model`, and the optional `llm_api_key` / `embedding_model` only when non-empty. `nextId` skips the Ollama install/server/models pages and goes straight to Whisper setup.
 

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -480,6 +480,90 @@ class TestProviderChoicePage:
         finally:
             cfg_path.unlink(missing_ok=True)
 
+    def test_radios_are_mutually_exclusive(self, qapp):
+        """The two provider radios live in separate cards, so they need a
+        shared QButtonGroup to be mutually exclusive — checking one must
+        uncheck the other (and update the selection)."""
+        import tempfile
+        from pathlib import Path
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            f.write("{}")
+            cfg_path = Path(f.name)
+        try:
+            with patch("jarvis.config.default_config_path", return_value=cfg_path):
+                page = ProviderChoicePage()
+            # Default: Ollama selected, OpenAI not.
+            assert page._ollama_radio.isChecked() and not page._openai_radio.isChecked()
+            page._openai_radio.setChecked(True)
+            assert page._openai_radio.isChecked()
+            assert not page._ollama_radio.isChecked(), "radios must be mutually exclusive"
+            assert page._selected == "openai_compatible"
+            page._ollama_radio.setChecked(True)
+            assert not page._openai_radio.isChecked()
+            assert page._selected == "ollama"
+        finally:
+            cfg_path.unlink(missing_ok=True)
+
+    def test_openai_card_describes_a_local_server(self, qapp):
+        """The OpenAI-compatible card must not imply the option is cloud /
+        less private: its copy clarifies it points at a local server."""
+        import tempfile
+        from pathlib import Path
+        from PyQt6.QtWidgets import QLabel
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            f.write("{}")
+            cfg_path = Path(f.name)
+        try:
+            with patch("jarvis.config.default_config_path", return_value=cfg_path):
+                page = ProviderChoicePage()
+            blob = " ".join(lbl.text().lower() for lbl in page.findChildren(QLabel))
+            assert "local" in blob and "network" in blob, (
+                "provider copy should make clear the OpenAI-compatible option "
+                "is also local"
+            )
+        finally:
+            cfg_path.unlink(missing_ok=True)
+
+    def test_nextid_ollama_routes_through_welcome_status(self):
+        """Ollama selection goes to the Welcome/status page (which surfaces
+        Ollama readiness only after the user has chosen Ollama)."""
+        page = ProviderChoicePage.__new__(ProviderChoicePage)
+        page._selected = "ollama"
+        wizard = MagicMock()
+        wizard.welcome_page_id = 5
+        page.wizard = MagicMock(return_value=wizard)
+        with patch("desktop_app.setup_wizard.SetupWizard", MagicMock):
+            assert page.nextId() == 5
+
+    def test_wizard_starts_on_provider_choice(self, qapp):
+        """Ollama is optional, so the wizard's first step is the provider
+        choice — not the Ollama-centric Welcome/status page."""
+        import tempfile
+        from pathlib import Path
+        from desktop_app.setup_wizard import SetupWizard
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            f.write("{}")
+            cfg_path = Path(f.name)
+        try:
+            with patch("jarvis.config.default_config_path", return_value=cfg_path):
+                wiz = SetupWizard()
+            assert wiz.startId() == wiz.provider_choice_page_id
+        finally:
+            cfg_path.unlink(missing_ok=True)
+
+
+class TestWelcomePageFlow:
+    """The Welcome/status page is reached only on the Ollama branch."""
+
+    def test_nextid_enters_ollama_flow(self):
+        from desktop_app.setup_wizard import WelcomePage
+        page = WelcomePage.__new__(WelcomePage)
+        wizard = MagicMock()
+        wizard.ollama_entry_page_id = MagicMock(return_value=9)
+        page.wizard = MagicMock(return_value=wizard)
+        with patch("desktop_app.setup_wizard.SetupWizard", MagicMock):
+            assert page.nextId() == 9
+
 
 class TestOpenAICompatiblePage:
     """Collects the OpenAI-compatible connection details."""


### PR DESCRIPTION
Three issues found testing the setup wizard now that Ollama is optional:

- The two provider radios sat in separate card frames, so Qt's auto-exclusivity (which only applies to radios sharing a parent) did not kick in and both could be checked. Put them in a shared QButtonGroup.
- The wizard's first step was the Ollama-centric Welcome/status dashboard, checking Ollama before the user had chosen a provider — misleading when Ollama is optional. The Provider Choice page is now the start page (setStartId); the Welcome/status page and the install/server/models flow are reached only on the Ollama branch.
- The provider copy implied non-Ollama options were not local/secure. Reworded so both options are clearly local: the OpenAI-compatible card describes pointing at another local app (LM Studio, oMLX, llama.cpp, vLLM, LocalAI) on your own machine or network, and the subtitle states data stays on machines you control.

Tests: radio mutual-exclusivity, OpenAI card mentions local/network, Ollama choice routes through the Welcome/status page, Welcome enters the Ollama flow, and the wizard starts on the provider choice.