### PR TITLE
fix(desktop): keep wizard worker threads alive until fully finished

### DIFF
--- a/src/desktop_app/app.py
+++ b/src/desktop_app/app.py
@@ -2413,16 +2413,18 @@ def main() -> int:
 
         class SetupCheckWorker(QThread):
             """Worker thread to check setup status without blocking UI."""
-            finished = pyqtSignal(bool)  # Emits True if setup wizard needed
+            # Named check_done so it does not shadow QThread's built-in
+            # finished signal (see _KeepAliveWorker in setup_wizard.py).
+            check_done = pyqtSignal(bool)  # Emits True if setup wizard needed
 
             def run(self):
                 try:
                     result = should_show_setup_wizard()
-                    self.finished.emit(result)
+                    self.check_done.emit(result)
                 except Exception as e:
                     print(f"  ❌ Setup check failed: {e}", flush=True)
                     # On error, show wizard to let user fix issues
-                    self.finished.emit(True)
+                    self.check_done.emit(True)
 
         setup_check_result = [None]  # Use list to allow modification in closure
 
@@ -2430,13 +2432,13 @@ def main() -> int:
             setup_check_result[0] = needs_wizard
 
         worker = SetupCheckWorker()
-        worker.finished.connect(on_setup_check_done)
+        worker.check_done.connect(on_setup_check_done)
         worker.start()
 
         # Use QEventLoop to wait while keeping UI fully responsive
         # This allows the splash animation to run smoothly
         loop = QEventLoop()
-        worker.finished.connect(loop.quit)
+        worker.check_done.connect(loop.quit)
         loop.exec()
 
         if setup_check_result[0]:
@@ -2486,15 +2488,17 @@ def main() -> int:
             # Run server check in background thread to keep splash animation alive
             class ServerCheckWorker(QThread):
                 """Worker thread to check Ollama server status without blocking UI."""
-                finished = pyqtSignal(bool, object)  # Emits (is_running, version)
+                # Named check_done so it does not shadow QThread's built-in
+                # finished signal (see _KeepAliveWorker in setup_wizard.py).
+                check_done = pyqtSignal(bool, object)  # Emits (is_running, version)
 
                 def run(self):
                     try:
                         running, ver = check_ollama_server()
-                        self.finished.emit(running, ver)
+                        self.check_done.emit(running, ver)
                     except Exception as e:
                         print(f"  ❌ Server check failed: {e}", flush=True)
-                        self.finished.emit(False, None)
+                        self.check_done.emit(False, None)
 
             server_check_result = [None, None]  # [is_running, version]
 
@@ -2503,12 +2507,12 @@ def main() -> int:
                 server_check_result[1] = ver
 
             server_worker = ServerCheckWorker()
-            server_worker.finished.connect(on_server_check_done)
+            server_worker.check_done.connect(on_server_check_done)
             server_worker.start()
 
             # Use QEventLoop to wait while keeping UI fully responsive
             server_loop = QEventLoop()
-            server_worker.finished.connect(server_loop.quit)
+            server_worker.check_done.connect(server_loop.quit)
             server_loop.exec()
 
             is_running, version = server_check_result

--- a/src/desktop_app/setup_wizard.py
+++ b/src/desktop_app/setup_wizard.py
@@ -14,7 +14,7 @@ import platform
 import webbrowser
 import json
 from pathlib import Path
-from typing import Optional, List, Tuple, Dict
+from typing import ClassVar, Optional, List, Tuple, Dict
 from dataclasses import dataclass
 from enum import Enum, auto
 
@@ -429,19 +429,45 @@ except ImportError:
     GEOIP2_AVAILABLE = False
 
 
-class StatusCheckWorker(QThread):
+class _KeepAliveWorker(QThread):
+    """QThread that keeps itself referenced until its OS thread has fully
+    finished.
+
+    Wizard pages rebind their worker attribute inside completion slots
+    (model install chains, refresh buttons, test-connection buttons). The
+    completion signal is emitted at the end of run(), so the slot can run
+    while the OS thread is still winding down; dropping the last Python
+    reference at that point destroys a running QThread and Qt aborts the
+    whole app ("Fatal Python error: Aborted" — #509, #407, #239).
+
+    Subclasses must NOT shadow the built-in ``finished`` signal — the
+    keep-alive registry relies on it to know when release is safe.
+    """
+
+    _active: ClassVar[set] = set()
+
+    def start(self, *args, **kwargs):
+        _KeepAliveWorker._active.add(self)
+        self.finished.connect(self._retire)
+        super().start(*args, **kwargs)
+
+    def _retire(self) -> None:
+        _KeepAliveWorker._active.discard(self)
+
+
+class StatusCheckWorker(_KeepAliveWorker):
     """Worker thread for checking Ollama status."""
