### PR TITLE
docs: record offline-first principle (no vendor-locked cloud integrations)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,7 @@
 Data privacy comes first, always.
 
+Jarvis is offline-first by principle. Do not add integrations that depend on a specific proprietary cloud vendor (e.g. ElevenLabs TTS, or any SaaS that requires shipping user audio/text/data to a third party's servers), not even as an opt-in feature. The line is the offline path: a backend is acceptable only if it can run fully locally. Generic, self-hostable protocols where the user points at their own endpoint (Ollama, OpenAI-compatible servers, LM Studio) are fine precisely because they can be local; a vendor-locked cloud service with no local option is not. When a feature request asks for such a service, decline it on principle and redirect to the offline equivalent (e.g. better local TTS voices rather than cloud TTS).
+
 All user-facing command line output should make use of emojis. Especially an initial emoji to start off the lines that depict what the line is about. Output should make use of indentation spacing to establish a visual hierarchy and aim to make output as easy to sift through as possible. Exception: Windows .bat scripts cannot use emojis (cmd.exe doesn't render Unicode properly).
 
 Any important point in our logical flows should have debug logs using the `debug_log` method from `src/jarvis/debug.py`. Avoid excessive logging to keep the logs easily readable and actionable.


### PR DESCRIPTION
## What

Adds a short principle to `CLAUDE.md`, right under the existing "Data privacy comes first" line: Jarvis is offline-first, so integrations that depend on a specific proprietary cloud vendor (e.g. ElevenLabs TTS, or any SaaS that requires shipping user audio/text/data to a third party) are declined on principle, **not even as an opt-in feature**.

## Why

This surfaced during issue triage. The ElevenLabs TTS request ([#429](https://github.com/isair/jarvis/issues/429)) was initially entertained as an opt-in cloud feature, which contradicts the project's offline-first stance. The rule is now written down so future triage and contributions apply it consistently.

## The line it draws

The distinction is **not** "remote vs local" (the project deliberately supports remote LLM endpoints). The line is *can it run fully locally*:

- ✅ Acceptable: generic, self-hostable protocols the user points at their own endpoint (Ollama, OpenAI-compatible servers, LM Studio) since they can run fully offline.
- ❌ Not acceptable: a vendor-locked cloud service with no local option.

When a request asks for such a service, the guidance is to decline on principle and redirect to the offline equivalent (e.g. better local TTS voices rather than cloud TTS).

## Reviewer notes

- Docs-only change; no code or behaviour affected.
- Related triage actions already applied to [#429](https://github.com/isair/jarvis/issues/429) (relabelled `wontfix`, closed, redirected to an offline TTS path).