-    finished = pyqtSignal(OllamaStatus)
+    status_ready = pyqtSignal(OllamaStatus)
 
     def run(self):
         status = check_ollama_status()
-        self.finished.emit(status)
+        self.status_ready.emit(status)
 
 
-class CommandWorker(QThread):
+class CommandWorker(_KeepAliveWorker):
     """Worker thread for running commands."""
     output = pyqtSignal(str)
-    finished = pyqtSignal(bool, str)
+    completed = pyqtSignal(bool, str)
 
     def __init__(self, command: List[str], parent=None):
         super().__init__(parent)
@@ -474,11 +500,11 @@ class CommandWorker(QThread):
             process.wait()
 
             if process.returncode == 0:
-                self.finished.emit(True, "✅ Command completed successfully")
+                self.completed.emit(True, "✅ Command completed successfully")
             else:
-                self.finished.emit(False, f"❌ Command failed with exit code {process.returncode}")
+                self.completed.emit(False, f"❌ Command failed with exit code {process.returncode}")
         except Exception as e:
-            self.finished.emit(False, f"❌ Error: {str(e)}")
+            self.completed.emit(False, f"❌ Error: {str(e)}")
 
 
 class SetupWizard(QWizard):
@@ -751,7 +777,7 @@ class WelcomePage(QWizardPage):
 
         # Start background check
         self.worker = StatusCheckWorker()
-        self.worker.finished.connect(self._on_status_checked)
+        self.worker.status_ready.connect(self._on_status_checked)
         self.worker.start()
 
     def _on_status_checked(self, status: OllamaStatus):
@@ -978,7 +1004,7 @@ class ProviderChoicePage(QWizardPage):
         return wizard.welcome_page_id
 
 
-class _ModelFetchWorker(QThread):
+class _ModelFetchWorker(_KeepAliveWorker):
     """Fetches the model list from an OpenAI-compatible server off the UI
     thread so the wizard never freezes while connecting."""
 
@@ -1902,7 +1928,7 @@ class ModelsPage(QWizardPage):
 
         self._worker = CommandWorker([ollama_path, "pull", model])
         self._worker.output.connect(self._on_install_output)
-        self._worker.finished.connect(self._on_install_finished)
+        self._worker.completed.connect(self._on_install_finished)
         self._worker.start()
 
     def _on_install_output(self, text: str):
@@ -2545,7 +2571,7 @@ class WhisperSetupPage(QWizardPage):
 
         self._worker = CommandWorker([brew_path, "install", "ffmpeg"])
         self._worker.output.connect(self._on_output)
-        self._worker.finished.connect(self._on_ffmpeg_installed)
+        self._worker.completed.connect(self._on_ffmpeg_installed)
         self._worker.start()
 
     def _install_mlx_whisper(self):
@@ -2561,7 +2587,7 @@ class WhisperSetupPage(QWizardPage):
         python_path = sys.executable
         self._worker = CommandWorker([python_path, "-m", "pip", "install", "mlx-whisper"])
         self._worker.output.connect(self._on_output)
-        self._worker.finished.connect(self._on_mlx_installed)
+        self._worker.completed.connect(self._on_mlx_installed)
         self._worker.start()
 
     def _on_output(self, text: str):

--- a/src/desktop_app/setup_wizard.spec.md
+++ b/src/desktop_app/setup_wizard.spec.md
@@ -88,8 +88,18 @@ Fields suffixed `?` are written only when non-empty (minimal-config invariant).
 
 ## Threading
 
-- `StatusCheckWorker(QThread)` — runs `check_ollama_status()` off the UI thread, emits result via signal.
-- `CommandWorker(QThread)` — runs shell commands (e.g. `ollama pull`), emits stdout line-by-line and completion status.
+- All wizard worker threads inherit `_KeepAliveWorker(QThread)`, which keeps
+  each started worker referenced in a class-level registry until its OS
+  thread has fully finished (released via the built-in `finished` signal).
+  Pages rebind their worker attribute inside completion slots (install
+  chains, refresh/test buttons); without the registry, dropping the last
+  reference to a winding-down thread destroys a running QThread and Qt
+  aborts the whole app. Because of this, worker subclasses must never
+  shadow the built-in `finished` signal — custom completion signals use
+  other names (`completed`, `status_ready`, `done`).
+- `StatusCheckWorker` — runs `check_ollama_status()` off the UI thread, emits result via `status_ready`.
+- `CommandWorker` — runs shell commands (e.g. `ollama pull`), emits stdout line-by-line via `output` and completion status via `completed`.
+- `_ModelFetchWorker` — fetches the OpenAI-compatible model list off the UI thread, emits via `done`.
 
 ## Settings NOT Configured by Wizard
 

--- a/tests/test_setup_wizard_install_chain.py
+++ b/tests/test_setup_wizard_install_chain.py
@@ -1,0 +1,76 @@
+"""
+Regression test for the macOS setup-wizard model-install crash
+(#509, #407, #239): "Fatal Python error: Aborted" at the
+``self._worker = CommandWorker(...)`` line while handling the previous
+worker's completion signal.
+
+Root cause: rebinding ``self._worker`` inside the completion slot drops
+the last Python reference to the previous CommandWorker while its OS
+thread can still be winding down after ``run()`` returned. Qt then
+destroys a running QThread ("QThread: Destroyed while thread is still
+running") and aborts the whole app with SIGABRT.
+
+The abort kills the interpreter, so the scenario runs in a subprocess:
+it chains rapid worker replacements exactly like the wizard's install
+loop. Pre-fix this reliably dies with SIGABRT within the iteration
+budget; post-fix it completes and prints CHAIN_OK.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+SCENARIO = r"""
+import os, sys
+
+sys.path.insert(0, r"{src}")
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from PyQt6.QtWidgets import QApplication
+
+from desktop_app.setup_wizard import CommandWorker
+
+app = QApplication([])
+
+N = 300
+state = {{"i": 0, "worker": None}}
+cmd = [sys.executable, "-c", "print('pulled')"]
+
+
+def start_next():
+    if state["i"] >= N:
+        app.quit()
+        return
+    state["i"] += 1
+    # Mirrors ModelsPage._install_next_model: rebinding drops the previous
+    # worker's reference inside the completion slot.
+    state["worker"] = CommandWorker(cmd)
+    state["worker"].completed.connect(on_completed)
+    state["worker"].start()
+
+
+def on_completed(success, message):
+    start_next()
+
+
+start_next()
+app.exec()
+print(f"CHAIN_OK after {{N}} replacements")
+"""
+
+
+def test_chained_worker_replacement_does_not_abort():
+    """Rapidly replacing CommandWorkers (the wizard install loop) must not SIGABRT."""
+    result = subprocess.run(
+        [sys.executable, "-c", SCENARIO.format(src=str(ROOT / "src"))],
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    assert result.returncode == 0, (
+        f"install chain crashed (returncode={result.returncode})\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+    assert "CHAIN_OK" in result.stdout


### PR DESCRIPTION
## Summary

Fixes the most-reported macOS crash family: `Fatal Python error: Aborted` while the setup wizard installs models (#509, #407, #239 — all three tracebacks abort at the same statement, `self._worker = CommandWorker(...)` inside `_on_install_finished`).

**Root cause (reproduced, not theorised):** wizard pages rebind their worker attribute inside completion slots. The custom completion signal is emitted at the end of `run()`, so the slot can execute while the previous QThread's OS thread is still winding down. Dropping the last Python reference at that moment destroys a running QThread, and Qt aborts the whole app with `QThread: Destroyed while thread '' is still running`. Reproduced deterministically on macOS with the shipped `CommandWorker`: chaining worker replacements SIGABRTs (rc=134) well within 300 iterations before the fix.

**Fix:** all wizard workers (`CommandWorker`, `StatusCheckWorker`, `_ModelFetchWorker`) now inherit `_KeepAliveWorker`, which registers each started worker in a class-level set and releases it via the built-in `QThread.finished` signal once the thread has truly finished. To make that possible, custom completion signals no longer shadow the built-in `finished` signal: `CommandWorker.finished` → `completed`, `StatusCheckWorker.finished` → `status_ready`. All connect/emit sites updated; no users outside `setup_wizard.py`. The same hazard existed on the refresh and test-connection buttons (rebinding on repeat clicks), which this also covers.

Follow-up from the adversarial review: `SetupCheckWorker` and `ServerCheckWorker` in `app.py` also shadowed the built-in `finished` signal. They are safe today (local references outlive the threads), but they now use `check_done` for consistency with the new invariant.

`setup_wizard.spec.md` Threading section updated with the keep-alive contract and the no-shadowing rule.

## Tests

New `tests/test_setup_wizard_install_chain.py` runs the exact wizard replacement pattern (300 chained `CommandWorker` replacements from the completion slot) in a subprocess. Pre-fix this dies with SIGABRT; post-fix it completes — verified stable across repeated runs. Wizard/desktop suites pass.

Note: the Windows `Fatal Python error: Aborted` reports (#458, #422) are a different failure class (daemon/MCP subprocess and listener startup) and are NOT addressed by this PR.

Closes #509
Closes #407
Closes #239