### PR TITLE
feat: community governance layer — task state, undo, policy, audit, health, isolation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,11 @@ Any code change must either adhere to our spec files perfectly or you should ask
 | `src/jarvis/memory/summariser.spec.md` | Diary summariser prompt contract, hygiene rules (deflection, attribution, topic separation), post-process scrub, and bulk-sweep clean button | Two-layer defence: prompt + deterministic scrub; corrupted summaries poison every downstream consumer |
 | `src/jarvis/memory/recall_gate.spec.md` | Deterministic skip-enrichment heuristic when the hot window covers a follow-up | Fail-open; language-agnostic via `\w{3,}` + `re.UNICODE`; planner intent always wins |
 | `src/jarvis/llm/llm.spec.md` | Pluggable LLM backend abstraction: `LLMBackend` ABC, `OllamaBackend`, `OpenAICompatibleBackend`, factory dispatch on `llm_provider`, `get_embedding_backend` override, config migrations, the two-tier model system (`Tier.FAST` / `Tier.CHAT` via `resolve_model`), function-style helpers | Provider-agnostic interface so Jarvis can run on Ollama, OpenAI-compatible (LM Studio / oMLX / llama.cpp / vLLM / LocalAI), or Anthropic-compatible servers; every context states its tier instead of defining a model fallback chain |
+| `src/jarvis/task_state.spec.md` | Task/step tracking, undo registry, approval flow | Session-scoped; reversible actions |
+| `src/jarvis/policy/policy.spec.md` | Workspace confinement, kill-switch, tool classification | Voice-first: act-then-undo, not approval gates |
+| `src/jarvis/audit/audit.spec.md` | SQLite audit trail, task/step/policy logging, PII redaction | Durable, privacy-preserving; opt-in |
+| `src/jarvis/execution/execution.spec.md` | Process isolation for high-risk tool execution | Containment without full sandboxing |
+| `src/jarvis/runtime/runtime.spec.md` | Health tracking, graceful shutdown, service lifecycle | Critical + optional services |
 
 The LLM contexts graph at `docs/llm_contexts.md` maps every LLM call in the app (model, gating, inputs, outputs, limits, flow). Keep it up-to-date at all times: any change that adds, removes, or alters an LLM context (model resolution, timeout, cap, prompt source, gating flag, data-flow edge) must update `docs/llm_contexts.md` in the same PR.
 

--- a/README.md
+++ b/README.md
@@ -633,6 +633,7 @@ provider can't run out the voice-assistant latency budget.
 - **100% offline** - No cloud services required
 - **Auto-redaction** - Emails, tokens, passwords automatically removed
 - **Local storage** - Everything in `~/.local/share/jarvis`
+- **Audit log** - When the audit feature is enabled, tool usage is recorded to `audit.db` (a SQLite file stored alongside the main database). The log contains already-redacted user intent and tool decisions — no raw personal data is written. You can disable auditing by leaving `audit_db_path` unset in your config.
 
 ## License
 

--- a/src/desktop_app/__init__.py
+++ b/src/desktop_app/__init__.py
@@ -15,6 +15,19 @@ os.environ.setdefault('OPENBLAS_NUM_THREADS', '1')
 os.environ.setdefault('MKL_NUM_THREADS', '1')
 os.environ.setdefault('OMP_NUM_THREADS', '1')
 
+# When launched as `python -m src.desktop_app` the package is registered in
+# sys.modules as 'src.desktop_app', but all internal imports use the bare
+# 'desktop_app' name (matching the PYTHONPATH=src invocation used by the run
+# scripts).  Alias ourselves and add src/ to sys.path so both styles work
+# without triggering a double-import of this __init__.
+import importlib
+_this_module = sys.modules[__name__]   # 'src.desktop_app' or 'desktop_app'
+if __name__ != 'desktop_app':
+    sys.modules.setdefault('desktop_app', _this_module)
+    _src_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    if _src_dir not in sys.path:
+        sys.path.insert(0, _src_dir)
+
 # Re-export main for entry point
 from desktop_app.app import main
 

--- a/src/jarvis/approval.py
+++ b/src/jarvis/approval.py
@@ -1,0 +1,246 @@
+"""
+Approval – risk assessment and approval logic.
+
+Implements the Decision Policy from the JARVIS specification:
+- Act automatically on clear, specific instructions
+- Ask clarification for broad or ambiguous requests
+- Require approval for destructive or high-impact actions
+
+Tools and tool arguments are inspected against known risk patterns to
+determine whether the operation requires explicit user confirmation
+before execution.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Dict, Any, Optional
+
+from .debug import debug_log
+# RiskLevel lives with each tool definition; re-exported here so existing
+# callers that do `from jarvis.approval import RiskLevel` continue to work.
+from .tools.types import RiskLevel  # noqa: F401
+from .tools.registry import BUILTIN_TOOLS
+
+
+def assess_risk(tool_name: Optional[str], tool_args: Optional[Dict[str, Any]]) -> RiskLevel:
+    """
+    Determine the risk level of a tool invocation.
+
+    Delegates to the tool's own ``assess_risk`` method so that risk
+    information stays co-located with the tool definition rather than
+    in a separate parallel mapping that can diverge when tools are added
+    or removed.
+
+    Args:
+        tool_name: Canonical tool identifier (camelCase or server__tool format)
+        tool_args: Arguments passed to the tool
+
+    Returns:
+        RiskLevel indicating safe, moderate, or high risk
+    """
+    if not tool_name:
+        return RiskLevel.SAFE
+
+    # MCP tools (server__toolname format) have no local definition
+    if "__" in tool_name:
+        return RiskLevel.MODERATE
+
+    tool = BUILTIN_TOOLS.get(tool_name)
+    if tool is None:
+        debug_log(f"unknown tool risk: defaulting to MODERATE for '{tool_name}'", "approval")
+        return RiskLevel.MODERATE
+
+    return tool.assess_risk(tool_args)
+
+
+# ---------------------------------------------------------------------------
+# Request classification (informational vs operational)
+# ---------------------------------------------------------------------------
+
+class RequestType(Enum):
+    """High-level classification of a user request."""
+    INFORMATIONAL = "informational"  # Answers a question, no side-effects
+    OPERATIONAL = "operational"      # Performs an action / changes state
+
+
+def classify_request(text: str, tool_name: Optional[str] = None) -> RequestType:
+    """
+    Classify a user request as informational or operational.
+
+    Classification is language-agnostic: if a tool has already been
+    selected for this request the classification is ``OPERATIONAL``;
+    otherwise it defaults to ``INFORMATIONAL``.  Callers in the reply
+    engine may update the classification after the agentic loop completes
+    (e.g. by calling this again once tool selection is known).
+
+    Args:
+        text: Redacted user query (unused in current implementation but
+              retained for API compatibility and future extension).
+        tool_name: Canonical tool identifier if one has been chosen,
+                   or ``None`` for the initial pre-loop classification.
+
+    Returns:
+        RequestType.OPERATIONAL if a tool is being executed,
+        RequestType.INFORMATIONAL otherwise.
+    """
+    if tool_name:
+        debug_log(f"request classified as operational (tool='{tool_name}')", "approval")
+        return RequestType.OPERATIONAL
+    debug_log("request classified as informational (pre-execution)", "approval")
+    return RequestType.INFORMATIONAL
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _summarise_args(tool_args: Optional[Dict[str, Any]], max_len: int = 80) -> str:
+    """Return a short, readable summary of tool arguments."""
+    if not tool_args:
+        return ""
+    parts = []
+    for key, value in tool_args.items():
+        parts.append(f"{key}={str(value)[:30]}")
+    summary = ", ".join(parts)
+    return summary[:max_len] + ("…" if len(summary) > max_len else "")
+
+
+# ---------------------------------------------------------------------------
+# Undo support
+# ---------------------------------------------------------------------------
+
+# Maps (tool_name, operation) → whether the action is reversible.
+# Operations listed here require a snapshot captured before execution in
+# order to undo; tools marked False are acknowledged as irreversible.
+_UNDOABLE: Dict[str, Any] = {
+    "localFiles": {
+        "write":  True,   # Undo by writing back the original content
+        "append": True,   # Undo by writing back the original content
+        "delete": True,   # Undo by writing back the snapshotted content
+        "list":   False,
+        "read":   False,
+    },
+    # Meal logging: undo support requires result parsing (meal_id) — future work
+    "logMeal":    False,
+    "deleteMeal": False,
+}
+
+
+def is_undoable(tool_name: Optional[str], tool_args: Optional[Dict[str, Any]]) -> bool:
+    """
+    Return True when this operation can be reversed via the UndoRegistry.
+
+    An operation is undoable only when:
+    - It has a declared reversal strategy (in ``_UNDOABLE``)
+    - The caller will provide a pre-execution snapshot where required
+
+    Args:
+        tool_name: Canonical tool identifier
+        tool_args: Arguments passed to the tool
+
+    Returns:
+        True if a reversal strategy exists for this tool/operation combination
+    """
+    if not tool_name:
+        return False
+    entry = _UNDOABLE.get(tool_name)
+    if entry is None:
+        return False
+    if isinstance(entry, bool):
+        return entry
+    if isinstance(entry, dict):
+        operation = str((tool_args or {}).get("operation", "")).lower()
+        return bool(entry.get(operation, False))
+    return False
+
+
+def pre_execution_warning(
+    tool_name: Optional[str], tool_args: Optional[Dict[str, Any]]
+) -> Optional[str]:
+    """
+    Return a brief spoken warning to deliver BEFORE executing a HIGH-risk,
+    irreversible action, or None if no warning is needed.
+
+    For HIGH-risk actions that ARE undoable, no pre-warning is issued
+    because a post-execution "say undo" note is less intrusive.
+
+    Args:
+        tool_name: Canonical tool identifier
+        tool_args: Arguments passed to the tool
+
+    Returns:
+        Warning string, or None
+    """
+    if assess_risk(tool_name, tool_args) != RiskLevel.HIGH:
+        return None
+    if is_undoable(tool_name, tool_args):
+        return None  # Post-note handles this case
+    args_summary = _summarise_args(tool_args)
+    action = f"{tool_name}"
+    if args_summary:
+        action += f" ({args_summary})"
+    return f"Heads up — {action} cannot be undone."
+
+
+def post_execution_note(
+    tool_name: Optional[str], tool_args: Optional[Dict[str, Any]]
+) -> Optional[str]:
+    """
+    Return a brief spoken note to append AFTER successfully executing a
+    HIGH-risk, undoable action, or None if no note is needed.
+
+    Args:
+        tool_name: Canonical tool identifier
+        tool_args: Arguments passed to the tool
+
+    Returns:
+        Note string, or None
+    """
+    if assess_risk(tool_name, tool_args) != RiskLevel.HIGH:
+        return None
+    if not is_undoable(tool_name, tool_args):
+        return None
+    return "Say undo if you'd like to reverse that."
+
+
+def build_undo_args(
+    tool_name: str,
+    tool_args: Dict[str, Any],
+    snapshot: Optional[Any] = None,
+) -> Optional[tuple]:
+    """
+    Build the (undo_tool, undo_args, description) triple for an UndoEntry.
+
+    Returns None when the operation is not undoable or when a required
+    snapshot was not provided.
+
+    Args:
+        tool_name:  Canonical tool identifier of the *executed* tool
+        tool_args:  Arguments that were passed to the tool
+        snapshot:   State captured before execution (e.g. original file content)
+
+    Returns:
+        (undo_tool, undo_args, description) tuple, or None
+    """
+    if not is_undoable(tool_name, tool_args):
+        return None
+
+    if tool_name == "localFiles":
+        operation = str(tool_args.get("operation", "")).lower()
+        path = tool_args.get("path", "")
+
+        if operation in ("write", "append", "delete"):
+            if snapshot is None:
+                debug_log(
+                    f"build_undo_args: no snapshot for localFiles/{operation} — "
+                    "cannot register undo",
+                    "approval",
+                )
+                return None
+            description = f"{operation}d {path}"
+            undo_args = {"operation": "write", "path": path, "content": snapshot}
+            return "localFiles", undo_args, description
+
+    debug_log(f"build_undo_args: no strategy for {tool_name!r}", "approval")
+    return None

--- a/src/jarvis/approval.py
+++ b/src/jarvis/approval.py
@@ -180,7 +180,14 @@ def pre_execution_warning(
     action = f"{tool_name}"
     if args_summary:
         action += f" ({args_summary})"
-    return f"Heads up — {action} cannot be undone."
+    # A model-directed instruction, not user-facing text: the reply LLM weaves
+    # the warning into its answer in the user's language. Never splice literal
+    # English into the spoken reply (language-agnostic rule).
+    return (
+        f"[Safety note: the {action} action that just ran is irreversible — "
+        f"it cannot be undone. Briefly mention this to the user, in the "
+        f"user's language.]"
+    )
 
 
 def post_execution_note(
@@ -201,7 +208,12 @@ def post_execution_note(
         return None
     if not is_undoable(tool_name, tool_args):
         return None
-    return "Say undo if you'd like to reverse that."
+    # Model-directed instruction (see pre_execution_warning): the reply LLM
+    # tells the user, in their language, that the action can be undone.
+    return (
+        "[Note: this action was registered as undoable. Briefly tell the "
+        "user they can ask you to undo it, in the user's language.]"
+    )
 
 
 def build_undo_args(

--- a/src/jarvis/audit/__init__.py
+++ b/src/jarvis/audit/__init__.py
@@ -1,0 +1,14 @@
+"""Jarvis Audit package — durable, queryable record of every planned and executed action."""
+
+from .recorder import AuditRecorder, get_recorder, configure as configure_audit
+from .models import TaskRecord, TaskStepRecord, PolicyDecisionRecord, ApprovalRecord
+
+__all__ = [
+    "AuditRecorder",
+    "get_recorder",
+    "configure_audit",
+    "TaskRecord",
+    "TaskStepRecord",
+    "PolicyDecisionRecord",
+    "ApprovalRecord",
+]

--- a/src/jarvis/audit/audit.spec.md
+++ b/src/jarvis/audit/audit.spec.md
@@ -1,0 +1,89 @@
+# Audit Package Specification
+
+## Purpose
+
+Records a durable, tamper-evident log of every task, tool execution, policy
+decision, and approval event to a SQLite database. The audit system is
+designed to support post-hoc investigation and operator accountability
+without compromising user privacy.
+
+## Privacy
+
+All text stored in the audit database is scrubbed with the same PII-removal
+rules that redact emails, tokens, and passwords from the dialogue. Both the
+task intent and step result summaries are passed through
+`utils.redact.redact()` inside the recorder before persisting to SQLite. No
+raw user input is written to disk.
+
+The audit database is an _additional_ SQLite file (default: `audit.db` in
+the same directory as the main database). Its existence should be
+documented to users. Auditing is entirely opt-in: leaving `audit_db_path`
+unset in the configuration disables the recorder and all calls to
+`get_recorder()` return `None`.
+
+## Components
+
+### `db.py` — `AuditDB`
+
+Low-level SQLite wrapper. Creates and migrates the schema on first open.
+
+**Tables:**
+
+| Table              | Description                                        |
+|--------------------|----------------------------------------------------|
+| `tasks`            | One row per user request (intent, profile, tools)  |
+| `task_steps`       | One row per tool invocation within a task          |
+| `policy_decisions` | One row per policy evaluation (allow/deny reasons) |
+| `approvals`        | One row per user approval grant or denial          |
+
+All timestamps are stored as UNIX epoch floats.
+
+### `recorder.py` — `AuditRecorder`
+
+High-level facade. Provides `begin_task()`, `finish_task()`,
+`record_step()`, `record_policy_decision()`, `record_approval()`.
+
+All methods are safe to call when the database is unavailable — they log a
+debug message and return silently. This ensures a database error never
+crashes the reply engine.
+
+**Module-level singleton:**
+
+```python
+from jarvis.audit.recorder import configure, get_recorder
+
+configure("/path/to/audit.db")   # call once at daemon startup
+recorder = get_recorder()        # returns None if not configured
+```
+
+### `models.py`
+
+Pure dataclasses used as arguments to `AuditRecorder` methods:
+
+- `TaskRecord` — intent, request_type, profile, status
+- `TaskStepRecord` — tool_name, args_hash, success, duration_ms
+- `PolicyDecisionRecord` — tool_class, risk_level, allowed, constraints_json
+- `ApprovalRecord` — tool_name, operation, path_prefix, decision, expires_at
+
+## Configuration Fields Used
+
+| Field          | Type  | Default | Effect                                          |
+|----------------|-------|---------|-------------------------------------------------|
+| `audit_db_path`| `str` | `None`  | Path to the SQLite audit database. If omitted, auditing is disabled. Defaults to `audit.db` alongside the main DB when set up via the bootstrap. |
+
+## Lifecycle
+
+```
+daemon startup
+  └─ configure(audit_db_path)       sets module singleton
+
+reply engine — per request
+  ├─ recorder.begin_task(…)
+  ├─ [per tool call] recorder.record_step(…)
+  │                  recorder.record_policy_decision(…)
+  │                  recorder.record_approval(…)           (if approval sought)
+  └─ recorder.finish_task(task_id, final_status)
+
+daemon shutdown
+  └─ recorder.close()
+```

--- a/src/jarvis/audit/db.py
+++ b/src/jarvis/audit/db.py
@@ -1,0 +1,181 @@
+"""
+Audit database — SQLite schema and low-level access layer.
+
+Tables
+------
+tasks            – one row per user query (top-level task)
+task_steps       – one row per tool invocation within a task
+policy_decisions – one row per policy evaluation (linked to a step)
+approvals        – one row per user approval or denial
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import threading
+from pathlib import Path
+from typing import Optional
+
+from ..debug import debug_log
+
+# ---------------------------------------------------------------------------
+# DDL
+# ---------------------------------------------------------------------------
+
+_SCHEMA_SQL = """
+PRAGMA journal_mode=WAL;
+PRAGMA synchronous=NORMAL;
+PRAGMA foreign_keys=ON;
+
+-- ── Tasks ──────────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS tasks (
+    task_id         TEXT PRIMARY KEY,
+    intent          TEXT NOT NULL DEFAULT '',
+    request_type    TEXT NOT NULL DEFAULT '',
+    selected_profile TEXT NOT NULL DEFAULT '',
+    selected_tools  TEXT NOT NULL DEFAULT '[]',   -- JSON array
+    status          TEXT NOT NULL DEFAULT 'planning',
+    started_at      REAL NOT NULL,
+    finished_at     REAL,
+    duration_ms     REAL,
+    final_status    TEXT NOT NULL DEFAULT 'unknown',
+    error           TEXT
+);
+
+-- ── Task steps ──────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS task_steps (
+    step_id         TEXT PRIMARY KEY,
+    task_id         TEXT NOT NULL REFERENCES tasks(task_id) ON DELETE CASCADE,
+    tool_name       TEXT NOT NULL DEFAULT '',
+    args_hash       TEXT NOT NULL DEFAULT '',
+    policy_audit_id TEXT NOT NULL DEFAULT '',
+    retry_count     INTEGER NOT NULL DEFAULT 0,
+    result_summary  TEXT NOT NULL DEFAULT '',
+    success         INTEGER NOT NULL DEFAULT 1,   -- 0/1 boolean
+    started_at      REAL NOT NULL,
+    finished_at     REAL,
+    duration_ms     REAL
+);
+
+CREATE INDEX IF NOT EXISTS idx_steps_task_id ON task_steps(task_id);
+
+-- ── Policy decisions ────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS policy_decisions (
+    audit_id          TEXT PRIMARY KEY,
+    task_id           TEXT NOT NULL DEFAULT '',
+    step_id           TEXT NOT NULL DEFAULT '',
+    tool_name         TEXT NOT NULL DEFAULT '',
+    tool_class        TEXT NOT NULL DEFAULT '',
+    risk_level        TEXT NOT NULL DEFAULT '',
+    allowed           INTEGER NOT NULL DEFAULT 1,
+    approval_required INTEGER NOT NULL DEFAULT 0,
+    decision_reason   TEXT NOT NULL DEFAULT '',
+    denied_reason     TEXT NOT NULL DEFAULT '',
+    constraints_json  TEXT NOT NULL DEFAULT '[]',
+    decided_at        REAL NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_pd_task_id ON policy_decisions(task_id);
+
+-- ── Approvals ───────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS approvals (
+    approval_id TEXT PRIMARY KEY,
+    task_id     TEXT NOT NULL DEFAULT '',
+    step_id     TEXT NOT NULL DEFAULT '',
+    tool_name   TEXT NOT NULL DEFAULT '',
+    operation   TEXT NOT NULL DEFAULT '*',
+    path_prefix TEXT NOT NULL DEFAULT '*',
+    decision    TEXT NOT NULL DEFAULT 'granted',
+    granted_by  TEXT NOT NULL DEFAULT 'user',
+    decided_at  REAL NOT NULL,
+    expires_at  REAL
+);
+
+CREATE INDEX IF NOT EXISTS idx_approvals_task_id ON approvals(task_id);
+"""
+
+
+class AuditDB:
+    """
+    Thread-safe SQLite wrapper for the audit database.
+
+    The audit tables are written to a *separate* database from the main Jarvis
+    database so that audit data is never accidentally cleared alongside
+    user memories.
+    """
+
+    def __init__(self, db_path: str) -> None:
+        self._db_path = db_path
+        self._lock = threading.Lock()
+        self._conn: Optional[sqlite3.Connection] = None
+        self._open()
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def _open(self) -> None:
+        try:
+            Path(self._db_path).parent.mkdir(parents=True, exist_ok=True)
+            self._conn = sqlite3.connect(
+                self._db_path,
+                check_same_thread=False,
+                timeout=10,
+            )
+            self._conn.row_factory = sqlite3.Row
+            self._conn.executescript(_SCHEMA_SQL)
+            self._conn.commit()
+            debug_log(f"audit db opened at {self._db_path}", "audit")
+        except Exception as exc:
+            debug_log(f"audit db init failed: {exc}", "audit")
+            self._conn = None
+
+    def close(self) -> None:
+        if self._conn:
+            try:
+                self._conn.close()
+            except Exception:
+                pass
+            self._conn = None
+
+    # ------------------------------------------------------------------
+    # Write helpers
+    # ------------------------------------------------------------------
+
+    def execute(self, sql: str, params: tuple = ()) -> None:
+        """Execute a single write statement inside a lock."""
+        if self._conn is None:
+            return
+        with self._lock:
+            try:
+                self._conn.execute(sql, params)
+                self._conn.commit()
+            except Exception as exc:
+                debug_log(f"audit db write error: {exc}", "audit")
+
+    def executemany(self, sql: str, params_seq) -> None:
+        """Execute a batch write statement inside a lock."""
+        if self._conn is None:
+            return
+        with self._lock:
+            try:
+                self._conn.executemany(sql, params_seq)
+                self._conn.commit()
+            except Exception as exc:
+                debug_log(f"audit db batch write error: {exc}", "audit")
+
+    # ------------------------------------------------------------------
+    # Query helpers
+    # ------------------------------------------------------------------
+
+    def fetchall(self, sql: str, params: tuple = ()):
+        """Execute a query and return all rows as dicts."""
+        if self._conn is None:
+            return []
+        with self._lock:
+            try:
+                cur = self._conn.execute(sql, params)
+                return [dict(row) for row in cur.fetchall()]
+            except Exception as exc:
+                debug_log(f"audit db query error: {exc}", "audit")
+                return []

--- a/src/jarvis/audit/models.py
+++ b/src/jarvis/audit/models.py
@@ -1,0 +1,159 @@
+"""
+Audit data models.
+
+These are lightweight data-transfer objects that map directly onto the
+``tasks``, ``task_steps``, ``policy_decisions``, and ``approvals`` tables
+in the audit database.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+
+# ---------------------------------------------------------------------------
+# TaskRecord
+# ---------------------------------------------------------------------------
+
+@dataclass
+class TaskRecord:
+    """
+    One logical task — corresponds to a single user query dispatched to the
+    reply engine.
+
+    Persisted to the ``tasks`` table.
+    """
+    task_id: str = field(default_factory=lambda: uuid.uuid4().hex)
+    """Stable unique identifier for this task."""
+
+    intent: str = ""
+    """Redacted user query / intent."""
+
+    request_type: str = ""
+    """Classification from :func:`jarvis.approval.classify_request`."""
+
+    selected_profile: str = ""
+    """Profile chosen by the profile-selector LLM."""
+
+    selected_tools: List[str] = field(default_factory=list)
+    """Tools invoked during execution (populated at the end)."""
+
+    status: str = "planning"
+    """One of: planning, executing, awaiting_approval, done, failed."""
+
+    started_at: float = field(default_factory=time.time)
+    """UNIX timestamp of task creation."""
+
+    finished_at: Optional[float] = None
+    """UNIX timestamp of task completion."""
+
+    duration_ms: Optional[float] = None
+    """Wall-clock duration in milliseconds."""
+
+    final_status: str = "unknown"
+    """done | failed | approval_denied | policy_denied"""
+
+    error: Optional[str] = None
+    """Error message if the task failed."""
+
+
+# ---------------------------------------------------------------------------
+# TaskStepRecord
+# ---------------------------------------------------------------------------
+
+@dataclass
+class TaskStepRecord:
+    """
+    One execution step within a task — typically one tool invocation.
+
+    Persisted to the ``task_steps`` table.
+    """
+    step_id: str = field(default_factory=lambda: uuid.uuid4().hex)
+    task_id: str = ""
+
+    tool_name: str = ""
+    """Canonical tool name (camelCase or server__tool)."""
+
+    args_hash: str = ""
+    """SHA-256 of the canonical JSON-serialised arguments (for dedup detection)."""
+
+    policy_audit_id: str = ""
+    """Foreign key into ``policy_decisions``."""
+
+    retry_count: int = 0
+    """How many times the tool was retried."""
+
+    result_summary: str = ""
+    """Short human-readable summary of the result (≤ 200 chars)."""
+
+    success: bool = True
+
+    started_at: float = field(default_factory=time.time)
+    finished_at: Optional[float] = None
+    duration_ms: Optional[float] = None
+
+    @staticmethod
+    def hash_args(args: Optional[Dict[str, Any]]) -> str:
+        """Return a SHA-256 hex digest of the canonically serialised arguments."""
+        canonical = json.dumps(args or {}, sort_keys=True, separators=(",", ":"))
+        return hashlib.sha256(canonical.encode()).hexdigest()[:16]
+
+
+# ---------------------------------------------------------------------------
+# PolicyDecisionRecord
+# ---------------------------------------------------------------------------
+
+@dataclass
+class PolicyDecisionRecord:
+    """
+    Snapshot of a :class:`~jarvis.policy.PolicyDecision`.
+
+    Persisted to the ``policy_decisions`` table.
+    """
+    audit_id: str = ""
+    task_id: str = ""
+    step_id: str = ""
+
+    tool_name: str = ""
+    tool_class: str = ""
+    risk_level: str = ""
+    allowed: bool = True
+    approval_required: bool = False
+    decision_reason: str = ""
+    denied_reason: str = ""
+    constraints_json: str = "[]"
+    """JSON-serialised list of applied constraint names."""
+
+    decided_at: float = field(default_factory=time.time)
+
+
+# ---------------------------------------------------------------------------
+# ApprovalRecord
+# ---------------------------------------------------------------------------
+
+@dataclass
+class ApprovalRecord:
+    """
+    Records a user approval decision.
+
+    Persisted to the ``approvals`` table.
+    """
+    approval_id: str = field(default_factory=lambda: uuid.uuid4().hex)
+    task_id: str = ""
+    step_id: str = ""
+
+    tool_name: str = ""
+    operation: str = "*"
+    path_prefix: str = "*"
+
+    decision: str = "granted"
+    """``"granted"`` | ``"denied"``"""
+
+    granted_by: str = "user"
+    decided_at: float = field(default_factory=time.time)
+    expires_at: Optional[float] = None

--- a/src/jarvis/audit/recorder.py
+++ b/src/jarvis/audit/recorder.py
@@ -1,0 +1,244 @@
+"""
+Audit recorder — high-level API for writing task, step, policy, and approval records.
+
+Usage::
+
+    from jarvis.audit import configure_audit, get_recorder
+
+    # At daemon startup:
+    configure_audit("/path/to/audit.db")
+
+    # In the reply engine:
+    recorder = get_recorder()
+    recorder.begin_task(task_record)
+    recorder.record_step(step_record)
+    recorder.record_policy_decision(decision_record)
+    recorder.finish_task(task_id, final_status="done")
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from typing import Optional
+
+from ..debug import debug_log
+from ..utils.redact import redact as _redact
+from .db import AuditDB
+from .models import ApprovalRecord, PolicyDecisionRecord, TaskRecord, TaskStepRecord
+
+
+class AuditRecorder:
+    """
+    High-level facade over :class:`~jarvis.audit.db.AuditDB`.
+
+    All methods are safe to call even when the database is unavailable —
+    they log a debug message and return silently.
+    """
+
+    def __init__(self, db: AuditDB) -> None:
+        self._db = db
+
+    # ------------------------------------------------------------------
+    # Task lifecycle
+    # ------------------------------------------------------------------
+
+    def begin_task(self, record: TaskRecord) -> None:
+        """Insert a new task row."""
+        self._db.execute(
+            """
+            INSERT OR IGNORE INTO tasks
+              (task_id, intent, request_type, selected_profile, selected_tools,
+               status, started_at, finished_at, duration_ms, final_status, error)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                record.task_id,
+                _redact(record.intent, max_len=500),
+                record.request_type,
+                record.selected_profile,
+                json.dumps(record.selected_tools),
+                record.status,
+                record.started_at,
+                record.finished_at,
+                record.duration_ms,
+                record.final_status,
+                record.error,
+            ),
+        )
+        debug_log(f"audit: task started task_id={record.task_id}", "audit")
+
+    def finish_task(
+        self,
+        task_id: str,
+        final_status: str,
+        selected_tools: Optional[list] = None,
+        selected_profile: str = "",
+        error: Optional[str] = None,
+        started_at: Optional[float] = None,
+    ) -> None:
+        """Update a task row with completion details.
+
+        Pass *started_at* to avoid a round-trip query for the value
+        recorded in :meth:`begin_task`.  When omitted the recorder
+        falls back to reading from the database.
+        """
+        finished = time.time()
+        if started_at is not None:
+            started = started_at
+        else:
+            rows = self._db.fetchall(
+                "SELECT started_at FROM tasks WHERE task_id = ?", (task_id,)
+            )
+            started = rows[0]["started_at"] if rows else finished
+        duration = (finished - started) * 1000
+
+        self._db.execute(
+            """
+            UPDATE tasks
+               SET status = ?,
+                   final_status = ?,
+                   finished_at = ?,
+                   duration_ms = ?,
+                   selected_tools = COALESCE(NULLIF(?, ''), selected_tools),
+                   selected_profile = COALESCE(NULLIF(?, ''), selected_profile),
+                   error = ?
+             WHERE task_id = ?
+            """,
+            (
+                final_status,  # status column
+                final_status,  # final_status column
+                finished,
+                duration,
+                json.dumps(selected_tools or []),
+                selected_profile,
+                error,
+                task_id,
+            ),
+        )
+        debug_log(f"audit: task finished task_id={task_id} status={final_status}", "audit")
+
+    # ------------------------------------------------------------------
+    # Step lifecycle
+    # ------------------------------------------------------------------
+
+    def record_step(self, record: TaskStepRecord) -> None:
+        """Insert a task-step row (or update if already exists)."""
+        finished = record.finished_at
+        duration = (
+            (finished - record.started_at) * 1000
+            if finished is not None
+            else None
+        )
+        # Redact result_summary before persisting to the audit database
+        safe_summary = _redact(record.result_summary, max_len=500) if record.result_summary else ""
+        self._db.execute(
+            """
+            INSERT OR REPLACE INTO task_steps
+              (step_id, task_id, tool_name, args_hash, policy_audit_id,
+               retry_count, result_summary, success, started_at, finished_at, duration_ms)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                record.step_id,
+                record.task_id,
+                record.tool_name,
+                record.args_hash,
+                record.policy_audit_id,
+                record.retry_count,
+                safe_summary,
+                int(record.success),
+                record.started_at,
+                finished,
+                duration,
+            ),
+        )
+
+    # ------------------------------------------------------------------
+    # Policy decisions
+    # ------------------------------------------------------------------
+
+    def record_policy_decision(self, record: PolicyDecisionRecord) -> None:
+        """Insert a policy-decision row."""
+        self._db.execute(
+            """
+            INSERT OR IGNORE INTO policy_decisions
+              (audit_id, task_id, step_id, tool_name, tool_class, risk_level,
+               allowed, approval_required, decision_reason, denied_reason,
+               constraints_json, decided_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                record.audit_id,
+                record.task_id,
+                record.step_id,
+                record.tool_name,
+                record.tool_class,
+                record.risk_level,
+                int(record.allowed),
+                int(record.approval_required),
+                record.decision_reason[:1000],
+                record.denied_reason[:1000],
+                record.constraints_json,
+                record.decided_at,
+            ),
+        )
+
+    # ------------------------------------------------------------------
+    # Approvals
+    # ------------------------------------------------------------------
+
+    def record_approval(self, record: ApprovalRecord) -> None:
+        """Insert an approval record."""
+        self._db.execute(
+            """
+            INSERT OR IGNORE INTO approvals
+              (approval_id, task_id, step_id, tool_name, operation,
+               path_prefix, decision, granted_by, decided_at, expires_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                record.approval_id,
+                record.task_id,
+                record.step_id,
+                record.tool_name,
+                record.operation,
+                record.path_prefix,
+                record.decision,
+                record.granted_by,
+                record.decided_at,
+                record.expires_at,
+            ),
+        )
+        debug_log(
+            f"audit: approval recorded tool={record.tool_name} decision={record.decision}",
+            "audit",
+        )
+
+    def close(self) -> None:
+        """Close the underlying database connection."""
+        self._db.close()
+
+
+# ---------------------------------------------------------------------------
+# Module-level singleton
+# ---------------------------------------------------------------------------
+
+_recorder: Optional[AuditRecorder] = None
+
+
+def configure(db_path: str) -> AuditRecorder:
+    """
+    Initialise the module-level :class:`AuditRecorder`.
+
+    Call once at daemon startup.
+    """
+    global _recorder
+    _recorder = AuditRecorder(AuditDB(db_path))
+    debug_log(f"audit recorder configured at {db_path}", "audit")
+    return _recorder
+
+
+def get_recorder() -> Optional[AuditRecorder]:
+    """Return the module-level recorder, or ``None`` if not configured."""
+    return _recorder

--- a/src/jarvis/config.py
+++ b/src/jarvis/config.py
@@ -269,6 +269,33 @@ class Settings:
     # MCP Integration
     mcps: Dict[str, Any]
 
+    # ── Policy & Workspace Confinement ─────────────────────────────────────────
+    policy_mode: str
+    """One of: always_allow | ask_destructive | ask_every_time | deny_all."""
+
+    workspace_roots: list[str]
+    """Directories the agent is permitted to read/write (workspace_only mode)."""
+
+    blocked_roots: list[str]
+    """Directories that are always denied even if inside workspace_roots."""
+
+    read_only_roots: list[str]
+    """Directories that may be read but not written or deleted."""
+
+    local_files_mode: str
+    """One of: workspace_only | home_only | unrestricted."""
+
+    # ── Audit ───────────────────────────────────────────────────────────────────────
+    audit_db_path: str | None
+    """Path to the audit SQLite database. Defaults to sibling of db_path."""
+
+    # ── Shutdown ───────────────────────────────────────────────────────────────────
+    shutdown_diary_timeout_sec: float
+    """Maximum seconds to wait for diary LLM update during shutdown."""
+
+    # ── Process Isolation ─────────────────────────────────────────────────────────────
+    use_subprocess_for_writes: bool
+    """Run WRITE_OPERATIONAL tools in an isolated subprocess."""
 
 
 def default_config_path() -> Path:
@@ -642,6 +669,24 @@ def get_default_config() -> Dict[str, Any]:
 
         # MCP Integration (external servers Jarvis can use). No defaults.
         "mcps": {},
+
+        # Policy & workspace confinement
+        "policy_mode": "ask_destructive",
+        "workspace_roots": [],
+        "blocked_roots": (
+            ["C:\\Windows", "C:\\Program Files", "C:\\Program Files (x86)"]
+            if sys.platform == "win32"
+            else ["/bin", "/boot", "/dev", "/etc", "/lib", "/lib64",
+                  "/proc", "/sbin", "/sys", "/usr"]
+        ),
+        "read_only_roots": [],
+        "local_files_mode": "home_only",
+        # Audit
+        "audit_db_path": None,
+        # Shutdown
+        "shutdown_diary_timeout_sec": 5.0,
+        # Process Isolation
+        "use_subprocess_for_writes": False,
     }
 
 
@@ -865,6 +910,24 @@ def load_settings() -> Settings:
     raw_dict = merged.get("dictation_custom_dictionary", [])
     dictation_custom_dictionary = list(raw_dict) if isinstance(raw_dict, list) else []
     mcps = _ensure_dict(merged.get("mcps"))
+
+    # Policy & workspace confinement
+    policy_mode = str(merged.get("policy_mode", "ask_destructive"))
+    workspace_roots = _ensure_list(merged.get("workspace_roots", []))
+    blocked_roots = _ensure_list(merged.get("blocked_roots", []))
+    read_only_roots = _ensure_list(merged.get("read_only_roots", []))
+    local_files_mode = str(merged.get("local_files_mode", "home_only"))
+
+    # Audit
+    audit_db_path_val = merged.get("audit_db_path")
+    audit_db_path = None if audit_db_path_val in (None, "", "null") else str(audit_db_path_val)
+
+    # Shutdown
+    shutdown_diary_timeout_sec = float(merged.get("shutdown_diary_timeout_sec", 5.0))
+
+    # Process Isolation
+    use_subprocess_for_writes = bool(merged.get("use_subprocess_for_writes", False))
+
     whisper_min_confidence = float(merged.get("whisper_min_confidence", 0.4))
     whisper_no_speech_threshold = float(merged.get("whisper_no_speech_threshold", 0.5))
     whisper_min_audio_duration = float(merged.get("whisper_min_audio_duration", 0.3))
@@ -1008,4 +1071,20 @@ def load_settings() -> Settings:
 
         # MCP Integration
         mcps=mcps,
+
+        # Policy & workspace confinement
+        policy_mode=policy_mode,
+        workspace_roots=workspace_roots,
+        blocked_roots=blocked_roots,
+        read_only_roots=read_only_roots,
+        local_files_mode=local_files_mode,
+
+        # Audit
+        audit_db_path=audit_db_path,
+
+        # Shutdown
+        shutdown_diary_timeout_sec=shutdown_diary_timeout_sec,
+
+        # Process Isolation
+        use_subprocess_for_writes=use_subprocess_for_writes,
     )

--- a/src/jarvis/config.py
+++ b/src/jarvis/config.py
@@ -671,7 +671,7 @@ def get_default_config() -> Dict[str, Any]:
         "mcps": {},
 
         # Policy & workspace confinement
-        "policy_mode": "ask_destructive",
+        "policy_mode": "active",
         "workspace_roots": [],
         "blocked_roots": (
             ["C:\\Windows", "C:\\Program Files", "C:\\Program Files (x86)"]
@@ -912,7 +912,7 @@ def load_settings() -> Settings:
     mcps = _ensure_dict(merged.get("mcps"))
 
     # Policy & workspace confinement
-    policy_mode = str(merged.get("policy_mode", "ask_destructive"))
+    policy_mode = str(merged.get("policy_mode", "active"))
     workspace_roots = _ensure_list(merged.get("workspace_roots", []))
     blocked_roots = _ensure_list(merged.get("blocked_roots", []))
     read_only_roots = _ensure_list(merged.get("read_only_roots", []))

--- a/src/jarvis/config.py
+++ b/src/jarvis/config.py
@@ -271,7 +271,10 @@ class Settings:
 
     # ── Policy & Workspace Confinement ─────────────────────────────────────────
     policy_mode: str
-    """One of: always_allow | ask_destructive | ask_every_time | deny_all."""
+    """One of: active | deny. "active" is the normal act-then-undo mode;
+    "deny" is a kill-switch that blocks every tool call. Legacy values
+    (always_allow, ask_destructive, ask_every_time) map to "active";
+    deny_all maps to "deny"."""
 
     workspace_roots: list[str]
     """Directories the agent is permitted to read/write (workspace_only mode)."""
@@ -291,11 +294,15 @@ class Settings:
 
     # ── Shutdown ───────────────────────────────────────────────────────────────────
     shutdown_diary_timeout_sec: float
-    """Maximum seconds to wait for diary LLM update during shutdown."""
+    """Maximum seconds to wait for diary LLM update during shutdown.
+    NOT YET WIRED: the daemon currently uses its own fixed timeout; this
+    key takes effect once ShutdownManager is integrated."""
 
     # ── Process Isolation ─────────────────────────────────────────────────────────────
     use_subprocess_for_writes: bool
-    """Run WRITE_OPERATIONAL tools in an isolated subprocess."""
+    """Run WRITE_OPERATIONAL tools in an isolated subprocess.
+    NOT YET WIRED: the reply engine does not route through ToolRunner yet;
+    this key is inert until the execution package is integrated."""
 
 
 def default_config_path() -> Path:

--- a/src/jarvis/daemon.py
+++ b/src/jarvis/daemon.py
@@ -332,9 +332,9 @@ def main() -> None:
         from .policy.engine import configure as _configure_policy
         _approval_store = _ApprovalStore()
         _configure_policy(cfg, _approval_store)
-        debug_log(f"policy engine configured: mode={getattr(cfg, 'policy_mode', 'ask_destructive')}", "runtime")
+        debug_log(f"policy engine configured: mode={getattr(cfg, 'policy_mode', 'active')}", "runtime")
         if _health:
-            _health.ready("policy", f"mode={getattr(cfg, 'policy_mode', 'ask_destructive')}")
+            _health.ready("policy", f"mode={getattr(cfg, 'policy_mode', 'active')}")
     except Exception as _pe:
         debug_log(f"policy init failed (non-fatal): {_pe}", "runtime")
         if _health:

--- a/src/jarvis/daemon.py
+++ b/src/jarvis/daemon.py
@@ -317,6 +317,51 @@ def main() -> None:
     print(f"🧠 Using chat model: {cfg.llm_chat_model}", flush=True)
     print(f"🎤 Using whisper model: {cfg.whisper_model}", flush=True)
 
+    # Initialise runtime health registry, policy engine, and audit recorder.
+    # Each init is graceful: a failure degrades the service but does not abort startup.
+    try:
+        from .runtime.health import configure as _configure_health
+        _health = _configure_health()
+        debug_log("health registry configured", "runtime")
+    except Exception as _he:
+        debug_log(f"health registry init failed (non-fatal): {_he}", "runtime")
+        _health = None
+
+    try:
+        from .policy.approvals import ApprovalStore as _ApprovalStore
+        from .policy.engine import configure as _configure_policy
+        _approval_store = _ApprovalStore()
+        _configure_policy(cfg, _approval_store)
+        debug_log(f"policy engine configured: mode={getattr(cfg, 'policy_mode', 'ask_destructive')}", "runtime")
+        if _health:
+            _health.ready("policy", f"mode={getattr(cfg, 'policy_mode', 'ask_destructive')}")
+    except Exception as _pe:
+        debug_log(f"policy init failed (non-fatal): {_pe}", "runtime")
+        if _health:
+            try:
+                _health.degraded("policy", "policy engine unavailable", error=str(_pe))
+            except Exception:
+                pass
+
+    try:
+        from .audit.recorder import configure as _configure_audit
+        from pathlib import Path as _Path
+        _audit_db_path = getattr(cfg, "audit_db_path", None)
+        if _audit_db_path:
+            _configure_audit(_audit_db_path)
+            debug_log(f"audit recorder configured: {_audit_db_path}", "runtime")
+            if _health:
+                _health.ready("audit", _audit_db_path)
+        else:
+            debug_log("audit recorder disabled (audit_db_path not set)", "runtime")
+    except Exception as _ae:
+        debug_log(f"audit init failed (non-fatal): {_ae}", "runtime")
+        if _health:
+            try:
+                _health.degraded("audit", "audit db unavailable", error=str(_ae))
+            except Exception:
+                pass
+
     # MCP preflight: discover and cache external MCP tools
     mcps = getattr(cfg, "mcps", {}) or {}
     if mcps:

--- a/src/jarvis/execution/__init__.py
+++ b/src/jarvis/execution/__init__.py
@@ -1,0 +1,12 @@
+"""Jarvis execution package — in-process and out-of-process tool runners."""
+
+from .runner import ToolRunner, RunnerMode, ExecutionResult
+from .worker_protocol import WorkerRequest, WorkerResponse
+
+__all__ = [
+    "ToolRunner",
+    "RunnerMode",
+    "ExecutionResult",
+    "WorkerRequest",
+    "WorkerResponse",
+]

--- a/src/jarvis/execution/execution.spec.md
+++ b/src/jarvis/execution/execution.spec.md
@@ -1,0 +1,88 @@
+# Execution Package Specification
+
+## Purpose
+
+Provides process-isolation primitives for running high-risk or destructive
+built-in tools in a short-lived subprocess rather than in the main daemon
+process. This contains the blast radius of a misbehaving or exploited tool
+and prevents it from directly accessing daemon state.
+
+## Architecture
+
+```
+ToolRunner (runner.py)
+    │
+    ├─ IN_PROCESS path  → tool.run(args, ctx)          (no isolation)
+    └─ SUBPROCESS path  → WorkerRequest → stdin/stdout pipe → subprocess_worker
+                                                        (isolated process)
+```
+
+## Components
+
+### `runner.py` — `ToolRunner`
+
+Central execution funnel. Every tool call from the reply engine passes through
+`ToolRunner.run()` after policy evaluation.
+
+**Mode selection:**
+| Tool class             | `use_subprocess_for_writes` | Mode         |
+|------------------------|-----------------------------|--------------|
+| `INFORMATIONAL`        | any                         | IN_PROCESS   |
+| `READ_ONLY_OPERATIONAL`| any                         | IN_PROCESS   |
+| `WRITE_OPERATIONAL`    | `False`                     | IN_PROCESS   |
+| `WRITE_OPERATIONAL`    | `True`                      | SUBPROCESS   |
+| `DESTRUCTIVE`          | any                         | SUBPROCESS   |
+| `EXTERNAL_DELEGATED`   | any                         | IN_PROCESS   |
+
+MCP tools are always run in-process (they communicate over their own
+protocol and cannot be forked into a subprocess).
+
+**Retry policy:** Only transient failures (`TimeoutExpired`, `ConnectionError`,
+`OSError`, `TimeoutError`) are retried up to `max_retries` times (default 2)
+with a back-off of 0.5 s × attempt number. Permanent errors (bad arguments,
+unknown tools, etc.) fail immediately without retry.
+
+### `subprocess_worker.py` — `main()`
+
+Standalone entry point executed as `python -m jarvis.execution.subprocess_worker`.
+
+Lifecycle:
+1. Reads one `WorkerRequest` from `stdin` (newline-delimited JSON).
+2. Sets a `SIGALRM` timeout on Unix (Windows relies on parent kill).
+3. Calls `_run_builtin(tool_name, tool_args, safety_config)`.
+4. Writes one `WorkerResponse` to `stdout` (newline-delimited JSON).
+5. Exits.
+
+**Path safety:** The worker receives `safety_config` from the parent via
+`WorkerRequest`. It reconstructs a `types.SimpleNamespace` cfg object
+containing `workspace_roots`, `blocked_roots`, `read_only_roots`, and
+`local_files_mode` so that tools enforce identical path constraints inside
+the subprocess as they do in-process.
+
+### `worker_protocol.py` — `WorkerRequest` / `WorkerResponse`
+
+Plain JSON-serialisable dataclasses. Both support `.to_json()` /
+`.from_json()` for stdin/stdout transport.
+
+`WorkerRequest.safety_config` carries the path constraints forwarded by the
+runner so the worker can enforce them without needing the full `Settings`
+object.
+
+## Security Notes
+
+- The worker runs as the same OS user as the daemon. OS-level confinement
+  (e.g. Windows Job Objects / Linux namespaces) is left for future hardening.
+- Only built-in tools are permitted in the worker. MCP tools are never
+  dispatched to a subprocess through this path.
+- `cfg=None` is explicitly prevented: `safety_config` is always forwarded
+  so that path-validation constraints remain active in the subprocess.
+
+## Configuration Fields Used
+
+| Field                    | Type        | Default       | Effect                                      |
+|--------------------------|-------------|---------------|---------------------------------------------|
+| `use_subprocess_for_writes` | `bool`  | `False`       | Also isolate `WRITE_OPERATIONAL` tools      |
+| `workspace_roots`        | `list[str]` | `[]`          | Forwarded to worker as path constraint      |
+| `blocked_roots`          | `list[str]` | `[]`          | Forwarded to worker as path constraint      |
+| `read_only_roots`        | `list[str]` | `[]`          | Forwarded to worker as path constraint      |
+| `local_files_mode`       | `str`       | `"home_only"` | Forwarded to worker as path constraint      |

--- a/src/jarvis/execution/execution.spec.md
+++ b/src/jarvis/execution/execution.spec.md
@@ -21,8 +21,17 @@ ToolRunner (runner.py)
 
 ### `runner.py` — `ToolRunner`
 
-Central execution funnel. Every tool call from the reply engine passes through
-`ToolRunner.run()` after policy evaluation.
+Intended central execution funnel: every tool call from the reply engine
+passes through `ToolRunner.run()` after policy evaluation.
+
+> **⚠️ NOT YET INTEGRATED.** The reply engine currently executes tools via
+> `run_tool_with_retries` directly; nothing instantiates `ToolRunner` in
+> production, and `use_subprocess_for_writes` is inert. Before wiring it in,
+> the runner must (a) actually invoke its `policy_decision_fn` when no
+> decision is supplied instead of defaulting to unmediated in-process
+> execution, (b) pass a scrubbed `env=` to the worker subprocess, and
+> (c) frame the worker response (last-line sentinel or length prefix)
+> rather than parsing the whole stdout as JSON.
 
 **Mode selection:**
 | Tool class             | `use_subprocess_for_writes` | Mode         |

--- a/src/jarvis/execution/runner.py
+++ b/src/jarvis/execution/runner.py
@@ -1,0 +1,297 @@
+"""
+Tool runner — manages in-process and out-of-process tool execution.
+
+The runner is the single execution funnel that tools pass through after
+policy evaluation.  It decides, based on tool class and policy decision,
+whether to execute in-process or spawn an isolated worker process.
+
+Runner modes
+------------
+* ``IN_PROCESS``  — default for INFORMATIONAL, READ_ONLY_OPERATIONAL, and WRITE_OPERATIONAL tools.
+* ``SUBPROCESS``  — forced for DESTRUCTIVE tools and optionally for WRITE_OPERATIONAL when
+  the ``use_subprocess_for_writes`` flag is set in configuration.
+
+Execution contract
+------------------
+Every execution attempt must:
+1. Have a valid :class:`~jarvis.policy.models.PolicyDecision` (``allowed=True``).
+2. Produce an :class:`ExecutionResult` regardless of internal failures.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import time
+import uuid
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Dict, Optional
+
+from ..debug import debug_log
+from ..policy.models import PolicyDecision, ToolClass
+
+# Exceptions considered transient (safe to retry).
+_TRANSIENT_ERRORS = (
+    subprocess.TimeoutExpired,
+    ConnectionError,
+    OSError,
+    TimeoutError,
+)
+
+
+class RunnerMode(Enum):
+    """Execution isolation mode."""
+    IN_PROCESS = "in_process"
+    SUBPROCESS = "subprocess"
+
+
+@dataclass
+class ExecutionResult:
+    """Unified result from either in-process or subprocess execution."""
+    success: bool
+    reply_text: str = ""
+    error_message: Optional[str] = None
+    runner_mode: RunnerMode = RunnerMode.IN_PROCESS
+    duration_ms: float = 0.0
+    retry_count: int = 0
+    execution_id: str = field(default_factory=lambda: uuid.uuid4().hex)
+
+
+class ToolRunner:
+    """
+    Executes tools in-process or out-of-process based on policy.
+
+    Args:
+        cfg: Settings object.
+        policy_decision_fn: Optional callable ``(tool_name, args) → PolicyDecision``
+            that re-evaluates policy immediately before execution (defence-in-depth).
+    """
+
+    def __init__(self, cfg, policy_decision_fn=None) -> None:
+        self._cfg = cfg
+        self._policy_fn = policy_decision_fn
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def run(
+        self,
+        tool_name: str,
+        tool_args: Optional[Dict[str, Any]],
+        *,
+        context,
+        decision: Optional[PolicyDecision] = None,
+        max_retries: int = 2,
+    ) -> ExecutionResult:
+        """
+        Execute *tool_name* with *tool_args* under the runner's isolation policy.
+
+        Args:
+            tool_name: Canonical tool identifier.
+            tool_args: Arguments for the tool.
+            context: :class:`~jarvis.tools.base.ToolContext` for in-process execution.
+            decision: Pre-computed :class:`~jarvis.policy.models.PolicyDecision`.
+                      If ``None``, the runner will call the policy function if set.
+            max_retries: Number of retry attempts on transient failures.
+
+        Returns:
+            :class:`ExecutionResult` describing the outcome.
+        """
+        start = time.monotonic()
+        retries = 0
+
+        mode = self._choose_mode(tool_name, decision)
+
+        last_error: Optional[str] = None
+        for attempt in range(max_retries + 1):
+            retries = attempt
+            try:
+                if mode == RunnerMode.SUBPROCESS:
+                    result = self._run_subprocess(tool_name, tool_args or {})
+                else:
+                    result = self._run_in_process(tool_name, tool_args, context)
+                duration = (time.monotonic() - start) * 1000
+                result.runner_mode = mode
+                result.duration_ms = duration
+                result.retry_count = attempt
+                return result
+            except _TRANSIENT_ERRORS as exc:
+                last_error = str(exc)
+                debug_log(f"runner: transient failure on attempt {attempt + 1} for {tool_name}: {exc}", "runner")
+                if attempt < max_retries:
+                    time.sleep(0.5 * (attempt + 1))
+            except Exception as exc:
+                # Permanent errors (bad args, unknown tool, etc.) — fail immediately
+                debug_log(f"runner: permanent failure for {tool_name}: {exc}", "runner")
+                duration = (time.monotonic() - start) * 1000
+                return ExecutionResult(
+                    success=False,
+                    error_message=str(exc),
+                    runner_mode=mode,
+                    duration_ms=duration,
+                    retry_count=attempt,
+                )
+
+        duration = (time.monotonic() - start) * 1000
+        return ExecutionResult(
+            success=False,
+            error_message=last_error or "Unknown error",
+            runner_mode=mode,
+            duration_ms=duration,
+            retry_count=retries,
+        )
+
+    # ------------------------------------------------------------------
+    # Mode selection
+    # ------------------------------------------------------------------
+
+    def _choose_mode(
+        self, tool_name: str, decision: Optional[PolicyDecision]
+    ) -> RunnerMode:
+        """Determine execution mode for *tool_name*."""
+        use_subprocess_for_writes = getattr(
+            self._cfg, "use_subprocess_for_writes", False
+        )
+
+        if decision is not None:
+            if decision.tool_class == ToolClass.DESTRUCTIVE:
+                return RunnerMode.SUBPROCESS
+            if use_subprocess_for_writes and decision.tool_class == ToolClass.WRITE_OPERATIONAL:
+                return RunnerMode.SUBPROCESS
+
+        return RunnerMode.IN_PROCESS
+
+    # ------------------------------------------------------------------
+    # In-process execution
+    # ------------------------------------------------------------------
+
+    def _run_in_process(
+        self,
+        tool_name: str,
+        tool_args: Optional[Dict[str, Any]],
+        context,
+    ) -> ExecutionResult:
+        """Execute the tool within the current process."""
+        from ..tools.registry import BUILTIN_TOOLS, get_cached_mcp_tools, run_mcp_tool
+
+        if "__" in tool_name:
+            # MCP tool
+            mcp_tools = get_cached_mcp_tools()
+            if tool_name not in mcp_tools:
+                return ExecutionResult(
+                    success=False,
+                    error_message=f"MCP tool not found: {tool_name}",
+                )
+            try:
+                mcp_result = run_mcp_tool(tool_name, tool_args or {}, mcp_tools)
+                return ExecutionResult(
+                    success=mcp_result.success,
+                    reply_text=mcp_result.reply_text or "",
+                    error_message=mcp_result.error_message,
+                )
+            except Exception as exc:
+                return ExecutionResult(success=False, error_message=str(exc))
+
+        tool = BUILTIN_TOOLS.get(tool_name)
+        if tool is None:
+            return ExecutionResult(
+                success=False, error_message=f"Unknown built-in tool: {tool_name}"
+            )
+
+        raw = tool.run(tool_args, context)
+        return ExecutionResult(
+            success=raw.success,
+            reply_text=raw.reply_text or "",
+            error_message=raw.error_message,
+        )
+
+    # ------------------------------------------------------------------
+    # Subprocess execution
+    # ------------------------------------------------------------------
+
+    def _run_subprocess(
+        self,
+        tool_name: str,
+        tool_args: Dict[str, Any],
+        timeout_sec: float = 30.0,
+    ) -> ExecutionResult:
+        """Spawn an isolated worker process and execute the tool there."""
+        from .worker_protocol import WorkerRequest, WorkerResponse
+
+        # Forward path-safety constraints so the worker can enforce them
+        # without a full cfg object (see WorkerRequest.safety_config).
+        safety_config = {
+            "workspace_roots": list(getattr(self._cfg, "workspace_roots", None) or []),
+            "blocked_roots": list(getattr(self._cfg, "blocked_roots", None) or []),
+            "read_only_roots": list(getattr(self._cfg, "read_only_roots", None) or []),
+            "local_files_mode": str(getattr(self._cfg, "local_files_mode", "home_only")),
+        }
+        req = WorkerRequest(
+            tool_name=tool_name,
+            tool_args=tool_args,
+            request_id=uuid.uuid4().hex,
+            timeout_sec=timeout_sec,
+            safety_config=safety_config,
+        )
+
+        python_exe = sys.executable
+        worker_module = "jarvis.execution.subprocess_worker"
+
+        debug_log(f"runner: spawning subprocess for {tool_name}", "runner")
+
+        try:
+            proc = subprocess.Popen(
+                [python_exe, "-m", worker_module],
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            stdout, stderr = proc.communicate(
+                input=req.to_json() + "\n",
+                timeout=timeout_sec + 5,
+            )
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait(timeout=5)
+            return ExecutionResult(
+                success=False,
+                error_message=f"Subprocess worker timed out after {timeout_sec}s",
+            )
+        except Exception as exc:
+            # Ensure the process is cleaned up if it was started
+            try:
+                proc.kill()
+                proc.wait(timeout=5)
+            except Exception:
+                pass  # proc may not have been assigned or already exited
+            return ExecutionResult(
+                success=False,
+                error_message=f"Failed to spawn subprocess worker: {exc}",
+            )
+
+        if stderr:
+            debug_log(f"runner: worker stderr: {stderr[:200]}", "runner")
+
+        if not stdout.strip():
+            return ExecutionResult(
+                success=False,
+                error_message=f"Subprocess worker produced no output (exit={proc.returncode})",
+            )
+
+        try:
+            resp = WorkerResponse.from_json(stdout.strip())
+            return ExecutionResult(
+                success=resp.success,
+                reply_text=resp.reply_text,
+                error_message=resp.error_message,
+                runner_mode=RunnerMode.SUBPROCESS,
+            )
+        except Exception as exc:
+            return ExecutionResult(
+                success=False,
+                error_message=f"Failed to parse worker response: {exc}",
+            )

--- a/src/jarvis/execution/subprocess_worker.py
+++ b/src/jarvis/execution/subprocess_worker.py
@@ -1,0 +1,164 @@
+"""
+Subprocess worker entry point.
+
+This module is executed as a standalone subprocess by
+:class:`~jarvis.execution.runner.ToolRunner` when a tool is classified
+as HIGH-risk or DESTRUCTIVE and therefore requires process isolation.
+
+The worker:
+1. Reads a single JSON :class:`~jarvis.execution.worker_protocol.WorkerRequest`
+   from stdin.
+2. Imports and executes the requested built-in tool.
+3. Writes a JSON :class:`~jarvis.execution.worker_protocol.WorkerResponse`
+   to stdout.
+4. Exits.
+
+Security considerations
+-----------------------
+* The worker runs in the same user context as the parent process.
+* Future hardening (Windows ICACLS / setuid on Unix) is applied *outside*
+  this module — the launcher in :mod:`~jarvis.execution.runner` is
+  responsible for setting up the execution context before spawning.
+* Only built-in tools are permitted in the worker.  MCP tools are never
+  run out-of-process through this path.
+"""
+
+from __future__ import annotations
+
+import json
+import signal
+import sys
+import threading
+import types
+
+
+def _write_error(request_id: str, message: str) -> None:
+    """
+    Write a minimal error :class:`WorkerResponse` to stdout and flush.
+
+    Used when the worker cannot parse or handle a request at all and
+    needs to return an error without a full response object.
+    """
+    error_resp = {
+        "request_id": request_id,
+        "success": False,
+        "reply_text": "",
+        "error_message": message,
+        "exit_code": 1,
+    }
+    sys.stdout.write(json.dumps(error_resp) + "\n")
+    sys.stdout.flush()
+
+
+def _timeout_handler(signum, frame):
+    sys.stderr.write("worker: timeout — exiting\n")
+    sys.exit(2)
+
+
+def main() -> None:
+    """Read one WorkerRequest from stdin, execute, write WorkerResponse to stdout."""
+    # Attempt to set a signal-based timeout (not available on Windows)
+    try:
+        signal.signal(signal.SIGALRM, _timeout_handler)  # type: ignore[attr-defined]
+    except AttributeError:
+        pass  # Windows — we rely on the parent's forced kill instead
+
+    try:
+        raw = sys.stdin.readline()
+        if not raw.strip():
+            _write_error("", "empty request")
+            return
+
+        from jarvis.execution.worker_protocol import WorkerRequest, WorkerResponse
+
+        try:
+            req = WorkerRequest.from_json(raw)
+        except Exception as exc:
+            _write_error("", f"failed to parse request: {exc}")
+            return
+
+        # Set alarm timeout (Unix only)
+        try:
+            signal.alarm(max(1, int(req.timeout_sec)))  # type: ignore[attr-defined]
+        except AttributeError:
+            pass
+
+        # Execute the tool
+        try:
+            result = _run_builtin(req.tool_name, req.tool_args, req.safety_config)
+            resp = WorkerResponse(
+                request_id=req.request_id,
+                success=result.get("success", False),
+                reply_text=result.get("reply_text", ""),
+                error_message=result.get("error_message"),
+            )
+        except Exception as exc:
+            resp = WorkerResponse(
+                request_id=req.request_id,
+                success=False,
+                error_message=str(exc),
+            )
+
+        sys.stdout.write(resp.to_json() + "\n")
+        sys.stdout.flush()
+
+    except Exception as exc:
+        sys.stderr.write(f"worker: unhandled error: {exc}\n")
+        sys.exit(1)
+
+
+def _run_builtin(tool_name: str, tool_args: dict, safety_config: dict) -> dict:
+    """
+    Import and run the named built-in tool inside the worker subprocess.
+
+    Args:
+        tool_name: Canonical tool identifier.
+        tool_args: Arguments forwarded from the parent request.
+        safety_config: Path-safety constraints from the parent daemon config
+            (``workspace_roots``, ``blocked_roots``, ``read_only_roots``,
+            ``local_files_mode``).  Used to construct a minimal cfg object
+            so that tools enforce the same path constraints as in-process.
+    """
+    # Lazy imports keep subprocess startup fast.
+    # Only built-in tools are permitted here — MCP tools never run out-of-process.
+    from jarvis.tools.registry import BUILTIN_TOOLS
+    from jarvis.tools.base import ToolContext
+
+    tool = BUILTIN_TOOLS.get(tool_name)
+    if tool is None:
+        return {"success": False, "reply_text": "", "error_message": f"Unknown tool: {tool_name}"}
+
+    # Reconstruct a minimal cfg-like object from safety fields forwarded
+    # by the runner.  This ensures path-safety constraints (workspace_roots,
+    # blocked_roots, etc.) are enforced inside the worker even though the
+    # full Settings object is not available in the subprocess.
+    _safety = safety_config or {}
+    _cfg = types.SimpleNamespace(
+        workspace_roots=list(_safety.get("workspace_roots") or []),
+        blocked_roots=list(_safety.get("blocked_roots") or []),
+        read_only_roots=list(_safety.get("read_only_roots") or []),
+        local_files_mode=str(_safety.get("local_files_mode") or "home_only"),
+    )
+    ctx = ToolContext(
+        db=None,
+        cfg=_cfg,
+        system_prompt="",
+        original_prompt="",
+        redacted_text="",
+        max_retries=1,
+        user_print=lambda s: None,
+    )
+
+    try:
+        result = tool.run(tool_args, ctx)
+        return {
+            "success": result.success,
+            "reply_text": result.reply_text or "",
+            "error_message": result.error_message,
+        }
+    except Exception as exc:
+        return {"success": False, "reply_text": "", "error_message": str(exc)}
+
+
+if __name__ == "__main__":
+    main()

--- a/src/jarvis/execution/worker_protocol.py
+++ b/src/jarvis/execution/worker_protocol.py
@@ -1,0 +1,90 @@
+"""
+Worker protocol — JSON-serialisable request/response types for
+subprocess tool execution.
+
+Both classes are simple dataclasses that serialise to/from dicts so
+they can be sent over a subprocess stdin/stdout pipe without any
+special IPC dependencies.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+from typing import Any, Dict, Optional
+
+
+@dataclass
+class WorkerRequest:
+    """Command sent from the main process to the worker subprocess."""
+
+    tool_name: str
+    """Canonical tool name."""
+
+    tool_args: Dict[str, Any] = field(default_factory=dict)
+    """Arguments to pass to the tool."""
+
+    request_id: str = ""
+    """Correlation ID echoed back in the response."""
+
+    timeout_sec: float = 30.0
+    """Maximum execution time after which the worker should self-terminate."""
+
+    safety_config: Dict[str, Any] = field(default_factory=dict)
+    """
+    Path safety constraints forwarded from the parent daemon's config.
+
+    Expected keys (all optional):
+      ``workspace_roots``  – list[str] of allowed root paths
+      ``blocked_roots``    – list[str] of blocked path prefixes
+      ``read_only_roots``  – list[str] of read-only path prefixes
+      ``local_files_mode`` – str policy mode for file operations
+
+    Passing these through ensures the worker enforces the same path
+    constraints as the parent process even without a full cfg object.
+    """
+
+    def to_json(self) -> str:
+        return json.dumps(asdict(self))
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "WorkerRequest":
+        return cls(
+            tool_name=d.get("tool_name", ""),
+            tool_args=d.get("tool_args", {}),
+            request_id=d.get("request_id", ""),
+            timeout_sec=float(d.get("timeout_sec", 30.0)),
+            safety_config=d.get("safety_config", {}),
+        )
+
+    @classmethod
+    def from_json(cls, s: str) -> "WorkerRequest":
+        return cls.from_dict(json.loads(s))
+
+
+@dataclass
+class WorkerResponse:
+    """Response sent from the worker subprocess to the main process."""
+
+    request_id: str
+    success: bool
+    reply_text: str = ""
+    error_message: Optional[str] = None
+    exit_code: int = 0
+
+    def to_json(self) -> str:
+        return json.dumps(asdict(self))
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "WorkerResponse":
+        return cls(
+            request_id=d.get("request_id", ""),
+            success=bool(d.get("success", False)),
+            reply_text=d.get("reply_text", ""),
+            error_message=d.get("error_message"),
+            exit_code=int(d.get("exit_code", 0)),
+        )
+
+    @classmethod
+    def from_json(cls, s: str) -> "WorkerResponse":
+        return cls.from_dict(json.loads(s))

--- a/src/jarvis/policy/__init__.py
+++ b/src/jarvis/policy/__init__.py
@@ -1,0 +1,41 @@
+"""
+Jarvis Policy Engine
+====================
+Provides a formal policy layer between planning and tool execution.
+
+Every tool execution attempt must be evaluated by the policy engine
+before it is permitted. The engine produces a :class:`PolicyDecision`
+that describes whether the action is allowed, why, and which constraints
+apply.
+
+Public API::
+
+    from jarvis.policy import evaluate, PolicyDecision, PolicyDeniedError
+"""
+
+from .engine import evaluate, PolicyEngine
+from .models import (
+    PolicyDecision,
+    PolicyMode,
+    ToolClass,
+    NetworkClass,
+    AccessMode,
+    RiskLevel,
+)
+from .path_guard import resolve_and_validate_path, PathGuard
+from .approvals import ApprovalStore, ScopedGrant
+
+__all__ = [
+    "evaluate",
+    "PolicyEngine",
+    "PolicyDecision",
+    "PolicyMode",
+    "ToolClass",
+    "NetworkClass",
+    "AccessMode",
+    "RiskLevel",
+    "resolve_and_validate_path",
+    "PathGuard",
+    "ApprovalStore",
+    "ScopedGrant",
+]

--- a/src/jarvis/policy/approvals.py
+++ b/src/jarvis/policy/approvals.py
@@ -1,0 +1,268 @@
+"""
+Durable approval grants.
+
+When the policy engine decides that ``approval_required=True``, the caller
+obtains consent from the user.  That consent is stored as a
+:class:`ScopedGrant` so that repeated requests for the same scope do not
+prompt the user again during the session (or across sessions if persisted
+to SQLite).
+
+Grant scopes
+------------
+A grant covers a ``(tool_name, operation, path_prefix)`` triple where any
+component may be ``"*"`` (wildcard).  Scopes are intentionally coarse so
+that operators understand what they approved.
+
+Storage
+-------
+The :class:`ApprovalStore` can operate in two modes:
+
+* ``memory`` – grants are kept only for the lifetime of the process.
+* ``sqlite`` – grants are written to the audit database and survive restarts.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Tuple
+
+from ..debug import debug_log
+
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+@dataclass
+class ScopedGrant:
+    """A single approval grant covering a specific (tool, operation, path) scope."""
+
+    tool_name: str
+    """e.g. ``"localFiles"`` or ``"*"`` for all tools."""
+
+    operation: str
+    """e.g. ``"write"`` or ``"*"`` for all operations."""
+
+    path_prefix: str = "*"
+    """Canonical path prefix (absolute) or ``"*"`` for all paths."""
+
+    granted_at: float = field(default_factory=time.time)
+    """UNIX timestamp when the grant was given."""
+
+    expires_at: Optional[float] = None
+    """Optional UNIX timestamp after which the grant is no longer valid."""
+
+    granted_by: str = "user"
+    """Identity of the approver — always ``"user"`` in the current model."""
+
+    def is_valid(self) -> bool:
+        """Return True when this grant has not expired."""
+        if self.expires_at is not None and time.time() > self.expires_at:
+            return False
+        return True
+
+    def matches(self, tool_name: str, operation: str, path: str = "") -> bool:
+        """
+        Return True when this grant covers the requested (tool, operation, path).
+
+        Wildcard ``"*"`` matches any value.
+        """
+        if not self.is_valid():
+            return False
+
+        tool_ok = self.tool_name == "*" or self.tool_name == tool_name
+        op_ok = self.operation == "*" or self.operation == operation
+        if not self.path_prefix or self.path_prefix == "*":
+            path_ok = True
+        else:
+            try:
+                from pathlib import Path as _Path
+                _Path(path).relative_to(self.path_prefix)
+                path_ok = True
+            except ValueError:
+                path_ok = False
+
+        return tool_ok and op_ok and path_ok
+
+
+# ---------------------------------------------------------------------------
+# Store
+# ---------------------------------------------------------------------------
+
+class ApprovalStore:
+    """
+    Thread-safe store for :class:`ScopedGrant` objects.
+
+    Pass ``db_path`` to enable SQLite persistence.  When omitted the store
+    operates in in-memory mode and grants are lost on process exit.
+
+    ``default_ttl_sec`` sets an expiry time applied to every new grant
+    whose ``expires_at`` is not explicitly provided.  This prevents grants
+    from accumulating across restarts when SQLite persistence is enabled.
+    Defaults to 3 600 s (one hour).  Pass ``None`` to allow grants with
+    no expiry (not recommended for persisted stores).
+    """
+
+    _CREATE_TABLE = """
+    CREATE TABLE IF NOT EXISTS approval_grants (
+        id            INTEGER PRIMARY KEY,
+        tool_name     TEXT NOT NULL,
+        operation     TEXT NOT NULL,
+        path_prefix   TEXT NOT NULL DEFAULT '*',
+        granted_at    REAL NOT NULL,
+        expires_at    REAL,
+        granted_by    TEXT NOT NULL DEFAULT 'user'
+    );
+    """
+
+    def __init__(self, db_path: Optional[str] = None, default_ttl_sec: Optional[float] = 3600.0) -> None:
+        self._lock = threading.Lock()
+        self._memory: List[ScopedGrant] = []
+        self._db_path = db_path
+        self._db_conn: Optional[sqlite3.Connection] = None
+        self._default_ttl_sec = default_ttl_sec
+
+        if db_path:
+            try:
+                self._db_conn = sqlite3.connect(db_path, check_same_thread=False)
+                self._db_conn.execute(self._CREATE_TABLE)
+                self._db_conn.commit()
+                self._load_from_db()
+                debug_log(f"ApprovalStore: loaded {len(self._memory)} grants from {db_path}", "policy")
+            except Exception as exc:
+                debug_log(f"ApprovalStore: SQLite init failed, falling back to memory: {exc}", "policy")
+                self._db_conn = None
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def grant(
+        self,
+        tool_name: str,
+        operation: str,
+        path_prefix: str = "*",
+        expires_at: Optional[float] = None,
+        granted_by: str = "user",
+    ) -> ScopedGrant:
+        """
+        Record a new approval grant.
+
+        When ``expires_at`` is ``None`` and the store was initialised with a
+        ``default_ttl_sec``, the grant will expire after that many seconds.
+        This ensures grants do not persist indefinitely across sessions when
+        using SQLite-backed storage.
+
+        Returns the created :class:`ScopedGrant`.
+        """
+        if expires_at is None and self._default_ttl_sec is not None:
+            expires_at = time.time() + self._default_ttl_sec
+        g = ScopedGrant(
+            tool_name=tool_name,
+            operation=operation,
+            path_prefix=path_prefix,
+            granted_at=time.time(),
+            expires_at=expires_at,
+            granted_by=granted_by,
+        )
+        with self._lock:
+            self._memory.append(g)
+            if self._db_conn:
+                try:
+                    self._db_conn.execute(
+                        "INSERT INTO approval_grants "
+                        "(tool_name, operation, path_prefix, granted_at, expires_at, granted_by) "
+                        "VALUES (?, ?, ?, ?, ?, ?)",
+                        (g.tool_name, g.operation, g.path_prefix,
+                         g.granted_at, g.expires_at, g.granted_by),
+                    )
+                    self._db_conn.commit()
+                except Exception as exc:
+                    debug_log(f"ApprovalStore: failed to persist grant: {exc}", "policy")
+        debug_log(
+            f"ApprovalStore: grant recorded — tool={tool_name} op={operation} path={path_prefix}",
+            "policy",
+        )
+        return g
+
+    def is_granted(self, tool_name: str, operation: str, path: str = "") -> bool:
+        """
+        Return True when a valid un-expired grant covers this request.
+        """
+        with self._lock:
+            return any(g.matches(tool_name, operation, path) for g in self._memory)
+
+    def revoke_all(self) -> int:
+        """Remove all grants.  Returns the number of grants removed."""
+        with self._lock:
+            count = len(self._memory)
+            self._memory.clear()
+            if self._db_conn:
+                try:
+                    self._db_conn.execute("DELETE FROM approval_grants")
+                    self._db_conn.commit()
+                except Exception:
+                    pass
+        debug_log(f"ApprovalStore: revoked {count} grants", "policy")
+        return count
+
+    def list_grants(self) -> List[ScopedGrant]:
+        """Return a snapshot of all current (including expired) grants."""
+        with self._lock:
+            return list(self._memory)
+
+    def prune_expired(self) -> int:
+        """Remove expired grants from memory and the database."""
+        now = time.time()
+        with self._lock:
+            before = len(self._memory)
+            self._memory = [g for g in self._memory if g.is_valid()]
+            pruned = before - len(self._memory)
+            if pruned and self._db_conn:
+                try:
+                    self._db_conn.execute(
+                        "DELETE FROM approval_grants WHERE expires_at IS NOT NULL AND expires_at < ?",
+                        (now,),
+                    )
+                    self._db_conn.commit()
+                except Exception:
+                    pass
+        if pruned:
+            debug_log(f"ApprovalStore: pruned {pruned} expired grants", "policy")
+        return pruned
+
+    def close(self) -> None:
+        """Close the SQLite connection if open."""
+        if self._db_conn:
+            try:
+                self._db_conn.close()
+            except Exception:
+                pass
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _load_from_db(self) -> None:
+        """Load persisted grants from the database into memory."""
+        if not self._db_conn:
+            return
+        try:
+            rows = self._db_conn.execute(
+                "SELECT tool_name, operation, path_prefix, granted_at, expires_at, granted_by "
+                "FROM approval_grants"
+            ).fetchall()
+            for row in rows:
+                self._memory.append(ScopedGrant(
+                    tool_name=row[0],
+                    operation=row[1],
+                    path_prefix=row[2],
+                    granted_at=row[3],
+                    expires_at=row[4],
+                    granted_by=row[5],
+                ))
+        except Exception as exc:
+            debug_log(f"ApprovalStore: failed to load grants: {exc}", "policy")

--- a/src/jarvis/policy/engine.py
+++ b/src/jarvis/policy/engine.py
@@ -1,0 +1,375 @@
+"""
+Policy engine — central evaluation point for all tool invocations.
+
+Every tool call must pass through :func:`evaluate` before it is permitted.
+The function produces a :class:`PolicyDecision` that callers are expected to
+check (or call :meth:`PolicyDecision.assert_allowed`) before executing.
+
+Policy evaluation order
+-----------------------
+1. ``PolicyMode.DENY``  →  deny immediately (kill-switch).
+2. Classify the tool into a :class:`ToolClass`.
+3. Assess risk with :mod:`jarvis.approval`.
+4. For file-system operations: run :mod:`.path_guard`.
+5. MCP tools: check declared capability metadata.
+6. Emit final :class:`PolicyDecision` (risk handling delegated to act-then-undo model).
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any, Dict, List, Optional
+
+from ..debug import debug_log
+from .models import (
+    AccessMode,
+    AppliedConstraint,
+    NetworkClass,
+    PolicyDecision,
+    PolicyDeniedError,
+    PolicyMode,
+    RiskLevel,
+    ToolClass,
+)
+from .approvals import ApprovalStore
+from .path_guard import PathGuard
+
+
+# ---------------------------------------------------------------------------
+# Tool class registry
+# ---------------------------------------------------------------------------
+
+def _classify_tool(tool_name: str, tool_args: Optional[Dict[str, Any]]) -> ToolClass:
+    """Determine the :class:`ToolClass` for a given invocation.
+
+    Delegates to the tool's own ``classify()`` method so that classification
+    stays co-located with the tool definition.  MCP tools default to
+    ``EXTERNAL_DELEGATED``.
+    """
+    if "__" in tool_name:
+        # MCP tool — classified as external delegated by default
+        return ToolClass.EXTERNAL_DELEGATED
+
+    from ..tools.registry import BUILTIN_TOOLS
+    tool = BUILTIN_TOOLS.get(tool_name)
+    if tool is not None:
+        return tool.classify(tool_args)
+
+    return ToolClass.EXTERNAL_DELEGATED
+
+
+def _legacy_to_policy_risk(risk) -> RiskLevel:
+    """Passthrough — both modules now share the same :class:`RiskLevel` enum."""
+    return risk
+
+
+def _approval_required_for_mode(
+    mode: PolicyMode, tool_class: ToolClass, risk: RiskLevel
+) -> bool:
+    """Always returns False — Jarvis uses act-then-undo, not blocking approval gates.
+
+    Retained as a function to minimise churn in the evaluate() call site.
+    """
+    return False
+
+
+# ---------------------------------------------------------------------------
+# PolicyEngine class
+# ---------------------------------------------------------------------------
+
+class PolicyEngine:
+    """
+    Stateful policy evaluator.
+
+    Instantiate once at daemon startup and inject into the reply engine and
+    any tool that needs path validation.
+
+    Args:
+        cfg: ``Settings`` object (or any object with the relevant attributes).
+        approval_store: Shared :class:`ApprovalStore` instance.
+    """
+
+    def __init__(self, cfg, approval_store: Optional[ApprovalStore] = None) -> None:
+        self._cfg = cfg
+        self._approval_store: ApprovalStore = approval_store or ApprovalStore()
+        self._path_guard = PathGuard(cfg)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def evaluate(
+        self,
+        tool_name: str,
+        tool_args: Optional[Dict[str, Any]] = None,
+        *,
+        audit_id: Optional[str] = None,
+    ) -> PolicyDecision:
+        """
+        Evaluate whether *tool_name* with *tool_args* may be executed.
+
+        Args:
+            tool_name: Canonical tool identifier (camelCase or ``server__tool``).
+            tool_args: Arguments that will be passed to the tool.
+            audit_id: Optional pre-assigned audit identifier.
+
+        Returns:
+            :class:`PolicyDecision` — caller must check ``allowed`` before proceeding.
+        """
+        aid = audit_id or uuid.uuid4().hex
+        constraints: List[AppliedConstraint] = []
+        mode = self._get_mode()
+
+        # 1. Classify tool
+        tool_class = _classify_tool(tool_name, tool_args)
+
+        # 2. Assess risk (reuse existing logic for consistency)
+        # Lazy import to avoid circular dependency:
+        # approval -> tools.registry -> tools.builtin -> policy -> approval
+        from ..approval import assess_risk as _assess_risk
+        raw_risk = _assess_risk(tool_name, tool_args)
+        risk = _legacy_to_policy_risk(raw_risk)
+
+        debug_log(
+            f"policy.evaluate: tool={tool_name} class={tool_class.value} risk={risk.value} mode={mode.value}",
+            "policy",
+        )
+
+        # 3. Deny mode (kill-switch)
+        if mode == PolicyMode.DENY:
+            return PolicyDecision(
+                allowed=False,
+                decision_reason="Policy mode is DENY — no tool execution permitted.",
+                risk_level=risk,
+                tool_class=tool_class,
+                applied_constraints=[AppliedConstraint("deny", "PolicyMode.DENY is active")],
+                audit_id=aid,
+                denied_reason="Policy mode DENY blocks all tools.",
+            )
+
+        # 4. ACTIVE mode — continue to path guard, MCP checks, etc.
+
+        # 5. Path guard for file-system tools
+        if tool_name == "localFiles" and tool_args:
+            path_str = str(tool_args.get("path", ""))
+            op = str(tool_args.get("operation", "")).lower()
+            access_mode = {
+                "read":   AccessMode.READ,
+                "list":   AccessMode.LIST,
+                "write":  AccessMode.WRITE,
+                "append": AccessMode.WRITE,
+                "delete": AccessMode.DELETE,
+            }.get(op, AccessMode.READ)
+
+            try:
+                resolved = self._path_guard.validate(path_str, access_mode)
+                constraints.append(
+                    AppliedConstraint(
+                        "path_guard",
+                        f"Path resolved and validated: {resolved}",
+                    )
+                )
+            except PolicyDeniedError as exc:
+                return PolicyDecision(
+                    allowed=False,
+                    decision_reason=str(exc),
+                    risk_level=risk,
+
+                    tool_class=tool_class,
+                    applied_constraints=constraints,
+                    audit_id=aid,
+                    denied_reason=str(exc),
+                )
+
+        # 6. MCP capability check
+        if tool_class == ToolClass.EXTERNAL_DELEGATED:
+            mcp_decision = self._evaluate_mcp_capability(tool_name, tool_args, risk)
+            if mcp_decision is not None:
+                # Merge MCP constraints into the running list, then rebuild
+                # the decision with the combined set.
+                constraints.extend(mcp_decision.applied_constraints)
+                mcp_decision = PolicyDecision(
+                    allowed=mcp_decision.allowed,
+                    decision_reason=mcp_decision.decision_reason,
+                    risk_level=risk,
+                    tool_class=tool_class,
+                    applied_constraints=constraints,
+                    audit_id=aid,
+                    denied_reason=mcp_decision.denied_reason,
+                )
+                if not mcp_decision.allowed:
+                    return mcp_decision
+
+        # 7. Permitted — risk handling delegated to the act-then-undo model
+        reason = (
+            f"Tool '{tool_name}' ({tool_class.value}) evaluated as risk={risk.value}. Permitted."
+        )
+
+        return PolicyDecision(
+            allowed=True,
+            decision_reason=reason,
+            risk_level=risk,
+            tool_class=tool_class,
+            applied_constraints=constraints,
+            audit_id=aid,
+        )
+
+    @property
+    def approval_store(self) -> ApprovalStore:
+        """Shared approval store for recording user grants."""
+        return self._approval_store
+
+    @property
+    def path_guard(self) -> PathGuard:
+        """Path guard instance (can be injected into tools directly)."""
+        return self._path_guard
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _get_mode(self) -> PolicyMode:
+        """Read the active PolicyMode from configuration."""
+        raw = getattr(self._cfg, "policy_mode", "active")
+        normalised = str(raw).lower()
+        # Accept legacy names for backwards compatibility
+        if normalised in ("deny_all", "deny"):
+            return PolicyMode.DENY
+        # Everything else (including legacy ask_destructive / always_allow)
+        # maps to ACTIVE — the act-then-undo model handles risk decisions.
+        return PolicyMode.ACTIVE
+
+    def _evaluate_mcp_capability(
+        self,
+        tool_name: str,
+        tool_args: Optional[Dict[str, Any]],
+        risk: RiskLevel,
+    ) -> Optional[PolicyDecision]:
+        """
+        Check declared MCP capabilities for an external-delegated tool.
+
+        Returns a preliminary :class:`PolicyDecision` if a restriction applies,
+        or ``None`` to continue normal evaluation.
+        """
+        mcps_config: dict = getattr(self._cfg, "mcps", {}) or {}
+        if not mcps_config:
+            return None
+
+        # Derive server name from tool_name (format: server__toolname)
+        server_name = tool_name.split("__")[0] if "__" in tool_name else None
+        if server_name is None:
+            return None
+
+        server_cfg = mcps_config.get(server_name, {})
+        capabilities: dict = server_cfg.get("capabilities", {})
+
+        constraints: List[AppliedConstraint] = []
+
+        if not capabilities:
+            # Default to restricted when no capabilities declared
+            constraints.append(
+                AppliedConstraint(
+                    "mcp_no_capabilities",
+                    f"MCP server '{server_name}' has no capability declaration — defaulting to restricted.",
+                )
+            )
+            # Write/destructive operations are denied without explicit capability
+            if risk in (RiskLevel.MODERATE, RiskLevel.HIGH):
+                return PolicyDecision(
+                    allowed=False,
+                    decision_reason=(
+                        f"MCP server '{server_name}' lacks capability metadata. "
+                        "Write/destructive operations are denied by default."
+                    ),
+                    risk_level=risk,
+
+                    tool_class=ToolClass.EXTERNAL_DELEGATED,
+                    applied_constraints=constraints,
+                    audit_id=uuid.uuid4().hex,
+                    denied_reason=(
+                        f"MCP server '{server_name}' requires explicit 'capabilities' declaration "
+                        "in config to perform write or destructive operations."
+                    ),
+                )
+            return None  # Safe reads are allowed from undeclared servers
+
+        cap_mode = capabilities.get("mode", "restricted")
+        if cap_mode == "read_only" and tool_args:
+            # Infer intent from args if available
+            op = str(tool_args.get("operation", "")).lower()
+            if op in ("write", "append", "delete", "create", "update", "post", "put", "patch"):
+                return PolicyDecision(
+                    allowed=False,
+                    decision_reason=(
+                        f"MCP server '{server_name}' is declared read_only but "
+                        f"operation '{op}' implies a write."
+                    ),
+                    risk_level=risk,
+
+                    tool_class=ToolClass.EXTERNAL_DELEGATED,
+                    applied_constraints=constraints,
+                    audit_id=uuid.uuid4().hex,
+                    denied_reason=f"MCP capability mode 'read_only' blocks operation '{op}'.",
+                )
+
+        constraints.append(
+            AppliedConstraint(
+                "mcp_capabilities",
+                f"MCP server '{server_name}' capability mode='{cap_mode}'.",
+            )
+        )
+        return None  # Permit; caller adds constraints
+
+
+# ---------------------------------------------------------------------------
+# Module-level convenience function
+# ---------------------------------------------------------------------------
+
+_default_engine: Optional[PolicyEngine] = None
+
+
+def configure(cfg, approval_store: Optional[ApprovalStore] = None) -> PolicyEngine:
+    """
+    Initialise the module-level :class:`PolicyEngine`.
+
+    Call once from the daemon or service container at startup.  After this,
+    :func:`evaluate` can be used without passing an engine explicitly.
+    """
+    global _default_engine
+    _default_engine = PolicyEngine(cfg, approval_store)
+    debug_log("policy engine configured", "policy")
+    return _default_engine
+
+
+def evaluate(
+    tool_name: str,
+    tool_args: Optional[Dict[str, Any]] = None,
+    *,
+    audit_id: Optional[str] = None,
+) -> PolicyDecision:
+    """
+    Evaluate a tool invocation against the module-level policy engine.
+
+    Requires :func:`configure` to have been called first.  Falls back to a
+    permissive decision if no engine has been configured (to avoid breaking
+    existing code paths).
+    """
+    if _default_engine is None:
+        # No engine configured — fall through with a passive allow
+        debug_log(
+            "policy.evaluate called before configure() — assuming permissive",
+            "policy",
+        )
+        return PolicyDecision(
+            allowed=True,
+            decision_reason="Policy engine not configured — permissive default.",
+            risk_level=RiskLevel.SAFE,
+            tool_class=_classify_tool(tool_name, tool_args),
+            audit_id=audit_id or uuid.uuid4().hex,
+        )
+    return _default_engine.evaluate(tool_name, tool_args, audit_id=audit_id)
+
+
+def get_engine() -> Optional[PolicyEngine]:
+    """Return the module-level engine, or ``None`` if not yet configured."""
+    return _default_engine

--- a/src/jarvis/policy/models.py
+++ b/src/jarvis/policy/models.py
@@ -1,0 +1,151 @@
+"""
+Policy data models.
+
+All value types are immutable dataclasses or enums so the policy layer can
+be tested and reasoned about without side-effects.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import List, Optional
+
+
+# ---------------------------------------------------------------------------
+# Enumerations
+# ---------------------------------------------------------------------------
+
+class PolicyMode(Enum):
+    """Operator-controlled policy enforcement level.
+
+    Jarvis is a voice-first, hands-free assistant.  Blocking execution
+    to wait for approval is not viable — the user cannot easily tap a
+    button or type a confirmation while speaking.  Instead Jarvis uses
+    an **act-then-undo** model: risky-but-reversible actions execute
+    immediately and the user is told to "say undo" if needed;
+    irreversible actions get a brief spoken warning before proceeding.
+
+    The only hard gate is ``DENY`` which blocks all tool execution
+    (useful as a kill-switch or when running in read-only / demo mode).
+    """
+    ACTIVE = "active"
+    """Normal operation — act-then-undo for reversible actions, spoken
+    warning for irreversible ones, path guard still enforced."""
+    DENY = "deny"
+    """Block all tool execution (kill-switch / read-only mode)."""
+
+
+class ToolClass(Enum):
+    """Broad capability class of a tool — used to determine approval requirements."""
+    INFORMATIONAL = "informational"
+    """Read-only, no side-effects (screenshot, weather, recall)."""
+    READ_ONLY_OPERATIONAL = "read_only_operational"
+    """Reads from external systems but produces no mutations (web search, fetch page)."""
+    WRITE_OPERATIONAL = "write_operational"
+    """Creates or updates data (logMeal, localFiles write/append)."""
+    DESTRUCTIVE = "destructive"
+    """Permanently removes data (deleteMeal, localFiles delete)."""
+    EXTERNAL_DELEGATED = "external_delegated"
+    """Delegates to an external MCP server — trust depends on declared capabilities."""
+
+
+class NetworkClass(Enum):
+    """Network reach of a tool invocation."""
+    NONE = "none"
+    """No network access required."""
+    LOOPBACK = "loopback"
+    """127.0.0.1 / ::1 only (Ollama, local MCP servers)."""
+    LAN = "lan"
+    """RFC-1918 / CGNAT addresses."""
+    PUBLIC = "public"
+    """General public Internet."""
+    MCP_ENDPOINT = "mcp_endpoint"
+    """Outbound to a declared MCP server endpoint."""
+
+
+class AccessMode(Enum):
+    """Read / write intent for path-scoped operations."""
+    READ = "read"
+    WRITE = "write"
+    DELETE = "delete"
+    LIST = "list"
+
+
+# Canonical RiskLevel lives in tools.types; re-export here so
+# policy-layer callers can import from either location.
+from ..tools.types import RiskLevel  # noqa: F401
+
+
+# ---------------------------------------------------------------------------
+# Decision output
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class AppliedConstraint:
+    """A single constraint that was enforced as part of a policy decision."""
+    name: str
+    description: str
+
+
+@dataclass(frozen=True)
+class PolicyDecision:
+    """
+    The result of evaluating a tool invocation against the active policy.
+
+    Produced by :func:`jarvis.policy.engine.evaluate` for every tool call
+    before execution.
+    """
+    allowed: bool
+    """True when the action may proceed."""
+
+    decision_reason: str
+    """Human-readable explanation of the decision."""
+
+    risk_level: RiskLevel
+    """Assessed risk of the action."""
+
+    tool_class: ToolClass
+    """Capability class of the tool being invoked."""
+
+    approval_required: bool = False
+    """Deprecated — always False.  Jarvis uses an act-then-undo model
+    instead of blocking approval gates.  Retained for audit schema compat."""
+
+    applied_constraints: List[AppliedConstraint] = field(default_factory=list)
+    """Zero or more constraints that were evaluated."""
+
+    audit_id: str = field(default_factory=lambda: uuid.uuid4().hex)
+    """Unique identifier for this decision (used by the audit recorder)."""
+
+    denied_reason: Optional[str] = None
+    """Populated when ``allowed`` is False — explains why it was denied."""
+
+    # ------------------------------------------------------------------
+    # Convenience helpers
+    # ------------------------------------------------------------------
+
+    def assert_allowed(self) -> None:
+        """Raise :exc:`PolicyDeniedError` if the decision denies execution."""
+        if not self.allowed:
+            raise PolicyDeniedError(
+                self.denied_reason or self.decision_reason,
+                decision=self,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+class PolicyDeniedError(PermissionError):
+    """Raised when a policy decision blocks tool execution."""
+
+    def __init__(self, message: str, decision: Optional[PolicyDecision] = None) -> None:
+        super().__init__(message)
+        self.decision = decision
+
+
+class PolicyError(RuntimeError):
+    """Raised when the policy engine itself encounters an internal error."""

--- a/src/jarvis/policy/path_guard.py
+++ b/src/jarvis/policy/path_guard.py
@@ -1,0 +1,215 @@
+"""
+Workspace path guard.
+
+Every file-system operation that Jarvis performs passes through
+:func:`resolve_and_validate_path` before execution.  The function:
+
+1. Expands ``~`` / ``%USERPROFILE%`` references.
+2. Resolves symlinks to a canonical absolute path.
+3. Checks the result against configured *blocked roots* (always denied).
+4. Checks the result against configured *workspace roots*
+   (required when ``local_files_mode`` is ``"workspace_only"``).
+5. Enforces read-only roots for write/delete operations.
+
+Configuration keys consumed (from ``Settings``):
+
+* ``workspace_roots`` – list[str] – allowed directory trees.
+* ``blocked_roots``   – list[str] – always-denied directory trees.
+* ``read_only_roots`` – list[str] – directories that may be read but not written.
+* ``local_files_mode`` – ``"workspace_only"`` | ``"home_only"`` | ``"unrestricted"``
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import List, Optional, Sequence
+
+from .models import AccessMode, PolicyDeniedError
+
+
+# ---------------------------------------------------------------------------
+# Module-level defaults (overridden by PathGuard instance in production)
+# ---------------------------------------------------------------------------
+
+_DEFAULT_BLOCKED = [
+    # Windows system directories
+    "C:\\Windows",
+    "C:\\Program Files",
+    "C:\\Program Files (x86)",
+    # Unix-style system directories
+    "/bin",
+    "/boot",
+    "/dev",
+    "/etc",
+    "/lib",
+    "/lib64",
+    "/proc",
+    "/sbin",
+    "/sys",
+    "/usr",
+]
+
+
+def resolve_and_validate_path(
+    path: str,
+    access_mode: AccessMode,
+    *,
+    workspace_roots: Optional[Sequence[str]] = None,
+    blocked_roots: Optional[Sequence[str]] = None,
+    read_only_roots: Optional[Sequence[str]] = None,
+    local_files_mode: str = "home_only",
+) -> Path:
+    """
+    Resolve *path* to a canonical absolute path and validate it against policy.
+
+    Args:
+        path: Raw path string as supplied by the LLM or user.
+        access_mode: Intended operation (READ, WRITE, DELETE, LIST).
+        workspace_roots: Directories the caller is allowed to operate in.
+        blocked_roots: Directories that are always denied regardless of other rules.
+        read_only_roots: Directories that may be read but not modified.
+        local_files_mode: ``"workspace_only"`` constrains access to *workspace_roots*;
+            ``"home_only"`` (default) allows any path under the user home directory;
+            ``"unrestricted"`` skips workspace checks (not recommended).
+
+    Returns:
+        Canonical :class:`~pathlib.Path` if the access is permitted.
+
+    Raises:
+        PolicyDeniedError: If the resolved path falls outside permitted roots or
+            is a write/delete against a read-only root.
+    """
+    # 1. Expand user home shorthand
+    expanded = os.path.expanduser(os.path.expandvars(str(path)))
+
+    # 2. Resolve to canonical absolute path (follows symlinks)
+    try:
+        resolved = Path(expanded).resolve()
+    except (OSError, ValueError) as exc:
+        raise PolicyDeniedError(f"Cannot resolve path '{path}': {exc}") from exc
+
+    # 3. Blocked roots — always deny regardless of other rules
+    effective_blocked: List[Path] = []
+    for br in (blocked_roots or _DEFAULT_BLOCKED):
+        try:
+            effective_blocked.append(Path(os.path.expandvars(br)).resolve())
+        except (OSError, ValueError):
+            effective_blocked.append(Path(br))
+
+    for blocked in effective_blocked:
+        if _is_subpath(resolved, blocked):
+            raise PolicyDeniedError(
+                f"Access to '{resolved}' is denied — blocked root: {blocked}"
+            )
+
+    # 4. Workspace / home confinement
+    if local_files_mode == "workspace_only":
+        effective_roots: List[Path] = []
+        for wr in (workspace_roots or []):
+            try:
+                effective_roots.append(Path(os.path.expandvars(wr)).expanduser().resolve())
+            except (OSError, ValueError):
+                effective_roots.append(Path(wr))
+
+        if not effective_roots:
+            raise PolicyDeniedError(
+                "local_files_mode is 'workspace_only' but no workspace_roots are configured."
+            )
+
+        if not any(_is_subpath(resolved, root) for root in effective_roots):
+            roots_display = ", ".join(str(r) for r in effective_roots)
+            raise PolicyDeniedError(
+                f"Path '{resolved}' is outside configured workspace roots: [{roots_display}]"
+            )
+
+    elif local_files_mode == "home_only":
+        home = Path.home().resolve()
+        if not _is_subpath(resolved, home):
+            raise PolicyDeniedError(
+                f"Path '{resolved}' is outside the user home directory ({home})."
+            )
+
+    # local_files_mode == "unrestricted": skip containment checks
+
+    # 5. Read-only roots — deny write / delete operations
+    if access_mode in (AccessMode.WRITE, AccessMode.DELETE):
+        effective_ro: List[Path] = []
+        for ro in (read_only_roots or []):
+            try:
+                effective_ro.append(Path(os.path.expandvars(ro)).expanduser().resolve())
+            except (OSError, ValueError):
+                effective_ro.append(Path(ro))
+
+        for ro_root in effective_ro:
+            if _is_subpath(resolved, ro_root):
+                raise PolicyDeniedError(
+                    f"Write/delete access to '{resolved}' is denied — read-only root: {ro_root}"
+                )
+
+    return resolved
+
+
+# ---------------------------------------------------------------------------
+# Stateful guard (wraps a settings object for convenience)
+# ---------------------------------------------------------------------------
+
+class PathGuard:
+    """
+    Stateful wrapper around :func:`resolve_and_validate_path` that reads
+    workspace configuration from a ``Settings``-like object.
+
+    Instantiate once from the daemon / service container and inject into
+    tools that perform file-system operations.
+
+    Configuration values are cached at construction time to avoid
+    re-resolving paths on every ``validate()`` call.
+    """
+
+    def __init__(self, cfg) -> None:
+        self._cfg = cfg
+        # Cache configuration values at init time
+        self._workspace_roots = getattr(cfg, "workspace_roots", None)
+        self._blocked_roots = getattr(cfg, "blocked_roots", None)
+        self._read_only_roots = getattr(cfg, "read_only_roots", None)
+        self._local_files_mode = getattr(cfg, "local_files_mode", "home_only")
+        self._home = Path.home().resolve()
+
+    def validate(self, path: str, access_mode: AccessMode) -> Path:
+        """
+        Validate *path* for *access_mode* against the current configuration.
+
+        Equivalent to calling :func:`resolve_and_validate_path` with settings
+        drawn from the configuration object supplied at construction time.
+
+        Returns:
+            Resolved :class:`~pathlib.Path` on success.
+
+        Raises:
+            PolicyDeniedError: When the path is not permitted.
+        """
+        return resolve_and_validate_path(
+            path,
+            access_mode,
+            workspace_roots=self._workspace_roots,
+            blocked_roots=self._blocked_roots,
+            read_only_roots=self._read_only_roots,
+            local_files_mode=self._local_files_mode,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _is_subpath(candidate: Path, parent: Path) -> bool:
+    """
+    Return True when *candidate* equals *parent* or is located beneath it.
+
+    Works correctly after both paths have been resolved (no symlinks).
+    """
+    try:
+        candidate.relative_to(parent)
+        return True
+    except ValueError:
+        return False

--- a/src/jarvis/policy/path_guard.py
+++ b/src/jarvis/policy/path_guard.py
@@ -48,6 +48,20 @@ _DEFAULT_BLOCKED = [
     "/sbin",
     "/sys",
     "/usr",
+    # Credential and secret stores inside the user's home directory. The
+    # default "home_only" mode would otherwise expose these to any
+    # LLM-driven (or prompt-injected) read, since localFiles reads are
+    # classified SAFE. Data privacy comes first: these are denied by
+    # default and require an explicit workspace configuration to access.
+    "~/.ssh",
+    "~/.aws",
+    "~/.gnupg",
+    "~/.kube",
+    "~/.docker",
+    "~/.netrc",
+    "~/.npmrc",
+    "~/.pypirc",
+    "~/.git-credentials",
 ]
 
 
@@ -93,7 +107,9 @@ def resolve_and_validate_path(
     effective_blocked: List[Path] = []
     for br in (blocked_roots or _DEFAULT_BLOCKED):
         try:
-            effective_blocked.append(Path(os.path.expandvars(br)).resolve())
+            effective_blocked.append(
+                Path(os.path.expanduser(os.path.expandvars(br))).resolve()
+            )
         except (OSError, ValueError):
             effective_blocked.append(Path(br))
 
@@ -207,9 +223,33 @@ def _is_subpath(candidate: Path, parent: Path) -> bool:
     Return True when *candidate* equals *parent* or is located beneath it.
 
     Works correctly after both paths have been resolved (no symlinks).
+    Comparison is case-normalised (``os.path.normcase``) so that on
+    case-insensitive filesystems (macOS, Windows) a differently-cased
+    request (e.g. ``~/.SSH/id_rsa``) cannot evade a blocked or read-only
+    root. On case-sensitive filesystems normcase is a no-op.
     """
     try:
-        candidate.relative_to(parent)
-        return True
-    except ValueError:
+        cand = os.path.normcase(str(candidate))
+        par = os.path.normcase(str(parent))
+        if cand == par or cand.startswith(par.rstrip(os.sep) + os.sep):
+            return True
+    except (TypeError, ValueError):
         return False
+    # String comparison missed. On case-insensitive filesystems (macOS,
+    # Windows) a differently-cased path still names the same file, and
+    # POSIX normcase does not fold case, so fall back to filesystem
+    # identity: walk the candidate's ancestry comparing device+inode with
+    # the parent. Non-existent components are skipped (a path that does
+    # not exist cannot alias an existing root).
+    try:
+        parent_stat = os.stat(parent)
+    except OSError:
+        return False
+    for ancestor in (candidate, *candidate.parents):
+        try:
+            a_stat = os.stat(ancestor)
+        except OSError:
+            continue
+        if os.path.samestat(a_stat, parent_stat):
+            return True
+    return False

--- a/src/jarvis/policy/policy.spec.md
+++ b/src/jarvis/policy/policy.spec.md
@@ -1,0 +1,84 @@
+# Policy Package Specification
+
+## Purpose
+
+Evaluates every tool invocation before it is executed and produces a
+`PolicyDecision` that the reply engine checks before dispatching to the
+`ToolRunner`. The policy engine enforces workspace confinement and
+provides a kill-switch to disable all tool execution.
+
+Risk-based approval is handled by the **act-then-undo model** in the
+reply engine (see `task_state.spec.md`), not by the policy engine.
+
+## Architecture
+
+```
+reply/engine.py
+    │
+    └─ policy.engine.evaluate(tool_name, tool_args)
+            │
+            ├─ _classify_tool()           → ToolClass
+            ├─ approval.assess_risk()     → RiskLevel
+            ├─ PathGuard.check()          → constraints / deny
+            ├─ _evaluate_mcp_capability()
+            └─ PolicyDecision(allowed, constraints, …)
+```
+
+## Components
+
+### `engine.py` — `evaluate()`
+
+Central evaluation function. Returns a `PolicyDecision`.
+
+**Evaluation order:**
+1. `PolicyMode.DENY` → deny immediately (kill-switch).
+2. Classify tool into `ToolClass` via `tool.classify(args)`.
+3. Assess risk level via `tool.assess_risk(args)`.
+4. File-system operations: run `PathGuard`.
+5. MCP tools: check declared capability metadata.
+6. Emit `PolicyDecision` — risk handling delegated to act-then-undo model.
+
+`configure(cfg, approval_store)` sets the module-level singleton.
+
+### `models.py`
+
+Value types used throughout the policy package:
+- `PolicyMode` — `ACTIVE` (default, act-then-undo), `DENY` (kill-switch)
+- `ToolClass` — `INFORMATIONAL`, `READ_ONLY_OPERATIONAL`, `WRITE_OPERATIONAL`, `DESTRUCTIVE`, `EXTERNAL_DELEGATED`
+- `RiskLevel` — re-exported from `tools.types` (`SAFE`, `MODERATE`, `HIGH`)
+- `PolicyDecision` — `allowed`, `constraints`, `denied_reason`, `tool_class`, `risk_level`
+- `PolicyDeniedError` — raised when `allowed=False` and caller calls `assert_allowed()`
+- `AppliedConstraint`, `AccessMode`, `NetworkClass`
+
+### `approvals.py` — `ApprovalStore`
+
+Durable store for scoped approval grants. Currently unused by the policy
+engine (approval gates have been removed for the voice-first model) but
+retained for potential future use (e.g. MCP server trust grants).
+
+### `path_guard.py` — `PathGuard`
+
+Validates file-system paths against operator-defined root lists:
+- `workspace_roots` — allowed path prefixes (deny if outside all roots)
+- `blocked_roots` — explicitly forbidden prefixes (deny if within any)
+- `read_only_roots` — write/delete denied; read/list permitted
+
+All paths are resolved to absolute canonical form before comparison.
+Configuration values are cached at `PathGuard.__init__()` time.
+
+## Configuration Fields Used
+
+| Field              | Type        | Default       | Effect                                     |
+|--------------------|-------------|---------------|--------------------------------------------|
+| `policy_mode`      | `str`       | `"active"`    | `"active"` or `"deny"` (legacy names accepted) |
+| `workspace_roots`  | `list[str]` | `[]`          | Allowed file-system roots                  |
+| `blocked_roots`    | `list[str]` | `[]`          | Explicitly forbidden path prefixes         |
+| `read_only_roots`  | `list[str]` | `[]`          | Read-only path prefixes                    |
+| `local_files_mode` | `str`       | `"home_only"` | Extra constraint for local file tool       |
+
+## Graceful Degradation
+
+When the policy engine is not configured (daemon started without calling
+`configure()`), `get_engine()` returns `None`. The reply engine treats a
+`None` engine as permissive so that existing deployments without explicit
+policy configuration are unaffected.

--- a/src/jarvis/policy/policy.spec.md
+++ b/src/jarvis/policy/policy.spec.md
@@ -64,6 +64,16 @@ Validates file-system paths against operator-defined root lists:
 - `read_only_roots` — write/delete denied; read/list permitted
 
 All paths are resolved to absolute canonical form before comparison.
+Containment checks are case-insensitive-safe: string comparison is
+case-normalised, with a device+inode fallback so that on case-insensitive
+filesystems (macOS, Windows) a differently-cased path cannot evade a
+blocked or read-only root.
+
+When `blocked_roots` is not configured, the defaults cover OS system
+directories **and credential stores inside the home directory** (`~/.ssh`,
+`~/.aws`, `~/.gnupg`, `~/.kube`, `~/.docker`, `~/.netrc`, `~/.npmrc`,
+`~/.pypirc`, `~/.git-credentials`) — the default `home_only` mode would
+otherwise expose these to any LLM-driven read. Data privacy comes first.
 Configuration values are cached at `PathGuard.__init__()` time.
 
 ## Configuration Fields Used

--- a/src/jarvis/reply/engine.py
+++ b/src/jarvis/reply/engine.py
@@ -1777,23 +1777,38 @@ def run_reply_engine(db: "Database", cfg, tts: Optional[Any],
     # Spoken post-notes accumulated during this turn (appended to final reply)
     _post_notes: list = []
 
+    # Snapshots larger than this are skipped: an undo entry restoring a
+    # partial snapshot would silently corrupt the file, which is worse than
+    # honestly offering no undo. The direct read below (rather than the
+    # localFiles read operation) avoids that tool's display truncation for
+    # the same reason.
+    _SNAPSHOT_MAX_BYTES = 1_000_000
+
     def _capture_snapshot(t_name: str, t_args: dict):
-        """Read current state of a resource before a destructive tool runs."""
+        """Read the full current state of a resource before a destructive tool runs.
+
+        Returns the exact file contents (or None). Never returns partial
+        content: undo must restore the file byte-for-byte or not exist at all.
+        """
         if t_name == "localFiles":
             op = str(t_args.get("operation", "")).lower()
             if op in ("write", "append", "delete"):
                 path = t_args.get("path")
                 if path:
                     try:
-                        snap = run_tool_with_retries(
-                            db=db, cfg=cfg,
-                            tool_name="localFiles",
-                            tool_args={"operation": "read", "path": path},
-                            system_prompt="", original_prompt="",
-                            redacted_text="", max_retries=0,
-                        )
-                        if snap.reply_text and not snap.error_message:
-                            return snap.reply_text
+                        import os as _os
+                        expanded = _os.path.expanduser(str(path))
+                        if not _os.path.isfile(expanded):
+                            return None  # nothing to snapshot (new file)
+                        if _os.path.getsize(expanded) > _SNAPSHOT_MAX_BYTES:
+                            debug_log(
+                                f"snapshot skipped for {t_name}: file exceeds "
+                                f"{_SNAPSHOT_MAX_BYTES} bytes, undo unavailable",
+                                "undo",
+                            )
+                            return None
+                        with open(expanded, "r", encoding="utf-8", errors="strict") as _fh:
+                            return _fh.read()
                     except Exception as _se:
                         debug_log(f"snapshot capture failed: {_se}", "undo")
         return None
@@ -1867,6 +1882,44 @@ def run_reply_engine(db: "Database", cfg, tts: Optional[Any],
                             and _name != "toolSearchTool"
                             and _cand_sig not in recent_tool_signatures
                         )
+                        # Governance gate: the direct-exec fast path is for
+                        # SAFE informational steps only. Anything that can
+                        # mutate state must run through the model-emitted
+                        # path below, which carries the full policy →
+                        # snapshot → undo → audit sequence. Policy DENY
+                        # (kill-switch) also blocks the fast path. Fail
+                        # closed: on any error the step simply falls back
+                        # to the governed loop.
+                        if _plan_exec_ok:
+                            try:
+                                if assess_risk(_name, _args or {}) != RiskLevel.SAFE:
+                                    debug_log(
+                                        f"planner: direct-exec declined for "
+                                        f"{_name} (non-SAFE risk) — deferring "
+                                        f"to governed tool loop",
+                                        "planning",
+                                    )
+                                    _plan_exec_ok = False
+                                else:
+                                    _gov_decision = _policy_engine_module.evaluate(
+                                        _name, _args or {}
+                                    )
+                                    if not _gov_decision.allowed:
+                                        debug_log(
+                                            f"planner: direct-exec denied by "
+                                            f"policy for {_name}: "
+                                            f"{_gov_decision.denied_reason}",
+                                            "planning",
+                                        )
+                                        _plan_exec_ok = False
+                            except Exception as _gov_exc:
+                                debug_log(
+                                    f"planner: direct-exec governance check "
+                                    f"failed ({_gov_exc}) — deferring to "
+                                    f"governed tool loop",
+                                    "planning",
+                                )
+                                _plan_exec_ok = False
                         if _plan_exec_ok:
                             debug_log(
                                 f"planner: direct-executing plan step "
@@ -2285,6 +2338,13 @@ def run_reply_engine(db: "Database", cfg, tts: Optional[Any],
                 debug_log("stop signal received - ending conversation without reply", "planning")
                 step.complete("stop signal")
                 task.complete()
+                # Finalise the audit record — every terminal path must close
+                # its TaskRecord or it stays "executing" in the audit DB forever.
+                if _audit:
+                    try:
+                        _audit.finish_task(_audit_task_id, final_status="done", started_at=task.started_at)
+                    except Exception as _exc:
+                        debug_log(f"audit: failed to finish task record on stop: {_exc}", "audit")
                 try:
                     print("💤 Returning to wake word mode\n", flush=True)
                 except Exception:
@@ -2320,29 +2380,38 @@ def run_reply_engine(db: "Database", cfg, tts: Optional[Any],
 
             # Append tool result
             if result.reply_text:
-                step.complete(result.reply_text[:120])
+                # Step state and undo registration are gated on result.success,
+                # not on the presence of reply_text: tools legitimately return
+                # success=False with a human-readable message in reply_text
+                # (e.g. "Access denied by policy", "Write failed"). Marking
+                # those complete and registering an undo entry would tell the
+                # user they can reverse an action that never happened.
+                if result.success:
+                    step.complete(result.reply_text[:120])
 
-                # Register undo entry if this was a reversible operation
-                _undo_built = build_undo_args(tool_name, tool_args or {}, _snapshot)
-                if _undo_built:
-                    _u_tool, _u_args, _u_desc = _undo_built
-                    _undo_entry = UndoEntry(
-                        step_id=step.step_id,
-                        description=_u_desc,
-                        tool_name=tool_name,
-                        tool_args=tool_args or {},
-                        undo_tool=_u_tool,
-                        undo_args=_u_args,
-                        snapshot=_snapshot,
-                    )
-                    push_undo(_undo_entry)
-                    step.mark_reversible(_undo_entry.step_id)
-                    _note = post_execution_note(tool_name, tool_args)
-                    if _note:
-                        _post_notes.append(_note)
-                        debug_log(
-                            f"undo registered for {tool_name}: {_u_desc}", "undo"
+                    # Register undo entry if this was a reversible operation
+                    _undo_built = build_undo_args(tool_name, tool_args or {}, _snapshot)
+                    if _undo_built:
+                        _u_tool, _u_args, _u_desc = _undo_built
+                        _undo_entry = UndoEntry(
+                            step_id=step.step_id,
+                            description=_u_desc,
+                            tool_name=tool_name,
+                            tool_args=tool_args or {},
+                            undo_tool=_u_tool,
+                            undo_args=_u_args,
+                            snapshot=_snapshot,
                         )
+                        push_undo(_undo_entry)
+                        step.mark_reversible(_undo_entry.step_id)
+                        _note = post_execution_note(tool_name, tool_args)
+                        if _note:
+                            _post_notes.append(_note)
+                            debug_log(
+                                f"undo registered for {tool_name}: {_u_desc}", "undo"
+                            )
+                else:
+                    step.fail((result.error_message or result.reply_text or "")[:120])
 
                 # toolSearchTool is an escape hatch: merge the surfaced tool
                 # names into the per-turn allow-list so the chat model can
@@ -2464,18 +2533,32 @@ def run_reply_engine(db: "Database", cfg, tts: Optional[Any],
                             f"\n\n[If the original query has sub-questions not yet answered "
                             "by this result, call another tool now. Otherwise reply.]"
                         )
+                    # Governance hints (irreversibility warning / undo note)
+                    # ride on the tool-result message so the reply LLM weaves
+                    # them into its answer in the user's language, rather than
+                    # having English spliced into the final reply.
+                    _gov_suffix = ""
+                    if _pre_warnings or _post_notes:
+                        _gov_suffix = "\n\n" + "\n".join(_pre_warnings + _post_notes)
+                        _pre_warnings.clear()
+                        _post_notes.clear()
                     messages.append({
                         "role": "user",
-                        "content": f"[Tool result: {tool_name}]\n{effective_result}{remainder_hint}",
+                        "content": f"[Tool result: {tool_name}]\n{effective_result}{remainder_hint}{_gov_suffix}",
                         "tool_name": tool_name,  # kept for duplicate detection
                         "tool_failed": not result.success,
                     })
                 else:
+                    _gov_suffix = ""
+                    if _pre_warnings or _post_notes:
+                        _gov_suffix = "\n\n" + "\n".join(_pre_warnings + _post_notes)
+                        _pre_warnings.clear()
+                        _post_notes.clear()
                     messages.append({
                         "role": "tool",
                         "tool_call_id": tool_call_id,
                         "tool_name": tool_name,  # Include tool_name for duplicate detection
-                        "content": effective_result,
+                        "content": effective_result + _gov_suffix,
                         "tool_failed": not result.success,
                     })
                 debug_log(f"    ✅ tool result appended ({len(effective_result)} chars)", "planning")
@@ -2534,7 +2617,8 @@ def run_reply_engine(db: "Database", cfg, tts: Optional[Any],
                     _policy_audit_id = (
                         _policy_decision.audit_id if _policy_decision else ""
                     )
-                    _step_success = bool(result.reply_text and not result.error_message)
+                    # Single success predicate shared with step state above.
+                    _step_success = bool(result.success)
                     _step_summary = (
                         result.reply_text[:200] if _step_success else (result.error_message or "")[:200]
                     )
@@ -2649,11 +2733,9 @@ def run_reply_engine(db: "Database", cfg, tts: Optional[Any],
         except Exception:
             pass
     debug_log(task.summary(), "task")
-    # Weave pre-warnings and post-notes into the spoken reply
-    if _pre_warnings:
-        reply = "  ".join(_pre_warnings) + "  " + (reply or "")
-    if _post_notes:
-        reply = (reply or "") + "  " + "  ".join(_post_notes)
+    # Governance hints (irreversibility warnings / undo notes) are delivered
+    # via the tool-result messages above so the LLM phrases them in the
+    # user's language — nothing is spliced into the reply here.
     safe_reply = reply.strip()
     if not safe_reply:
         safe_reply = "Sorry, I had trouble processing that. Could you try again?"

--- a/src/jarvis/reply/engine.py
+++ b/src/jarvis/reply/engine.py
@@ -2,10 +2,16 @@
 Reply Engine - Main orchestrator for response generation.
 
 Handles memory enrichment, tool planning and execution.
+Implements the JARVIS autonomy specification:
+  - Request classification (informational vs operational)
+  - Internal execution planning via the agentic loop
+  - Risk assessment and approval for destructive actions
+  - Task state tracking for execution visibility and resumption
+  - Recovery on tool failure with alternative approaches
 """
 
 from __future__ import annotations
-from typing import Optional, TYPE_CHECKING
+from typing import Optional, Any, TYPE_CHECKING
 
 from ..utils.redact import redact
 from ..system_prompt import build_system_prompt
@@ -62,12 +68,33 @@ from .planner import (
     resolve_next_tool_call as _resolve_plan_step,
 )
 from ..tools.selection import select_tools, ToolSelectionStrategy
+from .errors import (
+    AgentError,
+    ApprovalRequiredError,
+    LoopExhaustedError,
+    ModelOutputError,
+    PolicyDeniedError as AgentPolicyDeniedError,
+    ToolExecutionError,
+    ToolSchemaError,
+)
+from ..task_state import begin_task, get_active_task, TaskStatus
+from ..approval import (
+    classify_request, RequestType,
+    assess_risk, RiskLevel,
+    is_undoable, pre_execution_warning, post_execution_note, build_undo_args,
+)
+from ..undo_registry import UndoEntry, push_undo
 import json
 import re
 import uuid
 from datetime import datetime, timezone
 from ..utils.location import get_location_context_with_timezone
 from ..utils.time_context import format_time_context
+
+# Policy and audit imports (gracefully degrade when not configured)
+from ..policy import engine as _policy_engine_module, models as _policy_models
+from ..audit.recorder import get_recorder as _get_audit_recorder
+from ..audit.models import TaskRecord, TaskStepRecord, PolicyDecisionRecord
 
 if TYPE_CHECKING:
     from ..memory.db import Database
@@ -799,6 +826,26 @@ def run_reply_engine(db: "Database", cfg, tts: Optional[Any],
     """
     # Step 1: Redact sensitive information
     redacted = redact(text)
+
+    # Step 1a: Classify request and begin task state tracking
+    request_type = classify_request(redacted)
+    task = begin_task(redacted)
+    debug_log(f"request type: {request_type.value}", "planning")
+
+    # Step 1b: Begin audit record (no-op when audit not configured)
+    _audit = _get_audit_recorder()
+    _audit_task_id = task.task_id
+    if _audit:
+        try:
+            _audit_task_record = TaskRecord(
+                task_id=_audit_task_id,
+                intent=redacted[:500],
+                request_type=request_type.value if hasattr(request_type, "value") else str(request_type),
+                status="planning",
+            )
+            _audit.begin_task(_audit_task_record)
+        except Exception as _exc:
+            debug_log(f"audit: failed to begin task record: {_exc}", "audit")
 
     # Step 2: Check for recent dialogue context
     recent_messages = []
@@ -1722,6 +1769,35 @@ def run_reply_engine(db: "Database", cfg, tts: Optional[Any],
     if _prompt_dump_enabled():
         print(f"  📝 Prompt dump enabled (session {_dump_session_id})", flush=True)
 
+    # Transition task state to executing now that messages are built
+    task.set_executing()
+
+    # Spoken warnings accumulated during this turn (prepended to final reply)
+    _pre_warnings: list = []
+    # Spoken post-notes accumulated during this turn (appended to final reply)
+    _post_notes: list = []
+
+    def _capture_snapshot(t_name: str, t_args: dict):
+        """Read current state of a resource before a destructive tool runs."""
+        if t_name == "localFiles":
+            op = str(t_args.get("operation", "")).lower()
+            if op in ("write", "append", "delete"):
+                path = t_args.get("path")
+                if path:
+                    try:
+                        snap = run_tool_with_retries(
+                            db=db, cfg=cfg,
+                            tool_name="localFiles",
+                            tool_args={"operation": "read", "path": path},
+                            system_prompt="", original_prompt="",
+                            redacted_text="", max_retries=0,
+                        )
+                        if snap.reply_text and not snap.error_message:
+                            return snap.reply_text
+                    except Exception as _se:
+                        debug_log(f"snapshot capture failed: {_se}", "undo")
+        return None
+
     # Visible progress indicator before LLM loop (helps diagnose hangs)
     print(f"  💬 Generating response...", flush=True)
     debug_log(f"Starting LLM conversation loop (max {max_turns} turns)...", "planning")
@@ -2087,7 +2163,7 @@ def run_reply_engine(db: "Database", cfg, tts: Optional[Any],
                 stable_args = json.dumps(tool_args or {}, sort_keys=True, ensure_ascii=False)
                 signature = (tool_name, stable_args)
             except Exception:
-                signature = (tool_name, "__unserializable_args__")
+                signature = (tool_name, "__unserialised_args__")
 
             if signature in recent_tool_signatures:
                 debug_log(f"  ⚠️ Duplicate {tool_name} call - returning cached guidance", "planning")
@@ -2114,6 +2190,83 @@ def run_reply_engine(db: "Database", cfg, tts: Optional[Any],
                     messages.append({"role": "tool", "tool_call_id": tool_call_id, "content": f"You have already called {tool_name} {duplicate_tool_count} times. Please use the results from those calls to answer the user's question."})
                 continue
 
+            # Create step early so its ID can be shared across policy + audit records
+            step = task.add_step(
+                description=f"Execute {tool_name}",
+                tool_name=tool_name,
+            )
+
+            # Policy evaluation (replaces raw requires_approval check)
+            _policy_decision = None
+            try:
+                _policy_decision = _policy_engine_module.evaluate(tool_name, tool_args)
+                # Record policy decision in audit
+                if _audit:
+                    try:
+                        _constraints_json = json.dumps(
+                            [c.name for c in _policy_decision.applied_constraints]
+                        )
+                        _audit.record_policy_decision(PolicyDecisionRecord(
+                            audit_id=_policy_decision.audit_id,
+                            task_id=_audit_task_id,
+                            step_id=step.step_id,
+                            tool_name=tool_name,
+                            tool_class=_policy_decision.tool_class.value,
+                            risk_level=_policy_decision.risk_level.value,
+                            allowed=_policy_decision.allowed,
+                            approval_required=_policy_decision.approval_required,
+                            decision_reason=_policy_decision.decision_reason,
+                            denied_reason=_policy_decision.denied_reason or "",
+                            constraints_json=_constraints_json,
+                        ))
+                    except Exception as _ae:
+                        debug_log(f"audit: policy decision record error: {_ae}", "audit")
+
+                if not _policy_decision.allowed:
+                    debug_log(f"  🚫 policy denied {tool_name}: {_policy_decision.denied_reason}", "planning")
+                    step.skip(f"policy denied: {_policy_decision.denied_reason or _policy_decision.decision_reason}"[:120])
+                    messages.append({
+                        "role": "tool",
+                        "tool_call_id": tool_call_id,
+                        "content": f"Error: Action denied by policy — {_policy_decision.denied_reason or _policy_decision.decision_reason}",
+                    })
+                    continue
+
+            except _policy_models.PolicyDeniedError as _pde:
+                debug_log(f"  🚫 policy denied {tool_name}: {_pde}", "planning")
+                step.skip(f"policy denied: {_pde}"[:120])
+                messages.append({
+                    "role": "tool",
+                    "tool_call_id": tool_call_id,
+                    "content": f"Error: Action denied by policy — {_pde}",
+                })
+                continue
+            except Exception as _pe:
+                debug_log(f"  ⚠️ policy evaluation error: {_pe}", "planning")
+                # Fall through to legacy approval check on policy engine error
+
+            # Legacy approval check (used when policy engine is not configured
+            # or as defence-in-depth for HIGH-risk tools)
+            #
+            # NEW BEHAVIOUR (voice-first undo model):
+            #   HIGH risk + undoable  → act, register undo, append "say undo" note
+            #   HIGH risk + irreversible → emit spoken warning, then act
+            #   Approval gate removed — no hard stop
+            _warn = pre_execution_warning(tool_name, tool_args)
+            if _warn:
+                _pre_warnings.append(_warn)
+                try:
+                    print(f"  ⚠️  {_warn}", flush=True)
+                except Exception:
+                    pass
+
+            # Capture snapshot before destructive execution (needed for undo)
+            _snapshot = None
+            if is_undoable(tool_name, tool_args):
+                _snapshot = _capture_snapshot(tool_name, tool_args)
+
+            step.start()
+
             # Execute tool
             result = run_tool_with_retries(
                 db=db,
@@ -2130,6 +2283,8 @@ def run_reply_engine(db: "Database", cfg, tts: Optional[Any],
             # Handle stop tool - end conversation without response
             if result.reply_text == STOP_SIGNAL:
                 debug_log("stop signal received - ending conversation without reply", "planning")
+                step.complete("stop signal")
+                task.complete()
                 try:
                     print("💤 Returning to wake word mode\n", flush=True)
                 except Exception:
@@ -2165,6 +2320,30 @@ def run_reply_engine(db: "Database", cfg, tts: Optional[Any],
 
             # Append tool result
             if result.reply_text:
+                step.complete(result.reply_text[:120])
+
+                # Register undo entry if this was a reversible operation
+                _undo_built = build_undo_args(tool_name, tool_args or {}, _snapshot)
+                if _undo_built:
+                    _u_tool, _u_args, _u_desc = _undo_built
+                    _undo_entry = UndoEntry(
+                        step_id=step.step_id,
+                        description=_u_desc,
+                        tool_name=tool_name,
+                        tool_args=tool_args or {},
+                        undo_tool=_u_tool,
+                        undo_args=_u_args,
+                        snapshot=_snapshot,
+                    )
+                    push_undo(_undo_entry)
+                    step.mark_reversible(_undo_entry.step_id)
+                    _note = post_execution_note(tool_name, tool_args)
+                    if _note:
+                        _post_notes.append(_note)
+                        debug_log(
+                            f"undo registered for {tool_name}: {_u_desc}", "undo"
+                        )
+
                 # toolSearchTool is an escape hatch: merge the surfaced tool
                 # names into the per-turn allow-list so the chat model can
                 # call them on subsequent turns. `stop` and `toolSearchTool`
@@ -2327,6 +2506,7 @@ def run_reply_engine(db: "Database", cfg, tts: Optional[Any],
                 err = result.error_message or "(no result)"
                 _err_preview = err if len(err) <= 240 else err[:237] + "..."
                 print(f"    ❌ {tool_name} error: {_err_preview}", flush=True)
+                step.fail(err[:120])
                 if use_text_tools:
                     messages.append({
                         "role": "user",
@@ -2343,6 +2523,33 @@ def run_reply_engine(db: "Database", cfg, tts: Optional[Any],
                         "tool_failed": True,
                     })
                 debug_log(f"    ❌ tool error: {err}", "planning")
+
+            # Audit: record step outcome
+            if _audit:
+                try:
+                    import hashlib as _hashlib
+                    _args_hash = _hashlib.sha256(
+                        json.dumps(tool_args or {}, sort_keys=True).encode()
+                    ).hexdigest()[:16]
+                    _policy_audit_id = (
+                        _policy_decision.audit_id if _policy_decision else ""
+                    )
+                    _step_success = bool(result.reply_text and not result.error_message)
+                    _step_summary = (
+                        result.reply_text[:200] if _step_success else (result.error_message or "")[:200]
+                    )
+                    _audit.record_step(TaskStepRecord(
+                        step_id=step.step_id,
+                        task_id=_audit_task_id,
+                        tool_name=tool_name,
+                        args_hash=_args_hash,
+                        policy_audit_id=_policy_audit_id,
+                        result_summary=_step_summary,
+                        success=_step_success,
+                    ))
+                except Exception as _se:
+                    debug_log(f"audit: step record error: {_se}", "audit")
+
             # Loop continues to let the agent produce the next step/final reply
             continue
 
@@ -2405,6 +2612,12 @@ def run_reply_engine(db: "Database", cfg, tts: Optional[Any],
     if not reply or not reply.strip():
         reply = "Sorry, I had trouble processing that. Could you try again?"
         debug_log("no reply generated, returning error message", "planning")
+        task.fail("no reply generated")
+        if _audit:
+            try:
+                _audit.finish_task(_audit_task_id, final_status="failed", error="no reply generated")
+            except Exception:
+                pass
 
         # Print error message
         try:
@@ -2425,6 +2638,22 @@ def run_reply_engine(db: "Database", cfg, tts: Optional[Any],
         return reply
 
     # Step 10: Output and memory update
+    # Use set_reversible() when at least one step is still undoable
+    if task.reversible_steps:
+        task.set_reversible()
+    else:
+        task.complete()
+    if _audit:
+        try:
+            _audit.finish_task(_audit_task_id, final_status="done")
+        except Exception:
+            pass
+    debug_log(task.summary(), "task")
+    # Weave pre-warnings and post-notes into the spoken reply
+    if _pre_warnings:
+        reply = "  ".join(_pre_warnings) + "  " + (reply or "")
+    if _post_notes:
+        reply = (reply or "") + "  " + "  ".join(_post_notes)
     safe_reply = reply.strip()
     if not safe_reply:
         safe_reply = "Sorry, I had trouble processing that. Could you try again?"

--- a/src/jarvis/reply/engine.py
+++ b/src/jarvis/reply/engine.py
@@ -2615,7 +2615,7 @@ def run_reply_engine(db: "Database", cfg, tts: Optional[Any],
         task.fail("no reply generated")
         if _audit:
             try:
-                _audit.finish_task(_audit_task_id, final_status="failed", error="no reply generated")
+                _audit.finish_task(_audit_task_id, final_status="failed", error="no reply generated", started_at=task.started_at)
             except Exception:
                 pass
 
@@ -2645,7 +2645,7 @@ def run_reply_engine(db: "Database", cfg, tts: Optional[Any],
         task.complete()
     if _audit:
         try:
-            _audit.finish_task(_audit_task_id, final_status="done")
+            _audit.finish_task(_audit_task_id, final_status="done", started_at=task.started_at)
         except Exception:
             pass
     debug_log(task.summary(), "task")

--- a/src/jarvis/reply/errors.py
+++ b/src/jarvis/reply/errors.py
@@ -1,0 +1,98 @@
+"""
+Formal exception hierarchy for the agent loop.
+
+These exceptions are raised by the reply engine when specific failure
+conditions are encountered.  Callers can catch individual classes to
+apply targeted recovery logic.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+
+class AgentError(RuntimeError):
+    """Base class for all agent loop errors."""
+
+
+class ModelOutputError(AgentError):
+    """
+    Raised when the LLM returns output that cannot be processed.
+
+    This includes:
+    - Empty responses where a response was expected.
+    - Malformed JSON that cannot be recovered.
+    - Hallucinated API spec instead of conversational text.
+    """
+
+    def __init__(self, message: str, raw_content: Optional[str] = None) -> None:
+        super().__init__(message)
+        self.raw_content = raw_content
+
+
+class ToolSchemaError(AgentError):
+    """
+    Raised when the LLM requests a tool with arguments that do not
+    conform to the tool's declared JSON Schema.
+    """
+
+    def __init__(self, tool_name: str, reason: str) -> None:
+        super().__init__(f"Tool schema error for '{tool_name}': {reason}")
+        self.tool_name = tool_name
+        self.reason = reason
+
+
+class PolicyDeniedError(AgentError):
+    """
+    Raised when the policy engine blocks a tool invocation.
+
+    Note: :class:`jarvis.policy.models.PolicyDeniedError` is the primary
+    policy exception.  This subclass is re-raised from the agent loop so
+    callers only need to import from this module.
+    """
+
+    def __init__(self, tool_name: str, reason: str) -> None:
+        super().__init__(f"Policy denied tool '{tool_name}': {reason}")
+        self.tool_name = tool_name
+        self.reason = reason
+
+
+class ApprovalRequiredError(AgentError):
+    """
+    Raised when a tool requires explicit user approval before executing
+    and no prior grant covers the request.
+
+    Retained for API compatibility; the engine no longer raises this in
+    the default act-then-undo flow.
+    """
+
+    def __init__(self, tool_name: str, prompt: str) -> None:
+        super().__init__(f"Approval required for '{tool_name}': {prompt}")
+        self.tool_name = tool_name
+        self.prompt = prompt
+
+
+class ToolExecutionError(AgentError):
+    """
+    Raised when a tool invocation returns an unexpected error after
+    all retries have been exhausted.
+    """
+
+    def __init__(self, tool_name: str, reason: str, retry_count: int = 0) -> None:
+        super().__init__(
+            f"Tool '{tool_name}' failed after {retry_count} retries: {reason}"
+        )
+        self.tool_name = tool_name
+        self.reason = reason
+        self.retry_count = retry_count
+
+
+class LoopExhaustedError(AgentError):
+    """
+    Raised when the agentic loop reaches ``agentic_max_turns`` without
+    producing a final response.
+    """
+
+    def __init__(self, max_turns: int) -> None:
+        super().__init__(f"Agent loop exhausted after {max_turns} turns without a response.")
+        self.max_turns = max_turns

--- a/src/jarvis/reply/reply.spec.md
+++ b/src/jarvis/reply/reply.spec.md
@@ -4,17 +4,20 @@ This specification documents only the reply flow that begins when a valid user q
 
 ### Architecture Overview
 - Components:
-  - Reply Engine (`src/jarvis/reply/engine.py`): Orchestrates conversation-memory enrichment, tool-use protocol, messages loop, output, and memory update.
+  - Reply Engine (`src/jarvis/reply/engine.py`): Orchestrates request classification, conversation-memory enrichment, approval checking, tool-use protocol, messages loop, task state tracking, output, and memory update.
   - System Prompt (`src/jarvis/system_prompt.py`): Provides a unified `SYSTEM_PROMPT` with adaptive guidance for all topics. Declares the assistant's persona — a British butler named Jarvis with dry wit and light, good-natured sarcasm — with explicit behavioural rules (answer-first/quip-second, at most one quip, skip the quip for serious topics, no butler clichés, sarcasm never aimed at the user). The rules are phrased concretely rather than as tone adjectives so small models can follow them. Persona behaviour is not currently covered by an eval; add one if the tone regresses or the rules evolve.
   - LLM Gateway (`src/jarvis/llm/`): pluggable backend abstraction (`LLMBackend` ABC + `OllamaBackend` impl, factory at `get_llm_backend(settings)`). The reply engine uses the function-style helper `chat_with_messages` (sends the messages array and returns raw JSON) and `extract_text_from_response` (normalises content across providers); both dispatch to the same backend. See `src/jarvis/llm/llm.spec.md`.
   - Conversation Memory (`src/jarvis/memory/conversation.py`): Supplies recent dialogue messages and keyword/time-bounded recall.
   - Enrichment LLM (`src/jarvis/reply/enrichment.py`): Extracts search params (keywords and optional time bounds) from the current query to drive conversation recall.
+  - Task State (`src/jarvis/task_state.py`): Session-scoped tracker for the active task – intent, execution steps, status, and resumption support.
+  - Approval (`src/jarvis/approval.py`): Risk assessment and approval logic; classifies requests as informational/operational and tool invocations as safe/moderate/high risk.
 
 Design principles enforced by the engine:
 - Unified System Prompt: A single prompt with adaptive guidance handles all topics; no per-profile routing.
 - Tool Response Flow: Tools return raw data; formatting/personality is handled by the LLM through the engine's loop. The system prompt explicitly instructs the model to use tool results to fulfill the user's original request, not to describe the structure or format of the tool response.
 - Language-Agnostic Design: Prompts and ASR guidance avoid language-specific phrasing.
 - Data Privacy: Inputs are redacted and logging is concise and purposeful via `debug_log`.
+- Autonomy with Safety: The engine acts automatically on clear instructions, asks clarification only when genuinely ambiguous, and requires explicit approval for destructive or high-impact operations.
 
 ### Entry and Inputs
 - Entry point: the reply engine receives a user query from the ingestion layer.
@@ -27,6 +30,10 @@ Design principles enforced by the engine:
 ### Steps and Branches (Agentic Messages Loop)
 1. Redact
    - Redact input to remove sensitive data.
+
+1a. Classify & Begin Task
+   - Classify the request as `informational` or `operational` using `classify_request()` from `src/jarvis/approval.py`.
+   - Call `begin_task(intent)` from `src/jarvis/task_state.py` to initialise session-scoped state tracking.
 
 2. Recent Dialogue Context
    - Include short-term dialogue memory (last 5 minutes) as prior messages.
@@ -145,17 +152,32 @@ Design principles enforced by the engine:
    - Tool results: native path appends `{role: "tool", tool_call_id: "<id>", content: "<text>"}` messages; text-based fallback appends `{role: "user", content: "[Tool result: name]\n<text>"}` messages
    - No system message injection: The engine does NOT add system messages during the loop as this breaks native tool calling; instead, guidance is provided via tool error responses when needed
 
+   **Approval Gate (Decision Policy):**
+   - Before each tool execution, `requires_approval(tool_name, tool_args)` is called.
+   - HIGH-risk operations (e.g., `localFiles` with `operation=delete`, `deleteMeal`) require explicit user confirmation.
+   - When approval is required, the engine returns an approval prompt to the user and halts execution; the user must re-issue the command with confirmation.
+   - SAFE and MODERATE operations proceed automatically without interruption.
+   - Risk levels per tool are defined in `src/jarvis/approval.py`.
+
+   **Task Step Tracking:**
+   - Each tool execution is recorded as a `TaskStep` on the active `TaskState`.
+   - Steps track: description, tool name, status (PENDING→RUNNING→SUCCEEDED/FAILED), result summary, and timing.
+   - The `TaskState` transitions: IDLE → PLANNING → EXECUTING → AWAITING_APPROVAL | DONE | FAILED.
+
 8. Output and Memory Update
    - Remove any tool protocol markers (e.g., lines beginning with a reserved prefix) from the final response.
    - Print reply with a concise header; optionally include debug labeling.
    - If speech synthesis is enabled, pass the reply through the TTS preprocessor (link-to-description rewriting and markdown stripping — see `src/jarvis/output/tts.py::_preprocess_for_speech`) before speaking. Markdown stripping is required because small models often emit `**bold**`, bullets, and headings despite `VOICE_STYLE` guidance, and Piper-style TTS engines read the syntax characters literally ("asterisk asterisk ..."). The stripper handles bold/italic/strikethrough, inline and fenced code, HTML tags, blockquotes, ATX and setext headings, and bullet/numbered lists. Numbered-list markers are removed only when the line is part of a real list (≥2 adjacent numbered lines with numbers ≤ 99), so prose like "2024. The year..." is preserved. The `VOICE_STYLE` prompt also explicitly forbids markdown — belt-and-suspenders.
    - After speech finishes, trigger the follow-up listening window if configured.
+   - Mark the active `TaskState` as DONE (or FAILED on error).
    - Add the interaction (sanitized user/assistant texts) to short-term dialogue memory; ignore failures.
 
 ### Reply-only Branch Checklist
 - Redaction/DB
   - VSS enabled vs disabled
   - Embedding success vs failure (ignored)
+- Classification
+  - Informational vs operational request
 - System Prompt
   - Unified prompt loaded
 - Conversation Memory
@@ -168,6 +190,9 @@ Design principles enforced by the engine:
   - Plan JSON parsed vs invalid
   - Steps include FINAL_RESPONSE / ANALYZE / tool / unknown
   - Completed without final → partial fallback
+- Approval
+  - Safe/moderate tool proceeds automatically
+  - High-risk tool triggers approval prompt and halts execution
 - Retry
   - Plain chat retry produces text vs empty
 - Output

--- a/src/jarvis/reply/reply.spec.md
+++ b/src/jarvis/reply/reply.spec.md
@@ -152,17 +152,19 @@ Design principles enforced by the engine:
    - Tool results: native path appends `{role: "tool", tool_call_id: "<id>", content: "<text>"}` messages; text-based fallback appends `{role: "user", content: "[Tool result: name]\n<text>"}` messages
    - No system message injection: The engine does NOT add system messages during the loop as this breaks native tool calling; instead, guidance is provided via tool error responses when needed
 
-   **Approval Gate (Decision Policy):**
-   - Before each tool execution, `requires_approval(tool_name, tool_args)` is called.
-   - HIGH-risk operations (e.g., `localFiles` with `operation=delete`, `deleteMeal`) require explicit user confirmation.
-   - When approval is required, the engine returns an approval prompt to the user and halts execution; the user must re-issue the command with confirmation.
-   - SAFE and MODERATE operations proceed automatically without interruption.
-   - Risk levels per tool are defined in `src/jarvis/approval.py`.
+   **Governance (Voice-First Act-Then-Undo — no approval gates):**
+   - Before each model-emitted tool execution, the policy engine (`src/jarvis/policy/engine.py`) evaluates the call. A denial (e.g. `policy_mode=deny` kill-switch, or a path outside the allowed roots) skips execution, marks the step failed, and feeds a tool-error message back to the model — the loop continues, no hard stop.
+   - HIGH-risk **undoable** operations (e.g. `localFiles` write/append/delete): a full pre-execution snapshot is captured (skipped for files over the snapshot size cap — undo must be byte-exact or not offered at all), the action runs, and an `UndoEntry` is pushed to the undo registry. An instruction rides on the tool-result message telling the reply LLM to mention, in the user's language, that the action can be undone. There are no hardcoded user-facing strings.
+   - HIGH-risk **irreversible** operations (e.g. `deleteMeal`): the action runs, and an instruction on the tool-result message tells the reply LLM to warn the user, in their language, that it cannot be undone.
+   - SAFE and MODERATE operations proceed without commentary.
+   - Step completion and undo registration are gated on `result.success` — a tool that fails (even with a human-readable message in `reply_text`) marks its step FAILED and never registers an undo entry.
+   - The planner's direct-exec fast path only runs SAFE-risk, policy-allowed steps; any write/destructive plan step falls through to this governed loop.
+   - Risk levels are declared per tool (`Tool.assess_risk`); the undo strategy table lives in `src/jarvis/approval.py`.
 
    **Task Step Tracking:**
    - Each tool execution is recorded as a `TaskStep` on the active `TaskState`.
    - Steps track: description, tool name, status (PENDING→RUNNING→SUCCEEDED/FAILED), result summary, and timing.
-   - The `TaskState` transitions: IDLE → PLANNING → EXECUTING → AWAITING_APPROVAL | DONE | FAILED.
+   - The `TaskState` transitions: IDLE → PLANNING → EXECUTING → DONE | FAILED. Every terminal path (success, stop, no-reply backstop) also finalises the audit `TaskRecord`.
 
 8. Output and Memory Update
    - Remove any tool protocol markers (e.g., lines beginning with a reserved prefix) from the final response.
@@ -190,9 +192,10 @@ Design principles enforced by the engine:
   - Plan JSON parsed vs invalid
   - Steps include FINAL_RESPONSE / ANALYZE / tool / unknown
   - Completed without final → partial fallback
-- Approval
+- Governance
   - Safe/moderate tool proceeds automatically
-  - High-risk tool triggers approval prompt and halts execution
+  - Policy denial skips the step and feeds a tool-error back to the model
+  - High-risk undoable tool registers an undo entry; irreversible tool triggers a spoken warning via the reply LLM
 - Retry
   - Plain chat retry produces text vs empty
 - Output

--- a/src/jarvis/runtime/__init__.py
+++ b/src/jarvis/runtime/__init__.py
@@ -1,0 +1,11 @@
+"""Jarvis runtime management package."""
+
+from .health import HealthRegistry, ServiceHealth, HealthStatus
+from .shutdown_manager import ShutdownManager
+
+__all__ = [
+    "HealthRegistry",
+    "ServiceHealth",
+    "HealthStatus",
+    "ShutdownManager",
+]

--- a/src/jarvis/runtime/health.py
+++ b/src/jarvis/runtime/health.py
@@ -1,0 +1,218 @@
+"""
+Health registry — centralised service health tracking.
+
+Each subsystem registers itself and publishes periodic status updates.
+The daemon and desktop UI consume the registry to determine whether to
+start in degraded mode and what to surface to the operator.
+
+Design
+------
+* Thread-safe.
+* Subsystems are identified by a canonical string name.
+* Health states are one of: ``ready``, ``degraded``, ``unavailable``, ``initialising``.
+* A ``detail`` string may carry a human-readable explanation.
+* The registry is a module-level singleton initialised at daemon startup.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Callable, Dict, List, Optional
+
+from ..debug import debug_log
+
+
+# ---------------------------------------------------------------------------
+# Enumerations and value types
+# ---------------------------------------------------------------------------
+
+class HealthStatus(Enum):
+    """Operational status of a single subsystem."""
+    INITIALISING = "initialising"
+    """Subsystem is still starting up."""
+    READY = "ready"
+    """Subsystem is fully operational."""
+    DEGRADED = "degraded"
+    """Subsystem is partially operational — some features may be unavailable."""
+    UNAVAILABLE = "unavailable"
+    """Subsystem is not available — dependent features are disabled."""
+
+
+# Well-known subsystem identifiers (callers may also register custom names).
+class ServiceName:
+    DATABASE    = "database"
+    OLLAMA      = "ollama"
+    WHISPER     = "whisper"
+    MICROPHONE  = "microphone"
+    TTS         = "tts"
+    MCP         = "mcp"
+    LOCATION    = "location"
+    POLICY      = "policy"
+    AUDIT       = "audit"
+    VOICE       = "voice"
+
+
+@dataclass
+class ServiceHealth:
+    """Snapshot of a single service's health at a point in time."""
+    name: str
+    status: HealthStatus = HealthStatus.INITIALISING
+    detail: str = ""
+    last_updated: float = field(default_factory=time.time)
+    error: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+class HealthRegistry:
+    """
+    Thread-safe registry for all Jarvis subsystem health states.
+
+    Instantiate at daemon startup (or use the module-level singleton via
+    :func:`get_registry`).
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._services: Dict[str, ServiceHealth] = {}
+        self._listeners: List[Callable[[ServiceHealth], None]] = []
+
+    # ------------------------------------------------------------------
+    # Publish
+    # ------------------------------------------------------------------
+
+    def set(
+        self,
+        name: str,
+        status: HealthStatus,
+        detail: str = "",
+        error: Optional[str] = None,
+    ) -> None:
+        """
+        Update the health state for *name*.
+
+        Creates an entry if one does not yet exist.  Notifies registered listeners.
+        """
+        record = ServiceHealth(
+            name=name,
+            status=status,
+            detail=detail,
+            last_updated=time.time(),
+            error=error,
+        )
+        with self._lock:
+            self._services[name] = record
+            listeners = list(self._listeners)
+
+        debug_log(f"health: {name} → {status.value}" + (f" ({detail})" if detail else ""), "health")
+
+        for listener in listeners:
+            try:
+                listener(record)
+            except Exception:
+                pass
+
+    def ready(self, name: str, detail: str = "") -> None:
+        """Convenience: mark *name* as READY."""
+        self.set(name, HealthStatus.READY, detail)
+
+    def degraded(self, name: str, detail: str = "", error: Optional[str] = None) -> None:
+        """Convenience: mark *name* as DEGRADED."""
+        self.set(name, HealthStatus.DEGRADED, detail, error)
+
+    def unavailable(self, name: str, detail: str = "", error: Optional[str] = None) -> None:
+        """Convenience: mark *name* as UNAVAILABLE."""
+        self.set(name, HealthStatus.UNAVAILABLE, detail, error)
+
+    def initialising(self, name: str, detail: str = "") -> None:
+        """Convenience: mark *name* as INITIALISING."""
+        self.set(name, HealthStatus.INITIALISING, detail)
+
+    # ------------------------------------------------------------------
+    # Query
+    # ------------------------------------------------------------------
+
+    def get(self, name: str) -> Optional[ServiceHealth]:
+        """Return the current health record for *name*, or ``None``."""
+        with self._lock:
+            return self._services.get(name)
+
+    def is_ready(self, name: str) -> bool:
+        """Return True only when *name* is READY."""
+        record = self.get(name)
+        return record is not None and record.status == HealthStatus.READY
+
+    def is_operational(self, name: str) -> bool:
+        """Return True when *name* is READY or DEGRADED."""
+        record = self.get(name)
+        return record is not None and record.status in (HealthStatus.READY, HealthStatus.DEGRADED)
+
+    def all_statuses(self) -> Dict[str, ServiceHealth]:
+        """Return a shallow copy of all registered service health records."""
+        with self._lock:
+            return dict(self._services)
+
+    def summary(self) -> Dict[str, str]:
+        """
+        Return a simplified ``{name: status_value}`` dict suitable for
+        serialisation or display.
+        """
+        with self._lock:
+            return {name: h.status.value for name, h in self._services.items()}
+
+    def has_critical_failures(self) -> bool:
+        """
+        Return True if any *critical* subsystem is UNAVAILABLE.
+
+        Critical subsystems are: DATABASE, OLLAMA, WHISPER, MICROPHONE.
+        """
+        critical = {ServiceName.DATABASE, ServiceName.OLLAMA, ServiceName.WHISPER, ServiceName.MICROPHONE}
+        with self._lock:
+            for name, health in self._services.items():
+                if name in critical and health.status == HealthStatus.UNAVAILABLE:
+                    return True
+        return False
+
+    # ------------------------------------------------------------------
+    # Listeners
+    # ------------------------------------------------------------------
+
+    def add_listener(self, callback: Callable[[ServiceHealth], None]) -> None:
+        """Register a callback invoked whenever any service health changes."""
+        with self._lock:
+            self._listeners.append(callback)
+
+    def remove_listener(self, callback: Callable[[ServiceHealth], None]) -> None:
+        with self._lock:
+            try:
+                self._listeners.remove(callback)
+            except ValueError:
+                pass
+
+
+# ---------------------------------------------------------------------------
+# Module-level singleton
+# ---------------------------------------------------------------------------
+
+_registry: Optional[HealthRegistry] = None
+
+
+def configure() -> HealthRegistry:
+    """
+    Create and store the module-level :class:`HealthRegistry`.
+
+    Called once from the service container at daemon startup.
+    """
+    global _registry
+    _registry = HealthRegistry()
+    return _registry
+
+
+def get_registry() -> Optional[HealthRegistry]:
+    """Return the module-level registry, or ``None`` if not configured."""
+    return _registry

--- a/src/jarvis/runtime/runtime.spec.md
+++ b/src/jarvis/runtime/runtime.spec.md
@@ -1,0 +1,77 @@
+# Runtime Package Specification
+
+## Purpose
+
+Provides the service lifecycle infrastructure for the Jarvis daemon:
+health tracking, graceful degradation, and coordinated shutdown.
+
+## Components
+
+### `health.py` — `HealthRegistry`
+
+Thread-safe registry that tracks the operational status of every Jarvis
+subsystem. Each subsystem transitions through:
+
+```
+(not registered) → INITIALISING → READY | DEGRADED | UNAVAILABLE
+```
+
+**Module-level singleton:** `configure()` creates and registers the
+registry; `get_registry()` returns it. The daemon calls `configure()` once
+at startup; all other modules call `get_registry()`.
+
+**Well-known service names** are defined on `ServiceName`:
+`DATABASE`, `OLLAMA`, `WHISPER`, `MICROPHONE`, `TTS`, `MCP`, `LOCATION`,
+`POLICY`, `AUDIT`, `VOICE`.
+
+`health.summary()` returns a one-line human-readable status string
+suitable for log output.
+
+### `shutdown_manager.py` — `ShutdownManager`
+
+Coordinates orderly shutdown:
+1. Flushes the diary (with a configurable `shutdown_diary_timeout_sec`).
+2. Stops TTS.
+3. Closes the audit recorder.
+4. Closes the database.
+
+Registered services are shut down in reverse dependency order to avoid
+use-after-free.
+
+## Service Initialisation
+
+Services are initialised directly in `daemon.py` in dependency order.
+Each initialisation step is wrapped in `try/except` so that a failure
+marks the service as `DEGRADED` or `UNAVAILABLE` rather than aborting
+startup.
+
+**Initialisation order (in `daemon.py`):**
+1. Health registry
+2. Policy engine + approval store
+3. Audit recorder (opt-in via `audit_db_path`)
+4. Main database + dialogue memory
+5. TTS engine
+6. MCP tool discovery
+7. Location service probe
+
+## Configuration Fields Used
+
+| Field                       | Type    | Default | Effect                                  |
+|-----------------------------|---------|---------|-----------------------------------------|
+| `shutdown_diary_timeout_sec`| `float` | `5.0`   | Maximum time to wait for diary flush    |
+
+## Health States
+
+| State            | Meaning                                                  |
+|------------------|----------------------------------------------------------|
+| `INITIALISING`   | Service is starting up                                   |
+| `READY`          | Service is fully operational                             |
+| `DEGRADED`       | Partial operation; some features may be unavailable      |
+| `UNAVAILABLE`    | Service is not available; dependent features are disabled|
+
+## Graceful Degradation Guarantee
+
+Every service initialisation in `daemon.py` catches all exceptions and
+marks the affected service as `DEGRADED` or `UNAVAILABLE`. The daemon
+will always reach a running state even if optional services (TTS, MCP,
+audit, location) fail to initialise.

--- a/src/jarvis/runtime/runtime.spec.md
+++ b/src/jarvis/runtime/runtime.spec.md
@@ -29,6 +29,13 @@ suitable for log output.
 
 ### `shutdown_manager.py` — `ShutdownManager`
 
+> **⚠️ NOT YET INTEGRATED.** The daemon's shutdown path does not call
+> `ShutdownManager.shutdown()` yet; it retains its own inline shutdown
+> sequence with a fixed diary timeout, so `shutdown_diary_timeout_sec`
+> currently has no effect. The health registry, by contrast, IS wired:
+> the daemon `configure()`s it at startup, though only the `policy` and
+> `audit` services currently record readiness.
+
 Coordinates orderly shutdown:
 1. Flushes the diary (with a configurable `shutdown_diary_timeout_sec`).
 2. Stops TTS.

--- a/src/jarvis/runtime/shutdown_manager.py
+++ b/src/jarvis/runtime/shutdown_manager.py
@@ -1,0 +1,243 @@
+"""
+Shutdown manager — coordinates orderly daemon shutdown.
+
+Responsibilities
+----------------
+1. Stop the voice listener (sets stop flag and joins thread).
+2. Stop the TTS engine.
+3. Flush pending audit records.
+4. Perform the diary update (with configurable timeout).
+5. Close databases.
+6. Report final health status.
+
+The manager is agnostic to the desktop-app IPC layer; callbacks
+for diary progress can be injected so the desktop layer can display
+live update progress without coupling to this module.
+
+Usage::
+
+    manager = ShutdownManager(cfg, services)
+    manager.add_diary_callbacks(on_token=..., on_complete=...)
+    manager.shutdown(timeout_sec=60.0)
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from typing import Callable, Optional
+
+from ..debug import debug_log
+from .health import HealthRegistry, HealthStatus, ServiceName
+
+
+class ShutdownManager:
+    """
+    Coordinates a graceful daemon shutdown.
+
+    Args:
+        cfg: Settings object.
+        health: :class:`~jarvis.runtime.health.HealthRegistry` instance.
+    """
+
+    def __init__(self, cfg, health: Optional[HealthRegistry] = None) -> None:
+        self._cfg = cfg
+        self._health = health
+        self._lock = threading.Lock()
+        self._shutdown_complete = threading.Event()
+
+        # Optional service references set by the service container
+        self._voice_listener = None
+        self._tts_engine = None
+        self._dialogue_memory = None
+        self._db = None
+        self._audit_recorder = None
+
+        # Optional callbacks for diary update progress (used by desktop app)
+        self._on_token: Optional[Callable[[str], None]] = None
+        self._on_status: Optional[Callable[[str], None]] = None
+        self._on_chunks: Optional[Callable[[list], None]] = None
+        self._on_complete: Optional[Callable[[bool], None]] = None
+
+    # ------------------------------------------------------------------
+    # Service registration
+    # ------------------------------------------------------------------
+
+    def register_voice_listener(self, listener) -> None:
+        self._voice_listener = listener
+
+    def register_tts(self, engine) -> None:
+        self._tts_engine = engine
+
+    def register_dialogue_memory(self, memory) -> None:
+        self._dialogue_memory = memory
+
+    def register_db(self, db) -> None:
+        self._db = db
+
+    def register_audit_recorder(self, recorder) -> None:
+        self._audit_recorder = recorder
+
+    def add_diary_callbacks(
+        self,
+        on_token: Optional[Callable[[str], None]] = None,
+        on_status: Optional[Callable[[str], None]] = None,
+        on_chunks: Optional[Callable[[list], None]] = None,
+        on_complete: Optional[Callable[[bool], None]] = None,
+    ) -> None:
+        """Register callbacks for diary update progress (used by desktop layer)."""
+        self._on_token = on_token
+        self._on_status = on_status
+        self._on_chunks = on_chunks
+        self._on_complete = on_complete
+
+    # ------------------------------------------------------------------
+    # Main shutdown entry point
+    # ------------------------------------------------------------------
+
+    def shutdown(self, timeout_sec: float = 60.0) -> None:
+        """
+        Perform a full coordinated shutdown within *timeout_sec* seconds.
+
+        Steps are executed in order.  Each step catches its own exceptions
+        so that a failure in one step does not prevent later steps from
+        running.
+        """
+        debug_log("shutdown manager: beginning shutdown sequence", "shutdown")
+        start = time.time()
+
+        self._stop_voice_listener()
+        self._stop_tts()
+        self._flush_diary(timeout_remaining=max(0.0, timeout_sec - (time.time() - start)))
+        self._flush_audit()
+        self._close_db()
+
+        self._shutdown_complete.set()
+        debug_log(
+            f"shutdown manager: complete in {(time.time() - start):.1f}s", "shutdown"
+        )
+
+    def wait_complete(self, timeout: float = 70.0) -> bool:
+        """Block until shutdown is complete or *timeout* elapses."""
+        return self._shutdown_complete.wait(timeout=timeout)
+
+    # ------------------------------------------------------------------
+    # Individual shutdown steps
+    # ------------------------------------------------------------------
+
+    def _stop_voice_listener(self) -> None:
+        if not self._voice_listener:
+            return
+        try:
+            debug_log("shutdown: stopping voice listener", "shutdown")
+            if hasattr(self._voice_listener, "stop"):
+                self._voice_listener.stop()
+        except Exception as exc:
+            debug_log(f"shutdown: voice listener stop error: {exc}", "shutdown")
+        finally:
+            if self._health:
+                self._health.set(ServiceName.VOICE, HealthStatus.UNAVAILABLE, "stopped")
+
+    def _stop_tts(self) -> None:
+        if not self._tts_engine:
+            return
+        try:
+            debug_log("shutdown: stopping TTS", "shutdown")
+            if hasattr(self._tts_engine, "stop"):
+                self._tts_engine.stop()
+        except Exception as exc:
+            debug_log(f"shutdown: TTS stop error: {exc}", "shutdown")
+        finally:
+            if self._health:
+                self._health.set(ServiceName.TTS, HealthStatus.UNAVAILABLE, "stopped")
+
+    def _flush_diary(self, timeout_remaining: float = 45.0) -> None:
+        """
+        Attempt a diary update with a bounded timeout.
+
+        Falls back gracefully if the LLM is unavailable or the timeout elapses.
+        """
+        if not self._dialogue_memory or not self._db:
+            debug_log("shutdown: no dialogue memory — skipping diary flush", "shutdown")
+            if self._on_complete:
+                try:
+                    self._on_complete(False)
+                except Exception:
+                    pass
+            return
+
+        timeout = min(timeout_remaining, getattr(self._cfg, "shutdown_diary_timeout_sec", 5.0))
+
+        debug_log(f"shutdown: flushing diary (timeout={timeout:.0f}s)", "shutdown")
+
+        # Notify UI about pending chunks before blocking LLM call
+        if self._on_chunks:
+            try:
+                pending = self._dialogue_memory.get_pending_chunks() if self._dialogue_memory else []
+                self._on_chunks(pending)
+            except Exception:
+                pass
+        if self._on_status:
+            try:
+                self._on_status("Writing diary entry…")
+            except Exception:
+                pass
+
+        result = [False]
+        done_event = threading.Event()
+
+        def _do_flush():
+            try:
+                from ..memory.conversation import update_diary_from_dialogue_memory
+                cfg = self._cfg
+                update_diary_from_dialogue_memory(
+                    db=self._db,
+                    dialogue_memory=self._dialogue_memory,
+                    ollama_base_url=getattr(cfg, "ollama_base_url", "http://localhost:11434"),
+                    ollama_chat_model=getattr(cfg, "ollama_chat_model", ""),
+                    ollama_embed_model=getattr(cfg, "ollama_embed_model", ""),
+                    source_app="voice",
+                    voice_debug=getattr(cfg, "voice_debug", False),
+                    timeout_sec=timeout,
+                    force=True,
+                    on_token=self._on_token,
+                )
+                result[0] = True
+                debug_log("shutdown: diary flush succeeded", "shutdown")
+            except Exception as exc:
+                debug_log(f"shutdown: diary flush failed: {exc}", "shutdown")
+            finally:
+                done_event.set()
+
+        t = threading.Thread(target=_do_flush, daemon=True, name="diary-flush")
+        t.start()
+        completed = done_event.wait(timeout=timeout)
+        if not completed:
+            debug_log("shutdown: diary flush timed out — proceeding without full diary", "shutdown")
+
+        if self._on_complete:
+            try:
+                self._on_complete(result[0])
+            except Exception:
+                pass
+
+    def _flush_audit(self) -> None:
+        """Close the audit recorder gracefully."""
+        if not self._audit_recorder:
+            return
+        try:
+            debug_log("shutdown: closing audit recorder", "shutdown")
+            if hasattr(self._audit_recorder, "close"):
+                self._audit_recorder.close()
+        except Exception as exc:
+            debug_log(f"shutdown: audit recorder close error: {exc}", "shutdown")
+
+    def _close_db(self) -> None:
+        if not self._db:
+            return
+        try:
+            debug_log("shutdown: closing database", "shutdown")
+            if hasattr(self._db, "close"):
+                self._db.close()
+        except Exception as exc:
+            debug_log(f"shutdown: db close error: {exc}", "shutdown")

--- a/src/jarvis/task_state.py
+++ b/src/jarvis/task_state.py
@@ -1,0 +1,264 @@
+"""
+Task State – session-scoped execution tracker.
+
+Maintains the active task state during multi-step workflow execution,
+supporting resumption within a session and providing clear execution
+visibility for the desktop console.
+
+Design principles:
+- Stays in memory for the lifetime of the session (no persistence by default)
+- Thread-safe via a simple lock
+- Lightweight: does not drive execution, only observes and records it
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+import uuid
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import List, Optional
+
+from .debug import debug_log
+
+
+class TaskStatus(Enum):
+    """Overall lifecycle of a task."""
+    IDLE = "idle"
+    PLANNING = "planning"
+    EXECUTING = "executing"
+    REVERSIBLE = "reversible"   # Completed; last action(s) can still be undone
+    DONE = "done"
+    FAILED = "failed"
+
+    # Backwards-compat alias so existing callers don't break during migration
+    AWAITING_APPROVAL = "reversible"
+
+
+class StepStatus(Enum):
+    """Lifecycle of a single execution step."""
+    PENDING = "pending"
+    RUNNING = "running"
+    SUCCEEDED = "succeeded"
+    REVERSIBLE = "reversible"   # Succeeded; registered in UndoRegistry
+    REVERSED = "reversed"       # Was undone by the user
+    FAILED = "failed"
+    SKIPPED = "skipped"
+
+
+@dataclass
+class TaskStep:
+    """A single step in an execution plan."""
+    description: str
+    tool_name: Optional[str] = None
+    status: StepStatus = StepStatus.PENDING
+    result_summary: Optional[str] = None
+    started_at: Optional[float] = None
+    finished_at: Optional[float] = None
+    # Unique identifier — used to link this step to an UndoEntry
+    step_id: str = field(default_factory=lambda: uuid.uuid4().hex)
+    # Set to True when a matching UndoEntry has been pushed to the registry
+    reversible: bool = False
+    undo_entry_id: Optional[str] = None
+
+    def start(self) -> None:
+        self.status = StepStatus.RUNNING
+        self.started_at = time.time()
+
+    def complete(self, result_summary: Optional[str] = None) -> None:
+        self.status = StepStatus.SUCCEEDED
+        self.result_summary = result_summary
+        self.finished_at = time.time()
+
+    def mark_reversible(self, undo_entry_id: str) -> None:
+        """
+        Transition a completed step to REVERSIBLE status.
+
+        Called by the engine after pushing an UndoEntry to the registry
+        so that the task log reflects that this step can still be undone.
+        """
+        self.status = StepStatus.REVERSIBLE
+        self.reversible = True
+        self.undo_entry_id = undo_entry_id
+        debug_log(f"step marked reversible: {self.description[:60]}", "task")
+
+    def mark_reversed(self, result_summary: Optional[str] = None) -> None:
+        """
+        Transition a reversible step to REVERSED status.
+
+        Called by the engine after a successful undo execution so the
+        task history accurately reflects that this step was undone.
+        """
+        self.status = StepStatus.REVERSED
+        self.result_summary = result_summary or "undone by user"
+        debug_log(f"step reversed: {self.description[:60]}", "task")
+
+    def fail(self, reason: Optional[str] = None) -> None:
+        self.status = StepStatus.FAILED
+        self.result_summary = reason
+        self.finished_at = time.time()
+
+    def skip(self, reason: Optional[str] = None) -> None:
+        self.status = StepStatus.SKIPPED
+        self.result_summary = reason
+        self.finished_at = time.time()
+
+
+@dataclass
+class TaskState:
+    """
+    Session-scoped state for the currently executing task.
+
+    Tracks the active intent, execution steps, and overall status so
+    that the desktop console can display real-time progress and the
+    engine can detect resumption opportunities.
+    """
+    task_id: str = field(default_factory=lambda: uuid.uuid4().hex)
+    intent: str = ""
+    status: TaskStatus = TaskStatus.IDLE
+    steps: List[TaskStep] = field(default_factory=list)
+    started_at: Optional[float] = None
+    finished_at: Optional[float] = None
+    error: Optional[str] = None
+
+    def begin(self, intent: str) -> None:
+        """Start tracking a new task."""
+        self.task_id = uuid.uuid4().hex
+        self.intent = intent
+        self.status = TaskStatus.PLANNING
+        self.steps = []
+        self.started_at = time.time()
+        self.finished_at = None
+        self.error = None
+        debug_log(f"task started: {intent[:80]}", "task")
+
+    def set_executing(self) -> None:
+        """Transition from planning to active execution."""
+        self.status = TaskStatus.EXECUTING
+        debug_log("task executing", "task")
+
+    def set_reversible(self) -> None:
+        """
+        Mark the task as completed with at least one reversible action.
+
+        Set this instead of ``complete()`` when the engine has pushed one
+        or more ``UndoEntry`` objects to the ``UndoRegistry``.
+        """
+        self.status = TaskStatus.REVERSIBLE
+        self.finished_at = time.time()
+        debug_log("task done (reversible actions registered)", "task")
+
+    # Backwards-compat aliases
+    def set_awaiting_approval(self) -> None:
+        """Deprecated — use set_reversible() instead."""
+        self.set_reversible()
+
+    def set_approved(self) -> None:
+        """Deprecated — previously resumed approval-gated execution."""
+        if self.status == TaskStatus.REVERSIBLE:
+            self.status = TaskStatus.EXECUTING
+            debug_log("task approved (compat) — resuming execution", "task")
+
+    def add_step(self, description: str, tool_name: Optional[str] = None) -> TaskStep:
+        """Add and return a new pending step."""
+        step = TaskStep(description=description, tool_name=tool_name)
+        self.steps.append(step)
+        debug_log(f"step added: {description[:60]}", "task")
+        return step
+
+    def complete(self) -> None:
+        """Mark the task as successfully completed."""
+        self.status = TaskStatus.DONE
+        self.finished_at = time.time()
+        debug_log("task done", "task")
+
+    def fail(self, reason: Optional[str] = None) -> None:
+        """Mark the task as failed."""
+        self.status = TaskStatus.FAILED
+        self.error = reason
+        self.finished_at = time.time()
+        debug_log(f"task failed: {reason}", "task")
+
+    def reset(self) -> None:
+        """Return to idle state (between conversations)."""
+        self.intent = ""
+        self.status = TaskStatus.IDLE
+        self.steps = []
+        self.started_at = None
+        self.finished_at = None
+        self.error = None
+        debug_log("task reset to idle", "task")
+
+    def can_resume(self) -> bool:
+        """
+        Returns True when a task was interrupted and has pending steps
+        that could be continued in the same session.
+        """
+        if self.status not in (TaskStatus.EXECUTING,):
+            return False
+        return any(s.status == StepStatus.PENDING for s in self.steps)
+
+    def can_undo(self) -> bool:
+        """
+        Returns True when the task completed with at least one reversible
+        step that has not yet been undone or expired.
+        """
+        return self.status == TaskStatus.REVERSIBLE and any(
+            s.status == StepStatus.REVERSIBLE for s in self.steps
+        )
+
+    @property
+    def completed_steps(self) -> List[TaskStep]:
+        return [
+            s for s in self.steps
+            if s.status in (StepStatus.SUCCEEDED, StepStatus.REVERSIBLE)
+        ]
+
+    @property
+    def reversible_steps(self) -> List[TaskStep]:
+        """Steps that completed successfully and can still be undone."""
+        return [s for s in self.steps if s.status == StepStatus.REVERSIBLE]
+
+    @property
+    def failed_steps(self) -> List[TaskStep]:
+        return [s for s in self.steps if s.status == StepStatus.FAILED]
+
+    def summary(self) -> str:
+        """Human-readable summary suitable for debug output."""
+        parts = [f"Task: {self.intent[:60]}", f"Status: {self.status.value}"]
+        if self.steps:
+            parts.append(f"Steps: {len(self.completed_steps)}/{len(self.steps)} completed")
+        rev = len(self.reversible_steps)
+        if rev:
+            parts.append(f"Reversible: {rev}")
+        if self.error:
+            parts.append(f"Error: {self.error[:60]}")
+        return " | ".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Module-level singleton – one active task per daemon session
+# ---------------------------------------------------------------------------
+
+_active_task: TaskState = TaskState()
+_task_lock = threading.Lock()
+
+
+def get_active_task() -> TaskState:
+    """Return the singleton active task state (thread-safe read)."""
+    with _task_lock:
+        return _active_task
+
+
+def begin_task(intent: str) -> TaskState:
+    """Begin a new task, resetting any previous state."""
+    with _task_lock:
+        _active_task.begin(intent)
+        return _active_task
+
+
+def reset_task() -> None:
+    """Reset the active task to idle."""
+    with _task_lock:
+        _active_task.reset()

--- a/src/jarvis/task_state.spec.md
+++ b/src/jarvis/task_state.spec.md
@@ -1,0 +1,304 @@
+﻿# Task State, Approval & Undo Spec
+
+This document specifies the task state tracker, risk assessment, and undo
+registry introduced to implement the JARVIS autonomy requirements.
+
+## Modules
+
+| Module | Path |
+|--------|------|
+| Task State | `src/jarvis/task_state.py` |
+| Approval / Risk | `src/jarvis/approval.py` |
+| Undo Registry | `src/jarvis/undo_registry.py` |
+
+---
+
+## 1. Task State (`task_state.py`)
+
+### Purpose
+
+Tracks the active task during multi-step workflow execution so that:
+- The desktop console can display real-time progress.
+- The engine can detect when a task is resumable within a session.
+- Debug logs contain a structured summary of what was executed.
+- Reversible actions are visible in the task history.
+
+### Lifecycle
+
+```
+IDLE -> PLANNING -> EXECUTING -> DONE
+                             -> REVERSIBLE   (completed; undo window open)
+                             -> FAILED
+```
+
+`REVERSIBLE` is a terminal variant of `DONE`. The task completed successfully
+but at least one step has a matching `UndoEntry` in the registry that has not
+yet expired.
+
+### TaskStatus
+
+| Value | Meaning |
+|-------|---------|
+| `IDLE` | No active task |
+| `PLANNING` | Intent recorded, steps not yet running |
+| `EXECUTING` | Tool steps are executing |
+| `REVERSIBLE` | Completed; last action(s) can still be undone |
+| `DONE` | Completed successfully, no undo pending |
+| `FAILED` | Terminated with an error |
+
+> `TaskStatus.AWAITING_APPROVAL` is kept as a backwards-compat alias for
+> `TaskStatus.REVERSIBLE`. New code should use `REVERSIBLE`.
+
+### StepStatus
+
+| Value | Meaning |
+|-------|---------|
+| `PENDING` | Step queued, not yet started |
+| `RUNNING` | Step is executing |
+| `SUCCEEDED` | Completed successfully (no undo registered) |
+| `REVERSIBLE` | Completed successfully; `UndoEntry` registered in registry |
+| `REVERSED` | Was successfully undone by the user |
+| `FAILED` | Terminated with an error |
+| `SKIPPED` | Deliberately bypassed |
+
+### TaskStep
+
+Each tool execution is recorded as a `TaskStep`:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `description` | str | Human-readable step description |
+| `tool_name` | Optional[str] | Tool identifier |
+| `status` | StepStatus | Current lifecycle status |
+| `result_summary` | Optional[str] | First 120 chars of result or error |
+| `started_at` | Optional[float] | Unix timestamp when step started |
+| `finished_at` | Optional[float] | Unix timestamp when step completed |
+| `step_id` | str | UUID hex -- links this step to its `UndoEntry` |
+| `reversible` | bool | True when a matching `UndoEntry` exists in the registry |
+| `undo_entry_id` | Optional[str] | `UndoEntry.step_id` of the registered undo |
+
+**Methods:**
+- `start()` -- transition to RUNNING
+- `complete(result_summary)` -- transition to SUCCEEDED
+- `mark_reversible(undo_entry_id)` -- transition to REVERSIBLE after undo pushed
+- `mark_reversed(result_summary)` -- transition to REVERSED after undo executed
+- `fail(reason)` -- transition to FAILED
+- `skip(reason)` -- transition to SKIPPED
+
+### TaskState methods
+
+| Method | Description |
+|--------|-------------|
+| `begin(intent)` | Reset and start a new task |
+| `set_executing()` | Transition PLANNING -> EXECUTING |
+| `set_reversible()` | Transition EXECUTING -> REVERSIBLE (at least one reversible step) |
+| `complete()` | Transition EXECUTING -> DONE |
+| `fail(reason)` | Transition -> FAILED |
+| `reset()` | Return to IDLE |
+| `can_resume()` | True when EXECUTING and pending steps remain |
+| `can_undo()` | True when REVERSIBLE and at least one REVERSIBLE step exists |
+| `add_step(...)` | Append a new PENDING step |
+
+### Properties
+
+| Property | Description |
+|----------|-------------|
+| `completed_steps` | Steps with status SUCCEEDED or REVERSIBLE |
+| `reversible_steps` | Steps with status REVERSIBLE |
+| `failed_steps` | Steps with status FAILED |
+
+### Module-Level Singleton
+
+```python
+from jarvis.task_state import begin_task, get_active_task, reset_task
+```
+
+- `begin_task(intent)` -- resets and begins a new task; returns the singleton.
+- `get_active_task()` -- returns the current singleton (thread-safe).
+- `reset_task()` -- returns to IDLE state.
+
+---
+
+## 2. Approval / Risk (`approval.py`)
+
+### Purpose
+
+Implements the **Decision Policy**:
+- Act automatically on clear, specific instructions.
+- Warn the user before truly irreversible destructive actions.
+- Register an undo entry after reversible destructive actions.
+- Never block execution waiting for approval -- Jarvis is voice-first and hands-free.
+
+### Risk Levels
+
+| Level | Meaning | Engine behaviour |
+|-------|---------|-----------------|
+| `SAFE` | Read-only / clearly reversible | Execute silently |
+| `MODERATE` | Writes that are easily undone | Execute; register undo silently |
+| `HIGH` + undoable | Destructive, state can be restored | Execute; register undo; speak "say undo" note |
+| `HIGH` + irreversible | Destructive, state cannot be restored | Speak brief warning, then execute |
+
+### Per-Tool Risk Table
+
+| Tool | Risk |
+|------|------|
+| `screenshot` | SAFE |
+| `recallConversation` | SAFE |
+| `fetchMeals` | SAFE |
+| `webSearch` | SAFE |
+| `fetchWebPage` | SAFE |
+| `getWeather` | SAFE |
+| `refreshMCPTools` | SAFE |
+| `stop` | SAFE |
+| `logMeal` | MODERATE |
+| `deleteMeal` | HIGH |
+| `localFiles` (list/read) | SAFE |
+| `localFiles` (write/append) | MODERATE |
+| `localFiles` (delete) | HIGH |
+| MCP tools | MODERATE (default) |
+| Unknown tools | MODERATE (cautious default) |
+
+### Undoable Operations
+
+| Tool / Operation | Undoable | Requires Snapshot |
+|-----------------|----------|-------------------|
+| `localFiles / write` | Yes | Yes (original file content) |
+| `localFiles / append` | Yes | Yes (original file content) |
+| `localFiles / delete` | Yes | Yes (file content before deletion) |
+| `logMeal` | No (future work) | -- |
+| `deleteMeal` | No (future work) | -- |
+| All MCP tools | No | -- |
+
+### Public API
+
+```python
+from jarvis.approval import (
+    RiskLevel,               # Enum: SAFE, MODERATE, HIGH
+    RequestType,             # Enum: INFORMATIONAL, OPERATIONAL
+    assess_risk,             # (tool_name, tool_args) -> RiskLevel
+    is_undoable,             # (tool_name, tool_args) -> bool
+    pre_execution_warning,   # (tool_name, tool_args) -> Optional[str]
+    post_execution_note,     # (tool_name, tool_args) -> Optional[str]
+    build_undo_args,         # (tool_name, tool_args, snapshot) -> Optional[tuple]
+    classify_request,        # (text) -> RequestType
+)
+```
+
+---
+
+## 3. Undo Registry (`undo_registry.py`)
+
+### Purpose
+
+Maintains a session-scoped, time-bounded stack of reversible operations so
+that users can say "undo that" or "undo the last 3 actions" after a task
+completes.
+
+### UndoEntry
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `step_id` | str | Matches the `TaskStep.step_id` that created it |
+| `description` | str | Human-readable, e.g. "deleted shopping_list.txt" |
+| `tool_name` | str | Tool that was executed |
+| `tool_args` | dict | Original arguments |
+| `undo_tool` | str | Tool to call for reversal |
+| `undo_args` | dict | Arguments for the reversal call |
+| `snapshot` | Optional[Any] | State captured before execution |
+| `created_at` | float | Unix timestamp |
+| `expires_at` | float | Unix timestamp; default +300 seconds |
+
+### UndoRegistry methods
+
+| Method | Description |
+|--------|-------------|
+| `push(entry)` | Add entry; prune expired; cap at MAX_ENTRIES (20) |
+| `pop_last(n=1)` | Remove and return last n non-expired entries, most-recent first |
+| `pop_by_id(step_id)` | Remove and return entry with matching step_id |
+| `peek_all()` | View all non-expired entries without removing |
+| `clear()` | Empty the stack |
+| `size` | Count of non-expired entries |
+
+### Singleton access
+
+```python
+from jarvis.undo_registry import (
+    get_undo_registry,    # -> UndoRegistry singleton
+    push_undo,            # (entry) -> None
+    pop_last_undo,        # (n=1) -> List[UndoEntry]  (most-recent first)
+    pop_undo_by_id,       # (step_id) -> Optional[UndoEntry]
+)
+```
+
+---
+
+## 4. Undo Tool (`tools/builtin/undo.py`)
+
+### Purpose
+
+Provides language-agnostic undo support as a builtin tool. The LLM selects
+`undo` through the normal tool-use protocol when the user asks to reverse,
+revert, or take back a previous action — in any language.
+
+This replaces the earlier approach of detecting undo intent via English-only
+regex patterns (`_detect_undo_intent`), which violated the language-agnostic
+requirement.
+
+### Input Schema
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `count` | integer | Number of recent actions to undo (default 1, max 20) |
+| `step_id` | string | Specific step ID to undo (overrides count if provided) |
+
+### Behaviour
+
+1. If `step_id` is provided, pop that specific entry from the undo registry.
+2. Otherwise, pop the last `count` entries (most-recent first).
+3. For each entry, execute the reversal tool via `run_tool_with_retries`.
+4. Return a summary of what was reversed (or "nothing to undo").
+
+### Risk Level
+
+`MODERATE` — the undo itself is a write operation but is always user-initiated.
+
+---
+
+## 5. Integration with Reply Engine
+
+```
+run_reply_engine(text, ...)
+  |-- redact(text)
+  |-- classify_request(redacted)
+  |-- begin_task(redacted)
+  |-- [profile selection, enrichment, messages build]
+  |-- task.set_executing()
+  `-- agentic loop:
+       `-- for each tool call:
+            |-- policy evaluation
+            |-- pre_execution_warning()   <- spoken before HIGH+irreversible
+            |-- _capture_snapshot()       <- reads original state if undoable
+            |-- step = task.add_step(...)
+            |-- step.start()
+            |-- run_tool_with_retries(tool_name, tool_args)
+            |   (if tool_name == "undo", UndoTool handles registry pop + reversal)
+            |-- step.complete(result)
+            |-- [if undoable and snapshot available]:
+            |    |-- build_undo_args(tool_name, tool_args, snapshot)
+            |    |-- push_undo(UndoEntry(...))
+            |    |-- step.mark_reversible(entry.step_id)
+            |    `-- _post_notes.append(post_execution_note())
+            `-- step.fail(err)
+  |-- if task.reversible_steps: task.set_reversible()
+  |   else: task.complete()
+  `-- reply = pre_warnings + llm_reply + post_notes
+```
+
+---
+
+## 6. Testing
+
+- **`tests/test_task_state.py`** -- unit tests for `TaskState`, `TaskStep`, the singleton, `can_undo()`, reversible/reversed step transitions.
+- **`tests/test_approval.py`** -- unit tests for `assess_risk`, `is_undoable`, `pre_execution_warning`, `post_execution_note`, `build_undo_args`, `classify_request`.
+- **`tests/test_undo_registry.py`** -- unit tests for `UndoRegistry`: push, pop_last, pop_by_id, expiry, multi-pop ordering, cap enforcement.
+- **`tests/test_undo_tool.py`** -- unit tests for the `UndoTool`: empty registry returns "nothing to undo", single undo pops and executes reversal, count parameter undoes N entries, step_id targets a specific entry, handles reversal tool failures gracefully.

--- a/src/jarvis/tools/base.py
+++ b/src/jarvis/tools/base.py
@@ -6,7 +6,8 @@ ensuring consistency with MCP tool format and enabling dictionary-based executio
 
 from abc import ABC, abstractmethod
 from typing import Dict, Any, Optional, Callable
-from .types import ToolExecutionResult
+from .types import RiskLevel, ToolExecutionResult
+from ..policy.models import ToolClass
 
 
 class ToolContext:
@@ -69,6 +70,35 @@ class Tool(ABC):
     def inputSchema(self) -> Dict[str, Any]:
         """JSON Schema for tool arguments (matches MCP format)."""
         pass
+
+    def classify(self, args: Optional[Dict[str, Any]] = None) -> ToolClass:
+        """Return the :class:`ToolClass` for this tool with the given args.
+
+        The default implementation returns ``ToolClass.WRITE_OPERATIONAL``.
+        Override in subclasses whose classification differs or varies by
+        argument (e.g. ``localFiles`` read vs write).
+        """
+        return ToolClass.WRITE_OPERATIONAL
+
+    def assess_risk(self, args: Optional[Dict[str, Any]] = None) -> RiskLevel:
+        """Return the risk level for executing this tool with the given args.
+
+        The default implementation returns ``RiskLevel.MODERATE``.  Tools that
+        are known to be read-only should override this to return
+        ``RiskLevel.SAFE``; tools whose risk depends on a particular argument
+        value (e.g. the ``operation`` field of ``localFiles``) should inspect
+        ``args`` and return the appropriate level.
+
+        Keeping risk information here ensures it stays co-located with the tool
+        that owns it and is not duplicated in a separate mapping elsewhere.
+
+        Args:
+            args: Arguments that will be passed to ``run``, or ``None``.
+
+        Returns:
+            RiskLevel for this tool/args combination.
+        """
+        return RiskLevel.MODERATE
 
     @abstractmethod
     def run(self, args: Optional[Dict[str, Any]], context: ToolContext) -> ToolExecutionResult:

--- a/src/jarvis/tools/builtin/fetch_web_page.py
+++ b/src/jarvis/tools/builtin/fetch_web_page.py
@@ -4,7 +4,7 @@ import requests
 from typing import Dict, Any, Optional
 from ...debug import debug_log
 from ..base import Tool, ToolContext
-from ..types import ToolExecutionResult
+from ..types import RiskLevel, ToolExecutionResult
 
 
 class FetchWebPageTool(Tool):
@@ -28,6 +28,13 @@ class FetchWebPageTool(Tool):
             },
             "required": ["url"]
         }
+
+    def classify(self, args=None):
+        from ...policy.models import ToolClass
+        return ToolClass.READ_ONLY_OPERATIONAL
+
+    def assess_risk(self, args: Optional[Dict[str, Any]] = None) -> RiskLevel:
+        return RiskLevel.SAFE
 
     def run(self, args: Optional[Dict[str, Any]], context: ToolContext) -> ToolExecutionResult:
         """Fetch and extract content from a web page."""

--- a/src/jarvis/tools/builtin/local_files.py
+++ b/src/jarvis/tools/builtin/local_files.py
@@ -4,11 +4,13 @@ import os
 from pathlib import Path
 from typing import Dict, Any, Optional
 from ..base import Tool, ToolContext
-from ..types import ToolExecutionResult
+from ..types import RiskLevel, ToolExecutionResult
+from ...policy.path_guard import resolve_and_validate_path
+from ...policy.models import AccessMode, PolicyDeniedError
 
 
 class LocalFilesTool(Tool):
-    """Tool for safe local file operations within user's home directory."""
+    """Tool for safe local file operations, constrained to configured workspace roots."""
 
     @property
     def name(self) -> str:
@@ -16,7 +18,7 @@ class LocalFilesTool(Tool):
 
     @property
     def description(self) -> str:
-        return "Safely read, write, list, append, or delete files within your home directory."
+        return "Safely read, write, list, append, or delete files within configured workspace roots."
 
     @property
     def inputSchema(self) -> Dict[str, Any]:
@@ -24,7 +26,7 @@ class LocalFilesTool(Tool):
             "type": "object",
             "properties": {
                 "operation": {"type": "string", "description": "Operation to perform: list, read, write, append, delete"},
-                "path": {"type": "string", "description": "File or directory path (relative to home directory)"},
+                "path": {"type": "string", "description": "File or directory path (relative to home directory or absolute workspace path)"},
                 "content": {"type": "string", "description": "Content to write/append (for write/append operations)"},
                 "glob": {"type": "string", "description": "Glob pattern for listing (default: *)"},
                 "recursive": {"type": "boolean", "description": "Whether to search recursively (for list operation)"}
@@ -32,30 +34,49 @@ class LocalFilesTool(Tool):
             "required": ["operation", "path"]
         }
 
+    def classify(self, args=None):
+        from ...policy.models import ToolClass
+        operation = str((args or {}).get("operation", "")).lower()
+        _op_class = {
+            "list": ToolClass.INFORMATIONAL,
+            "read": ToolClass.INFORMATIONAL,
+            "write": ToolClass.WRITE_OPERATIONAL,
+            "append": ToolClass.WRITE_OPERATIONAL,
+            "delete": ToolClass.DESTRUCTIVE,
+        }
+        return _op_class.get(operation, ToolClass.WRITE_OPERATIONAL)
+
+    def assess_risk(self, args: Optional[Dict[str, Any]] = None) -> RiskLevel:
+        """Return the risk level for this file operation."""
+        operation = str((args or {}).get("operation", "")).lower()
+        if operation in ("list", "read"):
+            return RiskLevel.SAFE
+        if operation in ("write", "append"):
+            return RiskLevel.MODERATE
+        if operation == "delete":
+            return RiskLevel.HIGH
+        return RiskLevel.MODERATE  # Unknown operation
+
     def run(self, args: Optional[Dict[str, Any]], context: ToolContext) -> ToolExecutionResult:
         """Execute the local files tool."""
         try:
-            # Safety: restrict to user's home directory by default
-            home_root = Path(os.path.expanduser("~")).resolve()
+            cfg = context.cfg if context else None
 
-            def _expand_user_path(p: str) -> str:
-                if not isinstance(p, str):
-                    return str(p)
-                if p == "~":
-                    return os.path.expanduser("~")
-                if p.startswith("~/") or p.startswith("~\\"):
-                    return os.path.join(os.path.expanduser("~"), p[2:])
-                return os.path.expanduser(p)
-
-            def _resolve_safe(p: str) -> Path:
-                resolved = Path(_expand_user_path(p)).resolve()
+            def _resolve_safe(p: str, access_mode: AccessMode) -> Path:
+                """Resolve path via the policy path guard using current config."""
                 try:
-                    # Allow exactly the home root or its descendants
-                    if resolved == home_root or str(resolved).startswith(str(home_root) + os.sep):
-                        return resolved
-                except Exception:
-                    pass
-                raise PermissionError(f"Path not allowed: {resolved}")
+                    return resolve_and_validate_path(
+                        p,
+                        access_mode,
+                        workspace_roots=getattr(cfg, "workspace_roots", None),
+                        blocked_roots=getattr(cfg, "blocked_roots", None),
+                        read_only_roots=getattr(cfg, "read_only_roots", None),
+                        local_files_mode=getattr(cfg, "local_files_mode", "home_only"),
+                    )
+                except PolicyDeniedError:
+                    raise
+                except Exception as exc:
+                    raise PermissionError(str(exc)) from exc
 
             if not (args and isinstance(args, dict)):
                 return ToolExecutionResult(success=False, reply_text="localFiles requires a JSON object with at least 'operation' and 'path'.")
@@ -65,7 +86,15 @@ class LocalFilesTool(Tool):
             if not operation or not path_arg:
                 return ToolExecutionResult(success=False, reply_text="localFiles requires 'operation' and 'path'.")
 
-            target = _resolve_safe(str(path_arg))
+            _OP_ACCESS_MAP = {
+                "list":   AccessMode.LIST,
+                "read":   AccessMode.READ,
+                "write":  AccessMode.WRITE,
+                "append": AccessMode.WRITE,
+                "delete": AccessMode.DELETE,
+            }
+            access_mode = _OP_ACCESS_MAP.get(operation, AccessMode.READ)
+            target = _resolve_safe(str(path_arg), access_mode)
 
             # list
             if operation == "list":
@@ -149,6 +178,8 @@ class LocalFilesTool(Tool):
                     return ToolExecutionResult(success=False, reply_text=f"Delete failed: {e}")
 
             return ToolExecutionResult(success=False, reply_text=f"Unknown localFiles operation: {operation}")
+        except PolicyDeniedError as pde:
+            return ToolExecutionResult(success=False, reply_text=f"Access denied by policy: {pde}")
         except PermissionError as pe:
             return ToolExecutionResult(success=False, reply_text=f"Permission error: {pe}")
         except Exception as e:

--- a/src/jarvis/tools/builtin/nutrition/delete_meal.py
+++ b/src/jarvis/tools/builtin/nutrition/delete_meal.py
@@ -4,7 +4,7 @@ from typing import Dict, Any, Optional, Callable
 
 from ....debug import debug_log
 from ...base import Tool, ToolContext
-from ...types import ToolExecutionResult
+from ...types import RiskLevel, ToolExecutionResult
 
 
 class DeleteMealTool(Tool):
@@ -28,6 +28,13 @@ class DeleteMealTool(Tool):
             "required": ["id"]
         }
     
+    def classify(self, args=None):
+        from ....policy.models import ToolClass
+        return ToolClass.DESTRUCTIVE
+
+    def assess_risk(self, args: Optional[Dict[str, Any]] = None) -> RiskLevel:
+        return RiskLevel.HIGH
+
     def run(self, args: Optional[Dict[str, Any]], context: ToolContext) -> ToolExecutionResult:
         """Execute the delete meal tool."""
         context.user_print("🗑️ Deleting the meal…")

--- a/src/jarvis/tools/builtin/nutrition/fetch_meals.py
+++ b/src/jarvis/tools/builtin/nutrition/fetch_meals.py
@@ -5,7 +5,7 @@ from datetime import datetime, timezone, timedelta
 
 from ....debug import debug_log
 from ...base import Tool, ToolContext
-from ...types import ToolExecutionResult
+from ...types import RiskLevel, ToolExecutionResult
 
 
 def _normalize_time_range(args: Optional[Dict[str, Any]]) -> tuple[str, str]:
@@ -98,6 +98,13 @@ class FetchMealsTool(Tool):
             "required": []
         }
     
+    def classify(self, args=None):
+        from ....policy.models import ToolClass
+        return ToolClass.INFORMATIONAL
+
+    def assess_risk(self, args: Optional[Dict[str, Any]] = None) -> RiskLevel:
+        return RiskLevel.SAFE
+
     def run(self, args: Optional[Dict[str, Any]], context: ToolContext) -> ToolExecutionResult:
         """Execute the fetch meals tool."""
         context.user_print("📖 Retrieving your meals…")

--- a/src/jarvis/tools/builtin/refresh_mcp_tools.py
+++ b/src/jarvis/tools/builtin/refresh_mcp_tools.py
@@ -6,7 +6,7 @@ when new tools are added or servers are restarted.
 
 from typing import Dict, Any, Optional
 from ..base import Tool, ToolContext
-from ..types import ToolExecutionResult
+from ..types import RiskLevel, ToolExecutionResult
 from ...debug import debug_log
 
 
@@ -32,6 +32,13 @@ class RefreshMCPToolsTool(Tool):
             "properties": {},
             "required": []
         }
+
+    def classify(self, args=None):
+        from ...policy.models import ToolClass
+        return ToolClass.READ_ONLY_OPERATIONAL
+
+    def assess_risk(self, args: Optional[Dict[str, Any]] = None) -> RiskLevel:
+        return RiskLevel.SAFE
 
     def run(self, args: Optional[Dict[str, Any]], context: ToolContext) -> ToolExecutionResult:
         """Execute MCP tools refresh."""

--- a/src/jarvis/tools/builtin/screenshot.py
+++ b/src/jarvis/tools/builtin/screenshot.py
@@ -7,7 +7,7 @@ import subprocess
 import shutil
 from ...debug import debug_log
 from ..base import Tool, ToolContext
-from ..types import ToolExecutionResult
+from ..types import RiskLevel, ToolExecutionResult
 
 class ScreenshotTool(Tool):
     """Tool for capturing screenshots and performing OCR."""
@@ -27,6 +27,13 @@ class ScreenshotTool(Tool):
             "properties": {},
             "required": []
         }
+
+    def classify(self, args=None):
+        from ...policy.models import ToolClass
+        return ToolClass.INFORMATIONAL
+
+    def assess_risk(self, args: Optional[Dict[str, Any]] = None) -> RiskLevel:
+        return RiskLevel.SAFE
 
     def run(self, args: Optional[Dict[str, Any]], context: ToolContext) -> ToolExecutionResult:
         """Execute the screenshot tool."""

--- a/src/jarvis/tools/builtin/stop.py
+++ b/src/jarvis/tools/builtin/stop.py
@@ -7,7 +7,7 @@ The user will need to use the wake word again to start a new conversation.
 
 from typing import Dict, Any, Optional
 from ..base import Tool, ToolContext
-from ..types import ToolExecutionResult
+from ..types import RiskLevel, ToolExecutionResult
 from ...debug import debug_log
 
 
@@ -38,6 +38,13 @@ class StopTool(Tool):
             "properties": {},
             "required": []
         }
+
+    def classify(self, args=None):
+        from ...policy.models import ToolClass
+        return ToolClass.INFORMATIONAL
+
+    def assess_risk(self, args: Optional[Dict[str, Any]] = None) -> RiskLevel:
+        return RiskLevel.SAFE
 
     def run(self, args: Optional[Dict[str, Any]], context: ToolContext) -> ToolExecutionResult:
         """Execute the stop tool - signals conversation end."""

--- a/src/jarvis/tools/builtin/undo.py
+++ b/src/jarvis/tools/builtin/undo.py
@@ -1,0 +1,98 @@
+"""Undo tool — reverses previous actions via the undo registry.
+
+This tool is language-agnostic: the LLM detects undo intent in any
+language and invokes this tool with the appropriate parameters.
+"""
+
+from typing import Dict, Any, Optional
+
+from ..base import Tool, ToolContext
+from ..types import RiskLevel, ToolExecutionResult
+from ...undo_registry import pop_last_undo, pop_undo_by_id
+from ...debug import debug_log
+
+
+class UndoTool(Tool):
+    """Reverses previous actions tracked in the undo registry."""
+
+    @property
+    def name(self) -> str:
+        return "undo"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Undo previous actions. Use when the user asks to undo, reverse, "
+            "revert, or take back something that was just done. "
+            "Set count to undo the last N actions, or step_id to undo a specific action."
+        )
+
+    @property
+    def inputSchema(self) -> Dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "count": {
+                    "type": "integer",
+                    "description": "Number of recent actions to undo (default 1, max 20)",
+                    "default": 1,
+                },
+                "step_id": {
+                    "type": "string",
+                    "description": "Specific step ID to undo (overrides count if provided)",
+                },
+            },
+        }
+
+    def assess_risk(self, args: Optional[Dict[str, Any]] = None) -> RiskLevel:
+        return RiskLevel.MODERATE
+
+    def run(self, args: Optional[Dict[str, Any]], context: ToolContext) -> ToolExecutionResult:
+        args = args or {}
+        step_id = args.get("step_id")
+        count = min(int(args.get("count", 1)), 20)
+
+        if step_id:
+            entry = pop_undo_by_id(step_id)
+            entries = [entry] if entry else []
+        else:
+            entries = pop_last_undo(count)
+
+        if not entries:
+            return ToolExecutionResult(
+                success=True,
+                reply_text="There is nothing to undo right now.",
+            )
+
+        from ..registry import run_tool_with_retries
+
+        results = []
+        for entry in entries:
+            debug_log(
+                f"undo: reversing '{entry.description}' via {entry.undo_tool}",
+                "undo",
+            )
+            try:
+                rev = run_tool_with_retries(
+                    db=context.db,
+                    cfg=context.cfg,
+                    tool_name=entry.undo_tool,
+                    tool_args=entry.undo_args,
+                    system_prompt="",
+                    original_prompt="",
+                    redacted_text="",
+                    max_retries=1,
+                )
+                if rev.reply_text and not rev.error_message:
+                    results.append(f"Reversed: {entry.description}.")
+                else:
+                    err = rev.error_message or "undo failed"
+                    results.append(f"Could not reverse '{entry.description}': {err}")
+            except Exception as exc:
+                debug_log(f"undo execution error: {exc}", "undo")
+                results.append(f"Undo failed for '{entry.description}': {exc}")
+
+        return ToolExecutionResult(
+            success=True,
+            reply_text="  ".join(results),
+        )

--- a/src/jarvis/tools/builtin/weather.py
+++ b/src/jarvis/tools/builtin/weather.py
@@ -6,7 +6,7 @@ from ...debug import debug_log
 from ...llm import get_llm_backend
 from ...utils.location import get_location_info
 from ..base import Tool, ToolContext
-from ..types import ToolExecutionResult
+from ..types import RiskLevel, ToolExecutionResult
 
 
 # Sentinel strings an LLM extractor may emit to mean "no place mentioned".
@@ -182,6 +182,13 @@ class WeatherTool(Tool):
         except Exception as e:
             debug_log(f"    ⚠️ location detection error: {e}", "tools")
             return None
+
+    def classify(self, args=None):
+        from ...policy.models import ToolClass
+        return ToolClass.READ_ONLY_OPERATIONAL
+
+    def assess_risk(self, args: Optional[Dict[str, Any]] = None) -> RiskLevel:
+        return RiskLevel.SAFE
 
     def run(self, args: Optional[Dict[str, Any]], context: ToolContext) -> ToolExecutionResult:
         """Get current weather for a location."""

--- a/src/jarvis/tools/builtin/web_search.py
+++ b/src/jarvis/tools/builtin/web_search.py
@@ -10,7 +10,7 @@ import requests
 from typing import Dict, Any, Optional, List, Tuple
 from ...debug import debug_log
 from ..base import Tool, ToolContext
-from ..types import ToolExecutionResult
+from ..types import RiskLevel, ToolExecutionResult
 
 
 # Per-fetch deadline — tight enough that a worst-case 3-way cascade fits the
@@ -574,6 +574,13 @@ class WebSearchTool(Tool):
             },
             "required": ["search_query"]
         }
+
+    def classify(self, args=None):
+        from ...policy.models import ToolClass
+        return ToolClass.READ_ONLY_OPERATIONAL
+
+    def assess_risk(self, args: Optional[Dict[str, Any]] = None) -> RiskLevel:
+        return RiskLevel.SAFE
 
     def run(self, args: Optional[Dict[str, Any]], context: ToolContext) -> ToolExecutionResult:
         """Execute web search using DuckDuckGo."""

--- a/src/jarvis/tools/registry.py
+++ b/src/jarvis/tools/registry.py
@@ -20,6 +20,7 @@ from .builtin.refresh_mcp_tools import RefreshMCPToolsTool
 from .builtin.weather import WeatherTool
 from .builtin.stop import StopTool
 from .builtin.tool_search import ToolSearchTool
+from .builtin.undo import UndoTool
 from .types import ToolExecutionResult
 from ..config import Settings
 from .external.mcp_client import MCPClient
@@ -39,6 +40,7 @@ BUILTIN_TOOLS = {
     "getWeather": WeatherTool(),
     "stop": StopTool(),
     "toolSearchTool": ToolSearchTool(),
+    "undo": UndoTool(),
 }
 
 # Global MCP tools cache

--- a/src/jarvis/tools/types.py
+++ b/src/jarvis/tools/types.py
@@ -1,7 +1,21 @@
 """Common types and result classes for tools."""
 
 from dataclasses import dataclass
+from enum import Enum
 from typing import Optional
+
+
+class RiskLevel(Enum):
+    """Classification of action risk.
+
+    Stored on each tool (via ``Tool.assess_risk``) so risk information
+    stays co-located with the tool that owns it rather than in a separate
+    parallel mapping that can diverge when tools are added or removed.
+    """
+
+    SAFE = "safe"       # Read-only or clearly reversible
+    MODERATE = "moderate"  # Writes that are easily undone
+    HIGH = "high"       # Potentially destructive or hard-to-undo
 
 
 @dataclass

--- a/src/jarvis/undo_registry.py
+++ b/src/jarvis/undo_registry.py
@@ -1,0 +1,232 @@
+"""
+Undo Registry – session-scoped stack of reversible operations.
+
+Tracks completed tool executions that can be reversed within a configurable
+time window.  The registry supports:
+
+- Undoing the last action ("undo that")
+- Undoing the last N actions in reverse chronological order
+- Undoing a specific action by its step ID
+- Automatic expiry after a configurable window (default 5 minutes)
+
+Design principles:
+- In-memory only; clears on daemon restart
+- Thread-safe via a simple lock
+- Capped at MAX_ENTRIES (default 20) entries to bound memory use
+- Tools declare their own undo inverse; the registry just stores and replays
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+from .debug import debug_log
+
+# Maximum number of undo entries to keep in the stack at one time.
+MAX_ENTRIES: int = 20
+
+# Default expiry window in seconds (5 minutes).
+DEFAULT_EXPIRY_SECONDS: float = 300.0
+
+
+@dataclass
+class UndoEntry:
+    """
+    A single reversible operation.
+
+    Attributes:
+        step_id:      Unique identifier matching the TaskStep that created it.
+        description:  Human-readable description, e.g. "deleted shopping_list.txt".
+        tool_name:    The tool that was executed (used for audit / display).
+        tool_args:    Arguments originally passed to the tool.
+        undo_tool:    Tool to call to reverse the operation.
+        undo_args:    Arguments to pass to undo_tool.
+        snapshot:     Optional captured state before execution (e.g. file
+                      contents before overwrite) needed to reconstruct the
+                      original state.
+        created_at:   Unix timestamp when the entry was created.
+        expires_at:   Unix timestamp after which the entry is considered expired.
+    """
+    step_id: str
+    description: str
+    tool_name: str
+    tool_args: Dict[str, Any]
+    undo_tool: str
+    undo_args: Dict[str, Any]
+    snapshot: Optional[Any] = None
+    created_at: float = field(default_factory=time.time)
+    expires_at: float = field(default_factory=lambda: time.time() + DEFAULT_EXPIRY_SECONDS)
+
+    @property
+    def is_expired(self) -> bool:
+        """Return True when the undo window has closed."""
+        return time.time() > self.expires_at
+
+    @property
+    def age_seconds(self) -> float:
+        """Seconds elapsed since this entry was created."""
+        return time.time() - self.created_at
+
+
+class UndoRegistry:
+    """
+    Session-scoped stack of reversible operations.
+
+    The stack is ordered oldest-first; ``pop_last(n)`` returns entries in
+    reverse chronological order (most-recent first) ready for sequential
+    execution.
+    """
+
+    def __init__(self, max_entries: int = MAX_ENTRIES) -> None:
+        self._entries: List[UndoEntry] = []
+        self._max_entries = max_entries
+        self._lock = threading.Lock()
+
+    # ------------------------------------------------------------------
+    # Mutation
+    # ------------------------------------------------------------------
+
+    def push(self, entry: UndoEntry) -> None:
+        """
+        Add a new reversible entry to the stack.
+
+        Expired entries and entries beyond the cap are pruned before
+        the new entry is added.
+        """
+        with self._lock:
+            # Purge expired entries first
+            self._entries = [e for e in self._entries if not e.is_expired]
+            self._entries.append(entry)
+            # Cap the stack
+            if len(self._entries) > self._max_entries:
+                dropped = len(self._entries) - self._max_entries
+                self._entries = self._entries[dropped:]
+                debug_log(
+                    f"undo stack capped — dropped {dropped} oldest entries",
+                    "undo",
+                )
+            debug_log(
+                f"undo entry pushed: {entry.description!r} "
+                f"(step_id={entry.step_id}, expires_in="
+                f"{entry.expires_at - time.time():.0f}s)",
+                "undo",
+            )
+
+    def pop_last(self, n: int = 1) -> List[UndoEntry]:
+        """
+        Remove and return the last ``n`` non-expired entries.
+
+        The returned list is ordered most-recent first so callers can
+        execute reversals in reverse chronological order by iterating
+        the list in order.
+
+        Expired entries encountered during the scan are silently dropped
+        without counting towards ``n``.
+        """
+        with self._lock:
+            result: List[UndoEntry] = []
+            surviving: List[UndoEntry] = []
+            # Walk from newest to oldest
+            for entry in reversed(self._entries):
+                if entry.is_expired:
+                    debug_log(
+                        f"undo entry expired and dropped: {entry.description!r}",
+                        "undo",
+                    )
+                    continue
+                if len(result) < n:
+                    result.append(entry)
+                else:
+                    surviving.insert(0, entry)
+
+            # Rebuild stack: surviving entries in original order
+            # (oldest first, without the ones we just popped)
+            popped_ids = {e.step_id for e in result}
+            self._entries = [e for e in self._entries if e.step_id not in popped_ids and not e.is_expired]
+
+            for entry in result:
+                debug_log(f"undo entry popped: {entry.description!r}", "undo")
+            return result  # most-recent first
+
+    def pop_by_id(self, step_id: str) -> Optional[UndoEntry]:
+        """
+        Remove and return the entry with the given step_id.
+
+        Returns ``None`` if no matching entry exists or if the entry has
+        expired.
+        """
+        with self._lock:
+            for i, entry in enumerate(self._entries):
+                if entry.step_id == step_id:
+                    if entry.is_expired:
+                        debug_log(
+                            f"undo entry {step_id!r} found but expired", "undo"
+                        )
+                        self._entries.pop(i)
+                        return None
+                    self._entries.pop(i)
+                    debug_log(
+                        f"undo entry popped by id: {entry.description!r}", "undo"
+                    )
+                    return entry
+            debug_log(f"undo entry not found: {step_id!r}", "undo")
+            return None
+
+    def clear(self) -> None:
+        """Remove all entries from the stack."""
+        with self._lock:
+            count = len(self._entries)
+            self._entries.clear()
+            debug_log(f"undo stack cleared ({count} entries removed)", "undo")
+
+    # ------------------------------------------------------------------
+    # Read-only
+    # ------------------------------------------------------------------
+
+    def peek_all(self) -> List[UndoEntry]:
+        """
+        Return a snapshot of all non-expired entries, oldest first.
+
+        Does not remove any entries.
+        """
+        with self._lock:
+            return [e for e in self._entries if not e.is_expired]
+
+    @property
+    def size(self) -> int:
+        """Number of non-expired entries currently in the stack."""
+        with self._lock:
+            return sum(1 for e in self._entries if not e.is_expired)
+
+    def __len__(self) -> int:
+        return self.size
+
+
+# ---------------------------------------------------------------------------
+# Module-level singleton – one registry per daemon session
+# ---------------------------------------------------------------------------
+
+_registry = UndoRegistry()
+
+
+def get_undo_registry() -> UndoRegistry:
+    """Return the singleton undo registry."""
+    return _registry
+
+
+def push_undo(entry: UndoEntry) -> None:
+    """Convenience wrapper: push an entry onto the singleton registry."""
+    _registry.push(entry)
+
+
+def pop_last_undo(n: int = 1) -> List[UndoEntry]:
+    """Convenience wrapper: pop and return the last ``n`` entries."""
+    return _registry.pop_last(n)
+
+
+def pop_undo_by_id(step_id: str) -> Optional[UndoEntry]:
+    """Convenience wrapper: pop a specific entry by step_id."""
+    return _registry.pop_by_id(step_id)

--- a/tests/orchestration/__init__.py
+++ b/tests/orchestration/__init__.py
@@ -1,0 +1,1 @@
+# Orchestration test suite — integration-level tests for Phase 1–3 spec items.

--- a/tests/orchestration/test_duplicate_tools.py
+++ b/tests/orchestration/test_duplicate_tools.py
@@ -1,0 +1,136 @@
+"""Orchestration tests — duplicate tool call suppression (spec 5.5).
+
+Tests that the agent loop does not execute the same tool call twice in the
+same turn, and escalates correctly when a loop is detected.
+"""
+
+from __future__ import annotations
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _build_signature(tool_name: str, tool_args: dict) -> tuple:
+    import json
+    stable = json.dumps(tool_args, sort_keys=True, ensure_ascii=False)
+    return (tool_name, stable)
+
+
+# ---------------------------------------------------------------------------
+# Signature deduplication logic (unit tests)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_same_args_produce_same_signature():
+    """Tool call with identical args produces an identical signature."""
+    sig1 = _build_signature("getWeather", {"city": "London"})
+    sig2 = _build_signature("getWeather", {"city": "London"})
+    assert sig1 == sig2
+
+
+@pytest.mark.unit
+def test_different_args_produce_different_signature():
+    """Tool call with different args produces a distinct signature."""
+    sig1 = _build_signature("getWeather", {"city": "London"})
+    sig2 = _build_signature("getWeather", {"city": "Paris"})
+    assert sig1 != sig2
+
+
+@pytest.mark.unit
+def test_different_tools_produce_different_signature():
+    """Different tool names produce distinct signatures even with identical args."""
+    sig1 = _build_signature("getWeather", {})
+    sig2 = _build_signature("webSearch", {})
+    assert sig1 != sig2
+
+
+# ---------------------------------------------------------------------------
+# Recent-signature memory management
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_signature_eviction_after_five():
+    """Only the last 5 signatures are kept; older ones are evicted."""
+    sigs = []
+    for i in range(7):
+        sigs.append(_build_signature("tool", {"n": i}))
+        if len(sigs) > 5:
+            sigs = sigs[-5:]
+    assert len(sigs) == 5
+    # First two should be evicted
+    assert _build_signature("tool", {"n": 0}) not in sigs
+    assert _build_signature("tool", {"n": 1}) not in sigs
+    assert _build_signature("tool", {"n": 6}) in sigs
+
+
+# ---------------------------------------------------------------------------
+# Duplicate count detection
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_duplicate_count_from_messages():
+    """duplicate_tool_count is correctly derived from recent message history."""
+    messages = [
+        {"role": "user", "content": "what's the weather?"},
+        {"role": "assistant", "content": "", "tool_calls": []},
+        {"role": "tool", "tool_call_id": "1", "tool_name": "getWeather", "content": "20°C"},
+        {"role": "assistant", "content": "", "tool_calls": []},
+        {"role": "tool", "tool_call_id": "2", "tool_name": "getWeather", "content": "20°C"},
+    ]
+    tool_name = "getWeather"
+    duplicate_count = sum(
+        1 for msg in messages[-10:]
+        if msg.get("role") == "tool" and msg.get("tool_name") == tool_name
+    )
+    assert duplicate_count == 2
+
+
+@pytest.mark.unit
+def test_no_duplicates_for_different_tools():
+    """Different tool names do not contribute to each other's duplicate count."""
+    messages = [
+        {"role": "tool", "tool_call_id": "1", "tool_name": "getWeather", "content": "x"},
+        {"role": "tool", "tool_call_id": "2", "tool_name": "webSearch", "content": "y"},
+    ]
+    count_weather = sum(
+        1 for m in messages[-10:] if m.get("role") == "tool" and m.get("tool_name") == "getWeather"
+    )
+    count_search = sum(
+        1 for m in messages[-10:] if m.get("role") == "tool" and m.get("tool_name") == "webSearch"
+    )
+    assert count_weather == 1
+    assert count_search == 1
+
+
+# ---------------------------------------------------------------------------
+# Recent-signature deduplication suppresses agent loop re-execution
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_signature_in_history_triggers_suppression():
+    """A signature already in recent_tool_signatures triggers cached-guidance response."""
+    recent_tool_signatures = []
+    tool_name = "getWeather"
+    tool_args = {"city": "London"}
+
+    import json
+    stable_args = json.dumps(tool_args, sort_keys=True, ensure_ascii=False)
+    signature = (tool_name, stable_args)
+    recent_tool_signatures.append(signature)
+
+    # Simulating the check that would happen in the loop
+    suppressed = signature in recent_tool_signatures
+    assert suppressed is True
+
+
+@pytest.mark.unit
+def test_new_signature_not_suppressed():
+    """A signature not yet seen passes through without suppression."""
+    recent_tool_signatures = [("getWeather", '{"city": "London"}')]
+    import json
+    new_sig = ("getWeather", json.dumps({"city": "Paris"}, sort_keys=True))
+    assert new_sig not in recent_tool_signatures

--- a/tests/orchestration/test_hot_window_transitions.py
+++ b/tests/orchestration/test_hot_window_transitions.py
@@ -1,0 +1,179 @@
+"""Orchestration tests — listening state machine hot-window transitions (spec 5.5).
+
+Tests that the StateManager correctly handles:
+- WAKE_WORD → COLLECTING transitions
+- COLLECTING → WAKE_WORD on clear 
+- HOT_WINDOW activation and expiry
+- Duplicate collection protection
+"""
+
+from __future__ import annotations
+
+import time
+import pytest
+from unittest.mock import patch
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_manager(**kwargs):
+    from jarvis.listening.state_manager import StateManager
+    return StateManager(
+        hot_window_seconds=kwargs.get("hot_window_seconds", 6.0),
+        echo_tolerance=kwargs.get("echo_tolerance", 0.1),
+        voice_collect_seconds=kwargs.get("voice_collect_seconds", 0.5),
+        max_collect_seconds=kwargs.get("max_collect_seconds", 60.0),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Initial state
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_initial_state_is_wake_word():
+    """StateManager starts in WAKE_WORD mode."""
+    from jarvis.listening.state_manager import ListeningState
+    sm = _make_manager()
+    assert sm.get_state() == ListeningState.WAKE_WORD
+
+
+@pytest.mark.unit
+def test_is_collecting_false_initially():
+    """is_collecting() returns False before collection starts."""
+    sm = _make_manager()
+    assert sm.is_collecting() is False
+
+
+@pytest.mark.unit
+def test_is_hot_window_false_initially():
+    """is_hot_window_active() returns False on startup."""
+    sm = _make_manager()
+    assert sm.is_hot_window_active() is False
+
+
+# ---------------------------------------------------------------------------
+# WAKE_WORD → COLLECTING transition
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_start_collection_enters_collecting_state():
+    """start_collection() transitions state to COLLECTING."""
+    from jarvis.listening.state_manager import ListeningState, StateManager
+    sm = _make_manager()
+    sm.start_collection("hello")
+    assert sm.get_state() == ListeningState.COLLECTING
+    assert sm.is_collecting() is True
+
+
+@pytest.mark.unit
+def test_start_collection_stores_initial_text():
+    """start_collection() seeds the pending query with initial text."""
+    sm = _make_manager()
+    sm.start_collection("set a timer")
+    assert sm.get_pending_query() == "set a timer"
+
+
+@pytest.mark.unit
+def test_add_to_collection_appends_text():
+    """add_to_collection() appends a word to the pending query."""
+    sm = _make_manager()
+    sm.start_collection("turn")
+    sm.add_to_collection("off the lights")
+    assert "turn" in sm.get_pending_query()
+    assert "off the lights" in sm.get_pending_query()
+
+
+# ---------------------------------------------------------------------------
+# COLLECTING → WAKE_WORD transition
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_clear_collection_returns_query():
+    """clear_collection() returns the accumulated query text."""
+    sm = _make_manager()
+    sm.start_collection("what time is it")
+    result = sm.clear_collection()
+    assert result == "what time is it"
+
+
+@pytest.mark.unit
+def test_clear_collection_resets_to_wake_word():
+    """clear_collection() transitions back to WAKE_WORD state."""
+    from jarvis.listening.state_manager import ListeningState
+    sm = _make_manager()
+    sm.start_collection("query")
+    sm.clear_collection()
+    assert sm.get_state() == ListeningState.WAKE_WORD
+
+
+@pytest.mark.unit
+def test_add_to_collection_does_nothing_when_not_collecting():
+    """add_to_collection() is a no-op when not in COLLECTING state."""
+    sm = _make_manager()
+    sm.add_to_collection("stray text")
+    assert sm.get_pending_query() == ""
+
+
+# ---------------------------------------------------------------------------
+# Collection silence timeout
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_collection_timeout_triggers_on_silence(monkeypatch):
+    """check_collection_timeout() returns True after silence exceeds threshold."""
+    sm = _make_manager(voice_collect_seconds=0.1)
+    sm.start_collection("test")
+    # Advance last_voice_time into the past
+    sm._last_voice_time = time.time() - 0.5
+    assert sm.check_collection_timeout() is True
+
+
+@pytest.mark.unit
+def test_collection_timeout_false_before_silence_threshold():
+    """check_collection_timeout() returns False when still within silence window."""
+    sm = _make_manager(voice_collect_seconds=30.0)
+    sm.start_collection("fast response")
+    assert sm.check_collection_timeout() is False
+
+
+# ---------------------------------------------------------------------------
+# HOT_WINDOW state
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_hot_window_expiry_returns_to_wake_word(monkeypatch):
+    """expire_hot_window() transitions from HOT_WINDOW to WAKE_WORD."""
+    from jarvis.listening.state_manager import ListeningState
+    sm = _make_manager()
+    with sm._state_lock:
+        sm._state = ListeningState.HOT_WINDOW
+        sm._hot_window_start_time = time.time() - 100.0  # already expired
+    sm.expire_hot_window()
+    assert sm.get_state() == ListeningState.WAKE_WORD
+
+
+@pytest.mark.unit
+def test_check_hot_window_expiry_returns_true_after_timeout(monkeypatch):
+    """check_hot_window_expiry() returns True when the hot window has timed out."""
+    from jarvis.listening.state_manager import ListeningState
+    sm = _make_manager(hot_window_seconds=1.0)
+    with sm._state_lock:
+        sm._state = ListeningState.HOT_WINDOW
+        sm._hot_window_start_time = time.time() - 5.0  # well past timeout
+    expired = sm.check_hot_window_expiry()
+    assert expired is True
+
+
+@pytest.mark.unit
+def test_check_hot_window_expiry_false_when_within_window():
+    """check_hot_window_expiry() returns False within the hot window period."""
+    from jarvis.listening.state_manager import ListeningState, StateManager
+    sm = _make_manager(hot_window_seconds=60.0)
+    with sm._state_lock:
+        sm._state = ListeningState.HOT_WINDOW
+        sm._hot_window_start_time = time.time()
+    expired = sm.check_hot_window_expiry()
+    assert expired is False

--- a/tests/orchestration/test_mcp_degraded_mode.py
+++ b/tests/orchestration/test_mcp_degraded_mode.py
@@ -1,0 +1,83 @@
+"""Orchestration tests — degraded mode when MCP tools are unavailable (spec 5.7).
+
+Tests that the health registry correctly tracks MCP availability and that
+the service container degrades gracefully when MCP discovery fails.
+"""
+
+from __future__ import annotations
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+
+# ---------------------------------------------------------------------------
+# HealthRegistry — core behaviour
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_health_registry_ready_service():
+    """A service marked ready is considered operational."""
+    from jarvis.runtime.health import HealthRegistry, HealthStatus
+
+    reg = HealthRegistry()
+    reg.ready("ollama", "http://localhost:11434")
+    assert reg.is_operational("ollama") is True
+
+
+@pytest.mark.unit
+def test_health_registry_degraded_service():
+    """A service marked degraded is NOT marked as fully ready."""
+    from jarvis.runtime.health import HealthRegistry
+
+    reg = HealthRegistry()
+    reg.degraded("mcp", "no tools discovered")
+    assert reg.is_ready("mcp") is False
+    # Degraded is still operational (partial service)
+    assert reg.is_operational("mcp") is True
+
+
+@pytest.mark.unit
+def test_health_registry_unavailable_service():
+    """A service marked unavailable is NOT considered operational."""
+    from jarvis.runtime.health import HealthRegistry
+
+    reg = HealthRegistry()
+    reg.unavailable("whisper", "dependency missing")
+    assert reg.is_operational("whisper") is False
+
+
+@pytest.mark.unit
+def test_health_registry_summary_contains_service_names():
+    """summary() returns a dict with service names as keys."""
+    from jarvis.runtime.health import HealthRegistry
+
+    reg = HealthRegistry()
+    reg.ready("database")
+    reg.degraded("mcp", "no tools")
+    summary = reg.summary()
+    assert isinstance(summary, dict)
+    assert "database" in summary
+    assert "mcp" in summary
+
+
+@pytest.mark.unit
+def test_has_critical_failures_false_when_all_ready():
+    """has_critical_failures() returns False when all registered services are ready."""
+    from jarvis.runtime.health import HealthRegistry
+
+    reg = HealthRegistry()
+    reg.ready("database")
+    reg.ready("ollama")
+    assert reg.has_critical_failures() is False
+
+
+@pytest.mark.unit
+def test_has_critical_failures_true_when_database_unavailable():
+    """has_critical_failures() returns True when the database is unavailable."""
+    from jarvis.runtime.health import HealthRegistry, ServiceName
+
+    reg = HealthRegistry()
+    reg.unavailable(ServiceName.DATABASE, "db file not found")
+    assert reg.has_critical_failures() is True
+
+

--- a/tests/orchestration/test_policy_paths.py
+++ b/tests/orchestration/test_policy_paths.py
@@ -1,0 +1,201 @@
+"""Orchestration tests — workspace path confinement (spec 5.2).
+
+Tests that PathGuard and resolve_and_validate_path enforce workspace and
+blocked-root rules correctly.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# resolve_and_validate_path — ALLOW cases
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_read_inside_workspace_allowed(tmp_path):
+    """Reading a file inside a declared workspace root is allowed."""
+    from jarvis.policy.path_guard import resolve_and_validate_path, AccessMode
+    target = tmp_path / "notes.txt"
+    target.write_text("data")
+    resolved = resolve_and_validate_path(
+        str(target),
+        AccessMode.READ,
+        workspace_roots=[str(tmp_path)],
+        blocked_roots=[],
+        read_only_roots=[],
+        local_files_mode="workspace_only",
+    )
+    assert resolved == target.resolve()
+
+
+@pytest.mark.unit
+def test_list_workspace_root_allowed(tmp_path):
+    """Listing the workspace root itself is allowed."""
+    from jarvis.policy.path_guard import resolve_and_validate_path, AccessMode
+    resolved = resolve_and_validate_path(
+        str(tmp_path),
+        AccessMode.LIST,
+        workspace_roots=[str(tmp_path)],
+        blocked_roots=[],
+        read_only_roots=[],
+        local_files_mode="workspace_only",
+    )
+    assert resolved == tmp_path.resolve()
+
+
+@pytest.mark.unit
+def test_write_inside_workspace_allowed(tmp_path):
+    """Writing a file inside the workspace root is allowed."""
+    from jarvis.policy.path_guard import resolve_and_validate_path, AccessMode
+    target = tmp_path / "output.txt"
+    resolved = resolve_and_validate_path(
+        str(target),
+        AccessMode.WRITE,
+        workspace_roots=[str(tmp_path)],
+        blocked_roots=[],
+        read_only_roots=[],
+        local_files_mode="workspace_only",
+    )
+    assert resolved == target.resolve()
+
+
+# ---------------------------------------------------------------------------
+# resolve_and_validate_path — DENY cases
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_read_outside_workspace_denied(tmp_path):
+    """Reading a path outside the declared workspace root is denied."""
+    from jarvis.policy.path_guard import resolve_and_validate_path, AccessMode
+    from jarvis.policy.models import PolicyDeniedError
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    outside = tmp_path / "secrets.txt"
+    outside.write_text("secret")
+    with pytest.raises(PolicyDeniedError):
+        resolve_and_validate_path(
+            str(outside),
+            AccessMode.READ,
+            workspace_roots=[str(workspace)],
+            blocked_roots=[],
+            read_only_roots=[],
+            local_files_mode="workspace_only",
+        )
+
+
+@pytest.mark.unit
+def test_blocked_root_denied(tmp_path):
+    """Access to a blocked root is denied regardless of workspace."""
+    from jarvis.policy.path_guard import resolve_and_validate_path, AccessMode
+    from jarvis.policy.models import PolicyDeniedError
+    blocked = tmp_path / "private"
+    blocked.mkdir()
+    target = blocked / "secret.txt"
+    target.write_text("classified")
+    with pytest.raises(PolicyDeniedError):
+        resolve_and_validate_path(
+            str(target),
+            AccessMode.READ,
+            workspace_roots=[str(tmp_path)],
+            blocked_roots=[str(blocked)],
+            read_only_roots=[],
+            local_files_mode="workspace_only",
+        )
+
+
+@pytest.mark.unit
+def test_write_to_read_only_root_denied(tmp_path):
+    """Writing to a read-only root is denied, reading is allowed."""
+    from jarvis.policy.path_guard import resolve_and_validate_path, AccessMode
+    from jarvis.policy.models import PolicyDeniedError
+    ro = tmp_path / "readonly"
+    ro.mkdir()
+    target = ro / "notes.txt"
+    target.write_text("existing")
+    # Read should succeed
+    resolve_and_validate_path(
+        str(target),
+        AccessMode.READ,
+        workspace_roots=[str(tmp_path)],
+        blocked_roots=[],
+        read_only_roots=[str(ro)],
+            local_files_mode="workspace_only",
+    )
+    # Write should fail
+    with pytest.raises(PolicyDeniedError):
+        resolve_and_validate_path(
+            str(target),
+            AccessMode.WRITE,
+            workspace_roots=[str(tmp_path)],
+            blocked_roots=[],
+            read_only_roots=[str(ro)],
+            local_files_mode="workspace_only",
+        )
+
+
+@pytest.mark.unit
+def test_path_traversal_denied(tmp_path):
+    """Traversal via ../ that escapes workspace is denied."""
+    from jarvis.policy.path_guard import resolve_and_validate_path, AccessMode
+    from jarvis.policy.models import PolicyDeniedError
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    # Construct a path that traverses out of workspace
+    traversal = str(workspace / ".." / "escape.txt")
+    with pytest.raises(PolicyDeniedError):
+        resolve_and_validate_path(
+            traversal,
+            AccessMode.READ,
+            workspace_roots=[str(workspace)],
+            blocked_roots=[],
+            read_only_roots=[],
+            local_files_mode="workspace_only",
+        )
+
+
+# ---------------------------------------------------------------------------
+# PathGuard class wrapper
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_path_guard_validate_allows_home_path():
+    """PathGuard in home_only mode allows reads within home directory."""
+    from jarvis.policy.path_guard import PathGuard, AccessMode
+
+    class _FakeCfg:
+        workspace_roots = []
+        blocked_roots = []
+        read_only_roots = []
+        local_files_mode = "home_only"
+
+    guard = PathGuard(_FakeCfg())
+    home = Path.home()
+    test_file = home / ".jarvis_test_guard.txt"
+    result = guard.validate(str(test_file), AccessMode.READ)
+    assert result.is_absolute()
+    assert str(home.resolve()) in str(result)
+
+
+@pytest.mark.unit
+def test_path_guard_validate_raises_for_blocked(tmp_path):
+    """PathGuard.validate() raises PolicyDeniedError for a blocked path."""
+    from jarvis.policy.path_guard import PathGuard, AccessMode
+    from jarvis.policy.models import PolicyDeniedError
+
+    blocked = tmp_path / "secret"
+    blocked.mkdir()
+    target = blocked / "data.txt"
+    target.write_text("classified")
+
+    class _FakeCfg:
+        workspace_roots = [str(tmp_path)]
+        blocked_roots = [str(blocked)]
+        read_only_roots = []
+        local_files_mode = "workspace_only"
+
+    guard = PathGuard(_FakeCfg())
+    with pytest.raises(PolicyDeniedError):
+        guard.validate(str(target), AccessMode.READ)

--- a/tests/orchestration/test_policy_paths.py
+++ b/tests/orchestration/test_policy_paths.py
@@ -199,3 +199,59 @@ def test_path_guard_validate_raises_for_blocked(tmp_path):
     guard = PathGuard(_FakeCfg())
     with pytest.raises(PolicyDeniedError):
         guard.validate(str(target), AccessMode.READ)
+
+
+@pytest.mark.unit
+def test_default_blocked_covers_home_secret_stores():
+    """Credential stores inside the home directory are denied by default.
+
+    home_only mode permits everything under home, so without these
+    defaults a prompt-injected read of ~/.ssh/id_rsa would be classified
+    SAFE and pass the guard.
+    """
+    from pathlib import Path
+    from jarvis.policy.path_guard import resolve_and_validate_path, AccessMode
+    from jarvis.policy.models import PolicyDeniedError
+    for secret in (".ssh/id_rsa", ".aws/credentials", ".gnupg/private-keys-v1.d/key", ".netrc"):
+        with pytest.raises(PolicyDeniedError):
+            resolve_and_validate_path(
+                str(Path.home() / secret),
+                AccessMode.READ,
+                workspace_roots=[],
+                blocked_roots=None,  # use defaults
+                read_only_roots=[],
+                local_files_mode="home_only",
+            )
+
+
+@pytest.mark.unit
+def test_blocked_root_not_evadable_by_case(tmp_path):
+    """A differently-cased path must not evade a blocked root.
+
+    On case-insensitive filesystems (macOS, Windows) the path refers to
+    the same file; comparison is case-normalised so the guard fails
+    closed either way.
+    """
+    import os
+    from jarvis.policy.path_guard import resolve_and_validate_path, AccessMode
+    from jarvis.policy.models import PolicyDeniedError
+    blocked = tmp_path / "private"
+    blocked.mkdir()
+    target = blocked / "secret.txt"
+    target.write_text("classified")
+    # Re-case only the final directory segment so the workspace prefix
+    # stays intact and the test isolates the blocked-root comparison.
+    cased = str(blocked / "secret.txt").replace(str(blocked), str(tmp_path / "PRIVATE"))
+    # Only meaningful where the filesystem is case-insensitive (macOS,
+    # Windows default): on a case-sensitive FS the cased path simply does
+    # not exist and resolution never grants access.
+    if os.path.exists(cased):
+        with pytest.raises(PolicyDeniedError):
+            resolve_and_validate_path(
+                cased,
+                AccessMode.WRITE,
+                workspace_roots=[str(tmp_path)],
+                blocked_roots=[str(blocked)],
+                read_only_roots=[],
+                local_files_mode="workspace_only",
+            )

--- a/tests/orchestration/test_shutdown_diary_timeout.py
+++ b/tests/orchestration/test_shutdown_diary_timeout.py
@@ -1,0 +1,155 @@
+"""Orchestration tests — graceful shutdown diary flush timeout (spec 5.3 / 5.7).
+
+Tests that ShutdownManager does not hang indefinitely if the LLM diary
+update takes longer than the configured timeout.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+import pytest
+from unittest.mock import MagicMock, patch
+
+
+# ---------------------------------------------------------------------------
+# ShutdownManager unit
+# ---------------------------------------------------------------------------
+
+def _make_shutdown_manager(timeout: float = 5.0):
+    from jarvis.runtime.shutdown_manager import ShutdownManager
+
+    class _FakeCfg:
+        shutdown_diary_timeout_sec: float = timeout
+
+    health = MagicMock()
+    manager = ShutdownManager(_FakeCfg(), health)
+    return manager
+
+
+def _make_fake_db():
+    db = MagicMock()
+    db.close = MagicMock()
+    return db
+
+
+def _make_fake_tts():
+    tts = MagicMock()
+    tts.stop = MagicMock()
+    return tts
+
+
+# ---------------------------------------------------------------------------
+# Diary flush respects timeout
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_shutdown_completes_within_timeout_when_diary_blocks(monkeypatch):
+    """Shutdown must finish even if the diary update hangs indefinitely."""
+    manager = _make_shutdown_manager(timeout=2.0)
+    db = _make_fake_db()
+    tts = _make_fake_tts()
+    manager.register_db(db)
+    manager.register_tts(tts)
+
+    # Simulate a blocking diary update
+    def _blocking_diary(*args, **kwargs):
+        time.sleep(60.0)  # Much longer than the timeout
+
+    monkeypatch.setattr(
+        "jarvis.memory.conversation.update_diary_from_dialogue_memory",
+        _blocking_diary,
+        raising=False,
+    )
+
+    dialogue_memory = MagicMock()
+    dialogue_memory.should_update_diary.return_value = True
+    dialogue_memory.get_pending_chunks.return_value = ["chunk1"]
+    manager.register_dialogue_memory(dialogue_memory)
+
+    start = time.time()
+    manager.shutdown(timeout_sec=2.0)
+    elapsed = time.time() - start
+
+    # Should finish within ~3 seconds (2s timeout + small buffer)
+    assert elapsed < 5.0, f"Shutdown took too long: {elapsed:.1f}s"
+
+
+@pytest.mark.unit
+def test_db_closed_after_timeout(monkeypatch):
+    """Database is closed even when the diary flush times out."""
+    manager = _make_shutdown_manager(timeout=1.0)
+    db = _make_fake_db()
+    tts = _make_fake_tts()
+    manager.register_db(db)
+    manager.register_tts(tts)
+
+    def _blocking_diary(*args, **kwargs):
+        time.sleep(30.0)
+
+    monkeypatch.setattr(
+        "jarvis.memory.conversation.update_diary_from_dialogue_memory",
+        _blocking_diary,
+        raising=False,
+    )
+
+    dialogue_memory = MagicMock()
+    dialogue_memory.should_update_diary.return_value = True
+    dialogue_memory.get_pending_chunks.return_value = ["chunk1"]
+    manager.register_dialogue_memory(dialogue_memory)
+
+    manager.shutdown(timeout_sec=1.0)
+    db.close.assert_called_once()
+
+
+@pytest.mark.unit
+def test_tts_stopped_after_timeout(monkeypatch):
+    """TTS engine is stopped even when the diary flush times out."""
+    manager = _make_shutdown_manager(timeout=1.0)
+    db = _make_fake_db()
+    tts = _make_fake_tts()
+    manager.register_db(db)
+    manager.register_tts(tts)
+
+    def _blocking_diary(*args, **kwargs):
+        time.sleep(30.0)
+
+    monkeypatch.setattr(
+        "jarvis.memory.conversation.update_diary_from_dialogue_memory",
+        _blocking_diary,
+        raising=False,
+    )
+
+    dialogue_memory = MagicMock()
+    dialogue_memory.should_update_diary.return_value = True
+    dialogue_memory.get_pending_chunks.return_value = ["chunk1"]
+    manager.register_dialogue_memory(dialogue_memory)
+
+    manager.shutdown(timeout_sec=1.0)
+    tts.stop.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Fast shutdown when no diary update is needed
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_shutdown_fast_when_no_diary_pending():
+    """Shutdown completes quickly when there are no pending diary chunks."""
+    manager = _make_shutdown_manager(timeout=30.0)
+    db = _make_fake_db()
+    tts = _make_fake_tts()
+    manager.register_db(db)
+    manager.register_tts(tts)
+
+    dialogue_memory = MagicMock()
+    dialogue_memory.should_update_diary.return_value = False
+    dialogue_memory.get_pending_chunks.return_value = []
+    manager.register_dialogue_memory(dialogue_memory)
+
+    start = time.time()
+    manager.shutdown(timeout_sec=30.0)
+    elapsed = time.time() - start
+
+    assert elapsed < 3.0, f"Expected fast shutdown, got {elapsed:.1f}s"
+    db.close.assert_called_once()

--- a/tests/orchestration/test_tool_approval.py
+++ b/tests/orchestration/test_tool_approval.py
@@ -1,7 +1,8 @@
-"""Orchestration tests — policy engine evaluation and tool approval flow (spec 5.1).
+"""Orchestration tests — policy engine evaluation under voice-first undo model.
 
-Tests that PolicyEngine.evaluate() correctly gates tool invocations
-under different policy modes.
+Tests that PolicyEngine.evaluate() correctly handles the ACTIVE and DENY
+policy modes.  Approval gates have been removed — Jarvis uses act-then-undo
+for reversible actions and spoken warnings for irreversible ones.
 """
 
 from __future__ import annotations
@@ -14,7 +15,7 @@ from unittest.mock import MagicMock, patch
 # Helpers
 # ---------------------------------------------------------------------------
 
-def _make_engine(mode: str = "ask_destructive"):
+def _make_engine(mode: str = "active"):
     """Return a configured PolicyEngine for the given mode."""
     from jarvis.policy.approvals import ApprovalStore
     from jarvis.policy.engine import PolicyEngine
@@ -34,89 +35,82 @@ def _make_engine(mode: str = "ask_destructive"):
 
 
 # ---------------------------------------------------------------------------
-# ALWAYS_ALLOW mode
+# ACTIVE mode (default) — act-then-undo, no blocking gates
 # ---------------------------------------------------------------------------
 
 @pytest.mark.unit
-def test_always_allow_permits_destructive():
-    """ALWAYS_ALLOW mode permits destructive tools without approval."""
-    engine = _make_engine("always_allow")
+def test_active_permits_destructive():
+    """ACTIVE mode permits destructive tools (undo model handles risk)."""
+    engine = _make_engine("active")
     decision = engine.evaluate("localFiles", {"operation": "delete", "path": "/tmp/x.txt"})
     assert decision.allowed is True
     assert decision.approval_required is False
 
 
 @pytest.mark.unit
-def test_always_allow_permits_informational():
-    """ALWAYS_ALLOW mode permits informational tools."""
-    engine = _make_engine("always_allow")
+def test_active_permits_informational():
+    """ACTIVE mode permits informational tools."""
+    engine = _make_engine("active")
     decision = engine.evaluate("getWeather", {})
     assert decision.allowed is True
 
 
+@pytest.mark.unit
+def test_active_permits_write():
+    """ACTIVE mode permits write operations (undo model handles risk)."""
+    engine = _make_engine("active")
+    decision = engine.evaluate("localFiles", {"operation": "write", "path": "/tmp/x.txt"})
+    assert decision.allowed is True
+
+
 # ---------------------------------------------------------------------------
-# DENY_ALL mode
+# Legacy mode names map to ACTIVE
 # ---------------------------------------------------------------------------
 
 @pytest.mark.unit
-def test_deny_all_blocks_any_tool():
-    """DENY_ALL mode blocks every tool call."""
-    engine = _make_engine("deny_all")
+def test_legacy_always_allow_maps_to_active():
+    """Legacy 'always_allow' config value maps to ACTIVE mode."""
+    engine = _make_engine("always_allow")
+    decision = engine.evaluate("localFiles", {"operation": "delete", "path": "/tmp/x.txt"})
+    assert decision.allowed is True
+
+
+@pytest.mark.unit
+def test_legacy_ask_destructive_maps_to_active():
+    """Legacy 'ask_destructive' config value maps to ACTIVE mode."""
+    engine = _make_engine("ask_destructive")
+    decision = engine.evaluate("getWeather", {})
+    assert decision.allowed is True
+    assert decision.approval_required is False
+
+
+# ---------------------------------------------------------------------------
+# DENY mode (kill-switch)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_deny_blocks_any_tool():
+    """DENY mode blocks every tool call."""
+    engine = _make_engine("deny")
     decision = engine.evaluate("getWeather", {})
     assert decision.allowed is False
     assert decision.denied_reason
 
 
 @pytest.mark.unit
-def test_deny_all_blocks_write_tool():
-    """DENY_ALL mode blocks write operations."""
-    engine = _make_engine("deny_all")
+def test_deny_blocks_write_tool():
+    """DENY mode blocks write operations."""
+    engine = _make_engine("deny")
     decision = engine.evaluate("localFiles", {"operation": "write", "path": "/tmp/x.txt"})
     assert decision.allowed is False
 
 
-# ---------------------------------------------------------------------------
-# ASK_DESTRUCTIVE mode
-# ---------------------------------------------------------------------------
-
 @pytest.mark.unit
-def test_ask_destructive_allows_read_tool(tmp_path):
-    """ASK_DESTRUCTIVE permits read-only operations without approval."""
-    from jarvis.policy.approvals import ApprovalStore
-    from jarvis.policy.engine import PolicyEngine
-
-    target = tmp_path / "notes.txt"
-    target.write_text("data")
-
-    class _FakeCfg:
-        policy_mode = "ask_destructive"
-        workspace_roots = [str(tmp_path)]
-        blocked_roots: list = []
-        read_only_roots: list = []
-        local_files_mode = "workspace_only"
-        mcps: dict = {}
-
-    engine = PolicyEngine(_FakeCfg(), ApprovalStore())
-    decision = engine.evaluate("localFiles", {"operation": "read", "path": str(target)})
-    assert decision.allowed is True
-
-
-@pytest.mark.unit
-def test_ask_destructive_flags_delete_for_approval():
-    """ASK_DESTRUCTIVE marks delete operations as requiring approval."""
-    engine = _make_engine("ask_destructive")
-    decision = engine.evaluate("localFiles", {"operation": "delete", "path": "/tmp/x.txt"})
-    # Either denied outright or flagged for approval
-    assert not decision.allowed or decision.approval_required
-
-
-@pytest.mark.unit
-def test_ask_destructive_allows_informational():
-    """ASK_DESTRUCTIVE permits informational tools (weather, web search etc.)."""
-    engine = _make_engine("ask_destructive")
-    for tool in ("getWeather", "webSearch", "screenshot"):
-        decision = engine.evaluate(tool, {})
-        assert decision.allowed is True, f"Expected {tool} to be allowed"
+def test_legacy_deny_all_maps_to_deny():
+    """Legacy 'deny_all' config value maps to DENY mode."""
+    engine = _make_engine("deny_all")
+    decision = engine.evaluate("getWeather", {})
+    assert decision.allowed is False
 
 
 # ---------------------------------------------------------------------------
@@ -126,7 +120,7 @@ def test_ask_destructive_allows_informational():
 @pytest.mark.unit
 def test_decision_has_audit_id():
     """Every PolicyDecision carries a non-empty audit_id."""
-    engine = _make_engine("ask_destructive")
+    engine = _make_engine("active")
     decision = engine.evaluate("getWeather", {})
     assert decision.audit_id and len(decision.audit_id) > 0
 
@@ -135,7 +129,7 @@ def test_decision_has_audit_id():
 def test_decision_has_tool_class():
     """Every PolicyDecision carries a ToolClass classification."""
     from jarvis.policy.models import ToolClass
-    engine = _make_engine("ask_destructive")
+    engine = _make_engine("active")
     decision = engine.evaluate("getWeather", {})
     assert isinstance(decision.tool_class, ToolClass)
 
@@ -165,7 +159,7 @@ def test_configure_returns_engine():
     from jarvis.policy.approvals import ApprovalStore
 
     class _Cfg:
-        policy_mode = "ask_destructive"
+        policy_mode = "active"
         workspace_roots: list = []
         blocked_roots: list = []
         read_only_roots: list = []

--- a/tests/orchestration/test_tool_approval.py
+++ b/tests/orchestration/test_tool_approval.py
@@ -1,0 +1,176 @@
+"""Orchestration tests — policy engine evaluation and tool approval flow (spec 5.1).
+
+Tests that PolicyEngine.evaluate() correctly gates tool invocations
+under different policy modes.
+"""
+
+from __future__ import annotations
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_engine(mode: str = "ask_destructive"):
+    """Return a configured PolicyEngine for the given mode."""
+    from jarvis.policy.approvals import ApprovalStore
+    from jarvis.policy.engine import PolicyEngine
+    from jarvis.policy.models import PolicyMode
+
+    store = ApprovalStore()
+
+    class _FakeCfg:
+        policy_mode = mode
+        workspace_roots: list = []
+        blocked_roots: list = []
+        read_only_roots: list = []
+        local_files_mode = "home_only"
+        mcps: dict = {}
+
+    return PolicyEngine(_FakeCfg(), store)
+
+
+# ---------------------------------------------------------------------------
+# ALWAYS_ALLOW mode
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_always_allow_permits_destructive():
+    """ALWAYS_ALLOW mode permits destructive tools without approval."""
+    engine = _make_engine("always_allow")
+    decision = engine.evaluate("localFiles", {"operation": "delete", "path": "/tmp/x.txt"})
+    assert decision.allowed is True
+    assert decision.approval_required is False
+
+
+@pytest.mark.unit
+def test_always_allow_permits_informational():
+    """ALWAYS_ALLOW mode permits informational tools."""
+    engine = _make_engine("always_allow")
+    decision = engine.evaluate("getWeather", {})
+    assert decision.allowed is True
+
+
+# ---------------------------------------------------------------------------
+# DENY_ALL mode
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_deny_all_blocks_any_tool():
+    """DENY_ALL mode blocks every tool call."""
+    engine = _make_engine("deny_all")
+    decision = engine.evaluate("getWeather", {})
+    assert decision.allowed is False
+    assert decision.denied_reason
+
+
+@pytest.mark.unit
+def test_deny_all_blocks_write_tool():
+    """DENY_ALL mode blocks write operations."""
+    engine = _make_engine("deny_all")
+    decision = engine.evaluate("localFiles", {"operation": "write", "path": "/tmp/x.txt"})
+    assert decision.allowed is False
+
+
+# ---------------------------------------------------------------------------
+# ASK_DESTRUCTIVE mode
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_ask_destructive_allows_read_tool(tmp_path):
+    """ASK_DESTRUCTIVE permits read-only operations without approval."""
+    from jarvis.policy.approvals import ApprovalStore
+    from jarvis.policy.engine import PolicyEngine
+
+    target = tmp_path / "notes.txt"
+    target.write_text("data")
+
+    class _FakeCfg:
+        policy_mode = "ask_destructive"
+        workspace_roots = [str(tmp_path)]
+        blocked_roots: list = []
+        read_only_roots: list = []
+        local_files_mode = "workspace_only"
+        mcps: dict = {}
+
+    engine = PolicyEngine(_FakeCfg(), ApprovalStore())
+    decision = engine.evaluate("localFiles", {"operation": "read", "path": str(target)})
+    assert decision.allowed is True
+
+
+@pytest.mark.unit
+def test_ask_destructive_flags_delete_for_approval():
+    """ASK_DESTRUCTIVE marks delete operations as requiring approval."""
+    engine = _make_engine("ask_destructive")
+    decision = engine.evaluate("localFiles", {"operation": "delete", "path": "/tmp/x.txt"})
+    # Either denied outright or flagged for approval
+    assert not decision.allowed or decision.approval_required
+
+
+@pytest.mark.unit
+def test_ask_destructive_allows_informational():
+    """ASK_DESTRUCTIVE permits informational tools (weather, web search etc.)."""
+    engine = _make_engine("ask_destructive")
+    for tool in ("getWeather", "webSearch", "screenshot"):
+        decision = engine.evaluate(tool, {})
+        assert decision.allowed is True, f"Expected {tool} to be allowed"
+
+
+# ---------------------------------------------------------------------------
+# Decision metadata
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_decision_has_audit_id():
+    """Every PolicyDecision carries a non-empty audit_id."""
+    engine = _make_engine("ask_destructive")
+    decision = engine.evaluate("getWeather", {})
+    assert decision.audit_id and len(decision.audit_id) > 0
+
+
+@pytest.mark.unit
+def test_decision_has_tool_class():
+    """Every PolicyDecision carries a ToolClass classification."""
+    from jarvis.policy.models import ToolClass
+    engine = _make_engine("ask_destructive")
+    decision = engine.evaluate("getWeather", {})
+    assert isinstance(decision.tool_class, ToolClass)
+
+
+# ---------------------------------------------------------------------------
+# Module-level singleton
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_module_evaluate_returns_permissive_when_unconfigured():
+    """Module-level evaluate() is permissive when configure() hasn't been called."""
+    import jarvis.policy.engine as eng
+    # Save and clear the singleton
+    original = eng._default_engine
+    eng._default_engine = None
+    try:
+        decision = eng.evaluate("anyTool", {})
+        assert decision.allowed is True
+    finally:
+        eng._default_engine = original
+
+
+@pytest.mark.unit
+def test_configure_returns_engine():
+    """configure() returns a PolicyEngine instance."""
+    from jarvis.policy.engine import configure
+    from jarvis.policy.approvals import ApprovalStore
+
+    class _Cfg:
+        policy_mode = "ask_destructive"
+        workspace_roots: list = []
+        blocked_roots: list = []
+        read_only_roots: list = []
+        local_files_mode = "home_only"
+        mcps: dict = {}
+
+    engine = configure(_Cfg(), ApprovalStore())
+    assert engine is not None

--- a/tests/orchestration/test_tool_approval.py
+++ b/tests/orchestration/test_tool_approval.py
@@ -8,7 +8,12 @@ for reversible actions and spoken warnings for irreversible ones.
 from __future__ import annotations
 
 import pytest
+from pathlib import Path
 from unittest.mock import MagicMock, patch
+
+# A path inside the user's home so the "home_only" path guard permits it on
+# every platform (/tmp is outside home and correctly denied).
+_HOME_FILE = str(Path.home() / "jarvis_policy_test.txt")
 
 
 # ---------------------------------------------------------------------------
@@ -42,7 +47,7 @@ def _make_engine(mode: str = "active"):
 def test_active_permits_destructive():
     """ACTIVE mode permits destructive tools (undo model handles risk)."""
     engine = _make_engine("active")
-    decision = engine.evaluate("localFiles", {"operation": "delete", "path": "/tmp/x.txt"})
+    decision = engine.evaluate("localFiles", {"operation": "delete", "path": _HOME_FILE})
     assert decision.allowed is True
     assert decision.approval_required is False
 
@@ -59,7 +64,7 @@ def test_active_permits_informational():
 def test_active_permits_write():
     """ACTIVE mode permits write operations (undo model handles risk)."""
     engine = _make_engine("active")
-    decision = engine.evaluate("localFiles", {"operation": "write", "path": "/tmp/x.txt"})
+    decision = engine.evaluate("localFiles", {"operation": "write", "path": _HOME_FILE})
     assert decision.allowed is True
 
 
@@ -71,7 +76,7 @@ def test_active_permits_write():
 def test_legacy_always_allow_maps_to_active():
     """Legacy 'always_allow' config value maps to ACTIVE mode."""
     engine = _make_engine("always_allow")
-    decision = engine.evaluate("localFiles", {"operation": "delete", "path": "/tmp/x.txt"})
+    decision = engine.evaluate("localFiles", {"operation": "delete", "path": _HOME_FILE})
     assert decision.allowed is True
 
 
@@ -101,7 +106,7 @@ def test_deny_blocks_any_tool():
 def test_deny_blocks_write_tool():
     """DENY mode blocks write operations."""
     engine = _make_engine("deny")
-    decision = engine.evaluate("localFiles", {"operation": "write", "path": "/tmp/x.txt"})
+    decision = engine.evaluate("localFiles", {"operation": "write", "path": _HOME_FILE})
     assert decision.allowed is False
 
 

--- a/tests/test_approval.py
+++ b/tests/test_approval.py
@@ -1,0 +1,327 @@
+﻿"""Unit tests for the approval module."""
+
+import pytest
+
+from jarvis.approval import (
+    RiskLevel,
+    RequestType,
+    assess_risk,
+    classify_request,
+    is_undoable,
+    pre_execution_warning,
+    post_execution_note,
+    build_undo_args,
+)
+
+
+# ---------------------------------------------------------------------------
+# assess_risk tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_safe_read_only_tools():
+    for tool in ("screenshot", "recallConversation", "fetchMeals", "webSearch",
+                 "fetchWebPage", "getWeather", "refreshMCPTools", "stop"):
+        assert assess_risk(tool, {}) == RiskLevel.SAFE, f"Expected SAFE for {tool}"
+
+
+@pytest.mark.unit
+def test_log_meal_is_moderate():
+    assert assess_risk("logMeal", {"name": "apple"}) == RiskLevel.MODERATE
+
+
+@pytest.mark.unit
+def test_delete_meal_is_high():
+    assert assess_risk("deleteMeal", {"id": 42}) == RiskLevel.HIGH
+
+
+@pytest.mark.unit
+def test_local_files_list_is_safe():
+    assert assess_risk("localFiles", {"operation": "list"}) == RiskLevel.SAFE
+
+
+@pytest.mark.unit
+def test_local_files_read_is_safe():
+    assert assess_risk("localFiles", {"operation": "read"}) == RiskLevel.SAFE
+
+
+@pytest.mark.unit
+def test_local_files_write_is_moderate():
+    assert assess_risk("localFiles", {"operation": "write"}) == RiskLevel.MODERATE
+
+
+@pytest.mark.unit
+def test_local_files_append_is_moderate():
+    assert assess_risk("localFiles", {"operation": "append"}) == RiskLevel.MODERATE
+
+
+@pytest.mark.unit
+def test_local_files_delete_is_high():
+    assert assess_risk("localFiles", {"operation": "delete"}) == RiskLevel.HIGH
+
+
+@pytest.mark.unit
+def test_local_files_unknown_operation_is_moderate():
+    assert assess_risk("localFiles", {"operation": "chmod"}) == RiskLevel.MODERATE
+
+
+@pytest.mark.unit
+def test_mcp_tool_is_moderate():
+    assert assess_risk("filesystem__readFile", {}) == RiskLevel.MODERATE
+    assert assess_risk("myserver__doThing", {"x": 1}) == RiskLevel.MODERATE
+
+
+@pytest.mark.unit
+def test_unknown_tool_is_moderate():
+    assert assess_risk("brandNewTool", {}) == RiskLevel.MODERATE
+
+
+@pytest.mark.unit
+def test_empty_tool_name_is_safe():
+    assert assess_risk("", {}) == RiskLevel.SAFE
+    assert assess_risk(None, {}) == RiskLevel.SAFE
+
+
+# ---------------------------------------------------------------------------
+# classify_request tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_informational_queries():
+    informational = [
+        "What is the weather in London?",
+        "Tell me about Python programming",
+        "How many calories are in an apple?",
+        "What time is it?",
+        "Who is the current president?",
+    ]
+    for query in informational:
+        result = classify_request(query)
+        assert result == RequestType.INFORMATIONAL, f"Expected INFORMATIONAL for: '{query}'"
+
+
+@pytest.mark.unit
+def test_operational_queries():
+    """With a tool_name supplied, classification is OPERATIONAL regardless of text."""
+    tool_invocations = [
+        ("delete the old log files", "localFiles"),
+        ("write a summary to notes.txt", "localFiles"),
+        ("save this conversation", "writeFile"),
+        ("create a new file called report.md", "localFiles"),
+        ("log meal apple for lunch", "logMeal"),
+        ("run the tests", "shell"),
+        ("book a restaurant tonight", "mcp_restaurant"),
+    ]
+    for query, tool_name in tool_invocations:
+        result = classify_request(query, tool_name=tool_name)
+        assert result == RequestType.OPERATIONAL, (
+            f"Expected OPERATIONAL when tool_name='{tool_name}' for: '{query}'"
+        )
+
+
+@pytest.mark.unit
+def test_operational_without_tool_is_informational():
+    """Without a tool_name, even action-sounding text is classified INFORMATIONAL.
+
+    classify_request() is language-agnostic: it relies on tool presence, not
+    keyword matching, so the same text may arrive in any language.
+    """
+    action_texts = [
+        "delete the old log files",
+        "write a summary to notes.txt",
+        "send an email to Alice",
+    ]
+    for query in action_texts:
+        result = classify_request(query)
+        assert result == RequestType.INFORMATIONAL, (
+            f"Expected INFORMATIONAL (no tool_name) for: '{query}'"
+        )
+
+
+@pytest.mark.unit
+def test_empty_query_is_informational():
+    assert classify_request("") == RequestType.INFORMATIONAL
+    assert classify_request(None) == RequestType.INFORMATIONAL
+
+
+# ---------------------------------------------------------------------------
+# is_undoable tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_local_files_write_is_undoable():
+    assert is_undoable("localFiles", {"operation": "write"}) is True
+
+
+@pytest.mark.unit
+def test_local_files_append_is_undoable():
+    assert is_undoable("localFiles", {"operation": "append"}) is True
+
+
+@pytest.mark.unit
+def test_local_files_delete_is_undoable():
+    assert is_undoable("localFiles", {"operation": "delete"}) is True
+
+
+@pytest.mark.unit
+def test_local_files_read_is_not_undoable():
+    assert is_undoable("localFiles", {"operation": "read"}) is False
+
+
+@pytest.mark.unit
+def test_local_files_list_is_not_undoable():
+    assert is_undoable("localFiles", {"operation": "list"}) is False
+
+
+@pytest.mark.unit
+def test_delete_meal_is_not_undoable():
+    assert is_undoable("deleteMeal", {"id": 42}) is False
+
+
+@pytest.mark.unit
+def test_log_meal_is_not_undoable():
+    assert is_undoable("logMeal", {"name": "apple"}) is False
+
+
+@pytest.mark.unit
+def test_unknown_tool_is_not_undoable():
+    assert is_undoable("webSearch", {"query": "hello"}) is False
+
+
+@pytest.mark.unit
+def test_none_tool_is_not_undoable():
+    assert is_undoable(None, {}) is False
+
+
+# ---------------------------------------------------------------------------
+# pre_execution_warning tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_pre_execution_warning_for_high_irreversible():
+    """deleteMeal is HIGH risk and NOT undoable -- must warn."""
+    warning = pre_execution_warning("deleteMeal", {"id": 99})
+    assert warning is not None
+    assert "deleteMeal" in warning
+
+
+@pytest.mark.unit
+def test_pre_execution_warning_none_for_high_undoable():
+    """localFiles/delete is HIGH but undoable -- no pre-warning (post-note instead)."""
+    warning = pre_execution_warning("localFiles", {"operation": "delete", "path": "notes.txt"})
+    assert warning is None
+
+
+@pytest.mark.unit
+def test_pre_execution_warning_none_for_safe_tools():
+    assert pre_execution_warning("webSearch", {"query": "weather"}) is None
+    assert pre_execution_warning("screenshot", {}) is None
+
+
+@pytest.mark.unit
+def test_pre_execution_warning_none_for_moderate_tools():
+    assert pre_execution_warning("logMeal", {"name": "salad"}) is None
+    assert pre_execution_warning("localFiles", {"operation": "write"}) is None
+
+
+# ---------------------------------------------------------------------------
+# post_execution_note tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_post_execution_note_for_high_undoable():
+    """localFiles/delete is HIGH + undoable -- should return undo hint."""
+    note = post_execution_note("localFiles", {"operation": "delete", "path": "notes.txt"})
+    assert note is not None
+    assert "undo" in note.lower()
+
+
+@pytest.mark.unit
+def test_post_execution_note_none_for_high_irreversible():
+    """deleteMeal is HIGH but not undoable -- no post-note."""
+    note = post_execution_note("deleteMeal", {"id": 5})
+    assert note is None
+
+
+@pytest.mark.unit
+def test_post_execution_note_none_for_safe_tool():
+    assert post_execution_note("webSearch", {"query": "hello"}) is None
+
+
+@pytest.mark.unit
+def test_post_execution_note_none_for_moderate_non_undoable():
+    assert post_execution_note("logMeal", {"name": "banana"}) is None
+
+
+# ---------------------------------------------------------------------------
+# build_undo_args tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_build_undo_args_write_with_snapshot():
+    result = build_undo_args(
+        "localFiles",
+        {"operation": "write", "path": "notes.txt"},
+        snapshot="original content",
+    )
+    assert result is not None
+    undo_tool, undo_args, description = result
+    assert undo_tool == "localFiles"
+    assert undo_args["operation"] == "write"
+    assert undo_args["path"] == "notes.txt"
+    assert undo_args["content"] == "original content"
+    assert "notes.txt" in description
+
+
+@pytest.mark.unit
+def test_build_undo_args_append_with_snapshot():
+    result = build_undo_args(
+        "localFiles",
+        {"operation": "append", "path": "log.txt"},
+        snapshot="before-append contents",
+    )
+    assert result is not None
+    _, undo_args, _ = result
+    assert undo_args["content"] == "before-append contents"
+
+
+@pytest.mark.unit
+def test_build_undo_args_delete_with_snapshot():
+    result = build_undo_args(
+        "localFiles",
+        {"operation": "delete", "path": "shopping_list.txt"},
+        snapshot="milk\neggs\nbread",
+    )
+    assert result is not None
+    undo_tool, undo_args, description = result
+    assert undo_tool == "localFiles"
+    assert undo_args["content"] == "milk\neggs\nbread"
+    assert "shopping_list.txt" in description
+
+
+@pytest.mark.unit
+def test_build_undo_args_write_without_snapshot_returns_none():
+    result = build_undo_args(
+        "localFiles",
+        {"operation": "write", "path": "notes.txt"},
+        snapshot=None,
+    )
+    assert result is None
+
+
+@pytest.mark.unit
+def test_build_undo_args_for_non_undoable_tool():
+    result = build_undo_args("deleteMeal", {"id": 1}, snapshot=None)
+    assert result is None
+
+
+@pytest.mark.unit
+def test_build_undo_args_for_read_operation():
+    """localFiles/read is not undoable -- should return None."""
+    result = build_undo_args(
+        "localFiles",
+        {"operation": "read", "path": "notes.txt"},
+        snapshot="some content",
+    )
+    assert result is None
+

--- a/tests/test_approval.py
+++ b/tests/test_approval.py
@@ -20,7 +20,7 @@ from jarvis.approval import (
 
 @pytest.mark.unit
 def test_safe_read_only_tools():
-    for tool in ("screenshot", "recallConversation", "fetchMeals", "webSearch",
+    for tool in ("screenshot", "fetchMeals", "webSearch",
                  "fetchWebPage", "getWeather", "refreshMCPTools", "stop"):
         assert assess_risk(tool, {}) == RiskLevel.SAFE, f"Expected SAFE for {tool}"
 

--- a/tests/test_audit_recorder.py
+++ b/tests/test_audit_recorder.py
@@ -1,0 +1,101 @@
+"""Unit tests for the audit recorder."""
+
+import time
+import pytest
+from unittest.mock import MagicMock, patch, call
+
+from jarvis.audit.recorder import AuditRecorder
+from jarvis.audit.models import TaskRecord, TaskStepRecord
+
+
+@pytest.fixture
+def mock_db():
+    db = MagicMock()
+    db.fetchall.return_value = [{"started_at": time.time() - 1.0}]
+    return db
+
+
+@pytest.fixture
+def recorder(mock_db):
+    return AuditRecorder(mock_db)
+
+
+# ---------------------------------------------------------------------------
+# finish_task uses final_status for both status and final_status columns
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_finish_task_sets_status_to_final_status(recorder, mock_db):
+    recorder.finish_task("task-1", final_status="failed", error="boom")
+
+    args = mock_db.execute.call_args[0]
+    sql = args[0]
+    params = args[1]
+
+    # The SQL should have two ? placeholders for status and final_status
+    assert "SET status = ?" in sql
+    # First two params should both be the final_status value
+    assert params[0] == "failed"  # status
+    assert params[1] == "failed"  # final_status
+
+
+@pytest.mark.unit
+def test_finish_task_done_status(recorder, mock_db):
+    recorder.finish_task("task-2", final_status="done")
+
+    params = mock_db.execute.call_args[0][1]
+    assert params[0] == "done"
+    assert params[1] == "done"
+
+
+# ---------------------------------------------------------------------------
+# result_summary is redacted before storage
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_record_step_redacts_result_summary(recorder, mock_db):
+    record = TaskStepRecord(
+        step_id="step-1",
+        task_id="task-1",
+        tool_name="localFiles",
+        args_hash="abc",
+        policy_audit_id="pol-1",
+        retry_count=0,
+        result_summary="User email is user@example.com and token is GHp_abcdef1234567890",
+        success=True,
+        started_at=time.time() - 1.0,
+        finished_at=time.time(),
+    )
+    recorder.record_step(record)
+
+    params = mock_db.execute.call_args[0][1]
+    summary = params[6]  # result_summary is 7th parameter
+    assert "user@example.com" not in summary
+    assert "[REDACTED_EMAIL]" in summary
+
+
+# ---------------------------------------------------------------------------
+# intent is redacted in begin_task
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_begin_task_redacts_intent(recorder, mock_db):
+    record = TaskRecord(
+        task_id="task-1",
+        intent="Send email to admin@company.com",
+        request_type="operational",
+        selected_profile="",
+        selected_tools=[],
+        status="executing",
+        started_at=time.time(),
+        finished_at=None,
+        duration_ms=None,
+        final_status=None,
+        error=None,
+    )
+    recorder.begin_task(record)
+
+    params = mock_db.execute.call_args[0][1]
+    intent = params[1]  # intent is 2nd parameter
+    assert "admin@company.com" not in intent
+    assert "[REDACTED_EMAIL]" in intent

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,0 +1,106 @@
+"""Unit tests for the ToolRunner execution logic."""
+
+import subprocess
+import pytest
+from unittest.mock import MagicMock, patch, PropertyMock
+
+from jarvis.execution.runner import ToolRunner, RunnerMode, ExecutionResult, _TRANSIENT_ERRORS
+from jarvis.policy.models import PolicyDecision, ToolClass, RiskLevel
+
+
+@pytest.fixture
+def cfg():
+    cfg = MagicMock()
+    cfg.use_subprocess_for_writes = False
+    cfg.workspace_roots = []
+    cfg.blocked_roots = []
+    cfg.read_only_roots = []
+    cfg.local_files_mode = "home_only"
+    return cfg
+
+
+@pytest.fixture
+def runner(cfg):
+    return ToolRunner(cfg)
+
+
+@pytest.fixture
+def context():
+    return MagicMock()
+
+
+# ---------------------------------------------------------------------------
+# Retry logic: transient vs permanent errors
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_transient_error_is_retried(runner, context):
+    """Transient errors (e.g. TimeoutError) trigger retries."""
+    call_count = 0
+
+    def _run_in_process(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count < 3:
+            raise TimeoutError("connection timed out")
+        return ExecutionResult(success=True, reply_text="ok")
+
+    with patch.object(runner, "_run_in_process", side_effect=_run_in_process):
+        result = runner.run("webSearch", {"query": "test"}, context=context, max_retries=2)
+
+    assert result.success is True
+    assert call_count == 3  # 2 retries + 1 success
+
+
+@pytest.mark.unit
+def test_permanent_error_fails_immediately(runner, context):
+    """Permanent errors (e.g. ValueError) do not trigger retries."""
+    call_count = 0
+
+    def _run_in_process(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        raise ValueError("bad argument")
+
+    with patch.object(runner, "_run_in_process", side_effect=_run_in_process):
+        result = runner.run("webSearch", {"query": "test"}, context=context, max_retries=2)
+
+    assert result.success is False
+    assert "bad argument" in result.error_message
+    assert call_count == 1  # No retries
+
+
+@pytest.mark.unit
+def test_transient_errors_tuple_contains_expected_types():
+    """Verify _TRANSIENT_ERRORS covers the right exception types."""
+    assert subprocess.TimeoutExpired in _TRANSIENT_ERRORS
+    assert ConnectionError in _TRANSIENT_ERRORS
+    assert OSError in _TRANSIENT_ERRORS
+    assert TimeoutError in _TRANSIENT_ERRORS
+
+
+# ---------------------------------------------------------------------------
+# Mode selection
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_destructive_uses_subprocess(runner):
+    decision = MagicMock(spec=PolicyDecision)
+    decision.tool_class = ToolClass.DESTRUCTIVE
+    assert runner._choose_mode("deleteMeal", decision) == RunnerMode.SUBPROCESS
+
+
+@pytest.mark.unit
+def test_informational_uses_in_process(runner):
+    decision = MagicMock(spec=PolicyDecision)
+    decision.tool_class = ToolClass.INFORMATIONAL
+    assert runner._choose_mode("screenshot", decision) == RunnerMode.IN_PROCESS
+
+
+@pytest.mark.unit
+def test_write_with_subprocess_flag(cfg):
+    cfg.use_subprocess_for_writes = True
+    runner = ToolRunner(cfg)
+    decision = MagicMock(spec=PolicyDecision)
+    decision.tool_class = ToolClass.WRITE_OPERATIONAL
+    assert runner._choose_mode("localFiles", decision) == RunnerMode.SUBPROCESS

--- a/tests/test_task_state.py
+++ b/tests/test_task_state.py
@@ -1,0 +1,359 @@
+"""Unit tests for the task_state module."""
+
+import time
+import pytest
+
+from jarvis.task_state import (
+    TaskState,
+    TaskStatus,
+    StepStatus,
+    TaskStep,
+    begin_task,
+    get_active_task,
+    reset_task,
+)
+
+
+# ---------------------------------------------------------------------------
+# TaskStep tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_step_lifecycle():
+    step = TaskStep(description="do something", tool_name="webSearch")
+    assert step.status == StepStatus.PENDING
+    assert step.started_at is None
+
+    step.start()
+    assert step.status == StepStatus.RUNNING
+    assert step.started_at is not None
+
+    step.complete("result summary")
+    assert step.status == StepStatus.SUCCEEDED
+    assert step.result_summary == "result summary"
+    assert step.finished_at is not None
+
+
+@pytest.mark.unit
+def test_step_fail():
+    step = TaskStep(description="risky action")
+    step.start()
+    step.fail("something went wrong")
+    assert step.status == StepStatus.FAILED
+    assert "wrong" in (step.result_summary or "")
+
+
+@pytest.mark.unit
+def test_step_skip():
+    step = TaskStep(description="optional step")
+    step.skip("not required")
+    assert step.status == StepStatus.SKIPPED
+
+
+# ---------------------------------------------------------------------------
+# TaskState tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_task_begin():
+    state = TaskState()
+    state.begin("search for weather in London")
+    assert state.status == TaskStatus.PLANNING
+    assert state.intent == "search for weather in London"
+    assert state.started_at is not None
+    assert state.steps == []
+    assert state.error is None
+
+
+@pytest.mark.unit
+def test_task_set_executing():
+    state = TaskState()
+    state.begin("do something")
+    state.set_executing()
+    assert state.status == TaskStatus.EXECUTING
+
+
+@pytest.mark.unit
+def test_task_set_awaiting_approval():
+    state = TaskState()
+    state.begin("delete file")
+    state.set_awaiting_approval()
+    assert state.status == TaskStatus.AWAITING_APPROVAL
+
+
+@pytest.mark.unit
+def test_task_complete():
+    state = TaskState()
+    state.begin("simple query")
+    state.set_executing()
+    state.complete()
+    assert state.status == TaskStatus.DONE
+    assert state.finished_at is not None
+
+
+@pytest.mark.unit
+def test_task_fail():
+    state = TaskState()
+    state.begin("failing task")
+    state.fail("timeout")
+    assert state.status == TaskStatus.FAILED
+    assert state.error == "timeout"
+    assert state.finished_at is not None
+
+
+@pytest.mark.unit
+def test_task_reset():
+    state = TaskState()
+    state.begin("something")
+    state.complete()
+    state.reset()
+    assert state.status == TaskStatus.IDLE
+    assert state.intent == ""
+    assert state.steps == []
+
+
+@pytest.mark.unit
+def test_task_add_steps():
+    state = TaskState()
+    state.begin("multi-step task")
+
+    s1 = state.add_step("Step 1", tool_name="webSearch")
+    s2 = state.add_step("Step 2", tool_name="localFiles")
+
+    assert len(state.steps) == 2
+    assert s1 is state.steps[0]
+    assert s2 is state.steps[1]
+    assert s1.tool_name == "webSearch"
+
+
+@pytest.mark.unit
+def test_task_completed_and_failed_steps():
+    state = TaskState()
+    state.begin("multi-step task")
+
+    s1 = state.add_step("Step 1")
+    s1.start()
+    s1.complete("ok")
+
+    s2 = state.add_step("Step 2")
+    s2.start()
+    s2.fail("error")
+
+    s3 = state.add_step("Step 3")  # pending
+
+    assert len(state.completed_steps) == 1
+    assert len(state.failed_steps) == 1
+    assert state.steps[2].status == StepStatus.PENDING
+
+
+@pytest.mark.unit
+def test_can_resume_when_pending_steps():
+    state = TaskState()
+    state.begin("resumable task")
+    state.set_executing()
+
+    s1 = state.add_step("Step 1")
+    s1.start()
+    s1.complete("done")
+
+    s2 = state.add_step("Step 2")  # still pending
+
+    assert state.can_resume() is True
+
+
+@pytest.mark.unit
+def test_cannot_resume_when_done():
+    state = TaskState()
+    state.begin("finished task")
+    state.add_step("Only step").complete()
+    state.complete()
+
+    assert state.can_resume() is False
+
+
+@pytest.mark.unit
+def test_cannot_resume_when_idle():
+    state = TaskState()
+    assert state.can_resume() is False
+
+
+@pytest.mark.unit
+def test_summary_contains_key_info():
+    state = TaskState()
+    state.begin("find and summarise articles about Python")
+    state.set_executing()
+    s = state.add_step("webSearch")
+    s.start()
+    s.complete("results")
+
+    summary = state.summary()
+    assert "Task:" in summary
+    assert "executing" in summary
+
+
+# ---------------------------------------------------------------------------
+# Module-level singleton tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_begin_task_updates_singleton():
+    task = begin_task("singleton test")
+    active = get_active_task()
+    assert active.intent == "singleton test"
+    assert active.status == TaskStatus.PLANNING
+
+
+@pytest.mark.unit
+def test_reset_task_clears_singleton():
+    begin_task("something to reset")
+    reset_task()
+    active = get_active_task()
+    assert active.status == TaskStatus.IDLE
+    assert active.intent == ""
+
+
+# ---------------------------------------------------------------------------
+# Option B — REVERSIBLE status / "act then undo" model
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_awaiting_approval_is_alias_for_reversible():
+    """Backward-compat: AWAITING_APPROVAL must equal REVERSIBLE."""
+    assert TaskStatus.AWAITING_APPROVAL == TaskStatus.REVERSIBLE
+
+
+@pytest.mark.unit
+def test_step_status_has_reversible_and_reversed():
+    assert hasattr(StepStatus, "REVERSIBLE")
+    assert hasattr(StepStatus, "REVERSED")
+
+
+@pytest.mark.unit
+def test_task_step_has_step_id():
+    step = TaskStep(description="write notes", tool_name="localFiles")
+    assert isinstance(step.step_id, str)
+    assert len(step.step_id) > 0
+
+
+@pytest.mark.unit
+def test_mark_reversible_sets_step_status():
+    step = TaskStep(description="write notes", tool_name="localFiles")
+    step.start()
+    step.complete("ok")
+    step.mark_reversible("entry-id-abc")
+    assert step.status == StepStatus.REVERSIBLE
+    assert step.reversible is True
+    assert step.undo_entry_id == "entry-id-abc"
+
+
+@pytest.mark.unit
+def test_mark_reversed_transitions_step_from_reversible():
+    step = TaskStep(description="delete report.txt", tool_name="localFiles")
+    step.start()
+    step.complete("ok")
+    step.mark_reversible("entry-xyz")
+    step.mark_reversed("restored original content")
+    assert step.status == StepStatus.REVERSED
+    assert "restored" in (step.result_summary or "")
+
+
+@pytest.mark.unit
+def test_task_set_reversible_sets_task_status():
+    state = TaskState()
+    state.begin("write a file")
+    state.set_reversible()
+    assert state.status == TaskStatus.REVERSIBLE
+
+
+@pytest.mark.unit
+def test_set_awaiting_approval_is_compat_alias():
+    """set_awaiting_approval() must delegate to set_reversible()."""
+    state = TaskState()
+    state.begin("delete file")
+    state.set_awaiting_approval()
+    assert state.status == TaskStatus.REVERSIBLE
+
+
+@pytest.mark.unit
+def test_can_undo_when_reversible_task_with_reversible_steps():
+    state = TaskState()
+    state.begin("write notes")
+    s = state.add_step("write notes.txt", tool_name="localFiles")
+    s.start()
+    s.complete("ok")
+    s.mark_reversible("entry-1")
+    state.set_reversible()
+    assert state.can_undo() is True
+
+
+@pytest.mark.unit
+def test_cannot_undo_when_done():
+    state = TaskState()
+    state.begin("simple read")
+    s = state.add_step("read file", tool_name="localFiles")
+    s.start()
+    s.complete("contents")
+    state.complete()
+    assert state.can_undo() is False
+
+
+@pytest.mark.unit
+def test_reversible_steps_property_returns_only_reversible_steps():
+    state = TaskState()
+    state.begin("multi-step")
+    s1 = state.add_step("read", tool_name="localFiles")
+    s1.start()
+    s1.complete("data")
+
+    s2 = state.add_step("write", tool_name="localFiles")
+    s2.start()
+    s2.complete("saved")
+    s2.mark_reversible("entry-2")
+
+    reversible = state.reversible_steps
+    assert len(reversible) == 1
+    assert reversible[0] is s2
+
+
+@pytest.mark.unit
+def test_completed_steps_includes_reversible_steps():
+    state = TaskState()
+    state.begin("mixed task")
+    s1 = state.add_step("search", tool_name="webSearch")
+    s1.start()
+    s1.complete("results")
+
+    s2 = state.add_step("write notes", tool_name="localFiles")
+    s2.start()
+    s2.complete("saved")
+    s2.mark_reversible("entry-w")
+
+    assert len(state.completed_steps) == 2
+    assert s2 in state.completed_steps
+
+
+@pytest.mark.unit
+def test_can_resume_false_when_reversible_status():
+    """REVERSIBLE is a terminal state; resumption should not be triggered."""
+    state = TaskState()
+    state.begin("write file")
+    s = state.add_step("write", tool_name="localFiles")
+    s.start()
+    s.complete("ok")
+    s.mark_reversible("e1")
+    state.set_reversible()
+    assert state.can_resume() is False
+
+
+@pytest.mark.unit
+def test_summary_contains_reversible_info():
+    state = TaskState()
+    state.begin("write shopping list")
+    s = state.add_step("write shopping_list.txt", tool_name="localFiles")
+    s.start()
+    s.complete("saved")
+    s.mark_reversible("e99")
+    state.set_reversible()
+    summary = state.summary()
+    # Should mention the task intent and contain some status information
+    assert "shopping list" in summary.lower() or "reversible" in summary.lower()

--- a/tests/test_tool_classify.py
+++ b/tests/test_tool_classify.py
@@ -1,0 +1,83 @@
+"""Unit tests for tool classification via the classify() method on Tool base class."""
+
+import pytest
+
+from jarvis.tools.registry import BUILTIN_TOOLS
+from jarvis.policy.models import ToolClass
+
+
+# ---------------------------------------------------------------------------
+# Informational tools
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+@pytest.mark.parametrize("tool_name", [
+    "screenshot", "recallConversation", "stop", "fetchMeals",
+])
+def test_informational_tools(tool_name):
+    tool = BUILTIN_TOOLS[tool_name]
+    assert tool.classify() == ToolClass.INFORMATIONAL
+
+
+# ---------------------------------------------------------------------------
+# Read-only operational tools
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+@pytest.mark.parametrize("tool_name", [
+    "getWeather", "webSearch", "fetchWebPage", "refreshMCPTools",
+])
+def test_read_only_operational_tools(tool_name):
+    tool = BUILTIN_TOOLS[tool_name]
+    assert tool.classify() == ToolClass.READ_ONLY_OPERATIONAL
+
+
+# ---------------------------------------------------------------------------
+# Write operational tools (default)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+@pytest.mark.parametrize("tool_name", ["logMeal", "undo"])
+def test_write_operational_tools(tool_name):
+    tool = BUILTIN_TOOLS[tool_name]
+    assert tool.classify() == ToolClass.WRITE_OPERATIONAL
+
+
+# ---------------------------------------------------------------------------
+# Destructive tools
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_delete_meal_is_destructive():
+    tool = BUILTIN_TOOLS["deleteMeal"]
+    assert tool.classify() == ToolClass.DESTRUCTIVE
+
+
+# ---------------------------------------------------------------------------
+# localFiles operation-dependent classification
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+@pytest.mark.parametrize("operation,expected", [
+    ("list", ToolClass.INFORMATIONAL),
+    ("read", ToolClass.INFORMATIONAL),
+    ("write", ToolClass.WRITE_OPERATIONAL),
+    ("append", ToolClass.WRITE_OPERATIONAL),
+    ("delete", ToolClass.DESTRUCTIVE),
+])
+def test_local_files_classify_by_operation(operation, expected):
+    tool = BUILTIN_TOOLS["localFiles"]
+    assert tool.classify({"operation": operation}) == expected
+
+
+@pytest.mark.unit
+def test_local_files_unknown_operation_defaults_to_write():
+    tool = BUILTIN_TOOLS["localFiles"]
+    assert tool.classify({"operation": "chmod"}) == ToolClass.WRITE_OPERATIONAL
+
+
+@pytest.mark.unit
+def test_local_files_no_args_defaults_to_write():
+    tool = BUILTIN_TOOLS["localFiles"]
+    assert tool.classify() == ToolClass.WRITE_OPERATIONAL
+    assert tool.classify(None) == ToolClass.WRITE_OPERATIONAL

--- a/tests/test_tool_classify.py
+++ b/tests/test_tool_classify.py
@@ -12,7 +12,7 @@ from jarvis.policy.models import ToolClass
 
 @pytest.mark.unit
 @pytest.mark.parametrize("tool_name", [
-    "screenshot", "recallConversation", "stop", "fetchMeals",
+    "screenshot", "stop", "fetchMeals",
 ])
 def test_informational_tools(tool_name):
     tool = BUILTIN_TOOLS[tool_name]

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -16,6 +16,11 @@ class DummyCfg:
         self.use_stdin = True
         self.web_search_enabled = False
         self.mcps = {}
+        # Policy & workspace confinement (community PRs)
+        self.workspace_roots = []
+        self.blocked_roots = []
+        self.read_only_roots = []
+        self.local_files_mode = "unrestricted"
 
 
 class DummyDB:
@@ -63,7 +68,7 @@ def test_delete_meal_failure(monkeypatch):
 
 
 @pytest.mark.unit
-def test_local_files_list_and_read(tmp_path):
+def test_local_files_list_and_read(tmp_path, monkeypatch):
     # Arrange
     root = tmp_path / "notes"
     root.mkdir()
@@ -74,110 +79,106 @@ def test_local_files_list_and_read(tmp_path):
 
     db = DummyDB()
     cfg = DummyCfg()
+    cfg.workspace_roots = [str(tmp_path)]
+    cfg.local_files_mode = "workspace_only"
 
-    # Monkeypatch expanduser to point to tmp home
-    import jarvis.tools.registry as tools_mod
-    import builtins
-    from pathlib import Path as _P
+    # Monkeypatch expanduser globally so all modules resolve ~ to tmp_path
+    import os as _os
+    _orig = _os.path.expanduser
+    monkeypatch.setattr(_os.path, "expanduser", lambda p: str(tmp_path) + p[1:] if p.startswith("~") else _orig(p))
 
-    orig_expanduser = tools_mod.os.path.expanduser
-    tools_mod.os.path.expanduser = lambda p: str(tmp_path) if p == "~" or p.startswith("~") else orig_expanduser(p)
+    # list
+    res_list = run_tool_with_retries(
+        db=db,
+        cfg=cfg,
+        tool_name="localFiles",
+        tool_args={"operation": "list", "path": "~/notes", "glob": "*.txt", "recursive": False},
+        system_prompt="",
+        original_prompt="",
+        redacted_text="",
+        max_retries=0,
+    )
+    assert res_list.success is True
+    assert "a.txt" in (res_list.reply_text or "")
 
-    try:
-        # list
-        res_list = run_tool_with_retries(
-            db=db,
-            cfg=cfg,
-            tool_name="localFiles",
-            tool_args={"operation": "list", "path": "~/notes", "glob": "*.txt", "recursive": False},
-            system_prompt="",
-            original_prompt="",
-            redacted_text="",
-            max_retries=0,
-        )
-        assert res_list.success is True
-        assert "a.txt" in (res_list.reply_text or "")
-
-        # read
-        res_read = run_tool_with_retries(
-            db=db,
-            cfg=cfg,
-            tool_name="localFiles",
-            tool_args={"operation": "read", "path": "~/notes/a.txt"},
-            system_prompt="",
-            original_prompt="",
-            redacted_text="",
-            max_retries=0,
-        )
-        assert res_read.success is True
-        assert (res_read.reply_text or "").strip() == "hello"
-    finally:
-        tools_mod.os.path.expanduser = orig_expanduser
+    # read
+    res_read = run_tool_with_retries(
+        db=db,
+        cfg=cfg,
+        tool_name="localFiles",
+        tool_args={"operation": "read", "path": "~/notes/a.txt"},
+        system_prompt="",
+        original_prompt="",
+        redacted_text="",
+        max_retries=0,
+    )
+    assert res_read.success is True
+    assert (res_read.reply_text or "").strip() == "hello"
 
 
 @pytest.mark.unit
-def test_local_files_write_append_delete(tmp_path):
+def test_local_files_write_append_delete(tmp_path, monkeypatch):
     db = DummyDB()
     cfg = DummyCfg()
-    import jarvis.tools.registry as tools_mod
+    cfg.workspace_roots = [str(tmp_path)]
+    cfg.local_files_mode = "workspace_only"
 
-    orig_expanduser = tools_mod.os.path.expanduser
-    tools_mod.os.path.expanduser = lambda p: str(tmp_path) if p == "~" or p.startswith("~") else orig_expanduser(p)
-    try:
-        # write
-        res_write = run_tool_with_retries(
-            db=db,
-            cfg=cfg,
-            tool_name="localFiles",
-            tool_args={"operation": "write", "path": "~/x/y.txt", "content": "abc"},
-            system_prompt="",
-            original_prompt="",
-            redacted_text="",
-            max_retries=0,
-        )
-        assert res_write.success is True
+    import os as _os
+    _orig = _os.path.expanduser
+    monkeypatch.setattr(_os.path, "expanduser", lambda p: str(tmp_path) + p[1:] if p.startswith("~") else _orig(p))
 
-        # append
-        res_append = run_tool_with_retries(
-            db=db,
-            cfg=cfg,
-            tool_name="localFiles",
-            tool_args={"operation": "append", "path": "~/x/y.txt", "content": "def"},
-            system_prompt="",
-            original_prompt="",
-            redacted_text="",
-            max_retries=0,
-        )
-        assert res_append.success is True
+    # write
+    res_write = run_tool_with_retries(
+        db=db,
+        cfg=cfg,
+        tool_name="localFiles",
+        tool_args={"operation": "write", "path": "~/x/y.txt", "content": "abc"},
+        system_prompt="",
+        original_prompt="",
+        redacted_text="",
+        max_retries=0,
+    )
+    assert res_write.success is True
 
-        # read back
-        res_read = run_tool_with_retries(
-            db=db,
-            cfg=cfg,
-            tool_name="localFiles",
-            tool_args={"operation": "read", "path": "~/x/y.txt"},
-            system_prompt="",
-            original_prompt="",
-            redacted_text="",
-            max_retries=0,
-        )
-        assert res_read.success is True
-        assert (res_read.reply_text or "").strip() == "abcdef"
+    # append
+    res_append = run_tool_with_retries(
+        db=db,
+        cfg=cfg,
+        tool_name="localFiles",
+        tool_args={"operation": "append", "path": "~/x/y.txt", "content": "def"},
+        system_prompt="",
+        original_prompt="",
+        redacted_text="",
+        max_retries=0,
+    )
+    assert res_append.success is True
 
-        # delete
-        res_del = run_tool_with_retries(
-            db=db,
-            cfg=cfg,
-            tool_name="localFiles",
-            tool_args={"operation": "delete", "path": "~/x/y.txt"},
-            system_prompt="",
-            original_prompt="",
-            redacted_text="",
-            max_retries=0,
-        )
-        assert res_del.success is True
-    finally:
-        tools_mod.os.path.expanduser = orig_expanduser
+    # read back
+    res_read = run_tool_with_retries(
+        db=db,
+        cfg=cfg,
+        tool_name="localFiles",
+        tool_args={"operation": "read", "path": "~/x/y.txt"},
+        system_prompt="",
+        original_prompt="",
+        redacted_text="",
+        max_retries=0,
+    )
+    assert res_read.success is True
+    assert (res_read.reply_text or "").strip() == "abcdef"
+
+    # delete
+    res_del = run_tool_with_retries(
+        db=db,
+        cfg=cfg,
+        tool_name="localFiles",
+        tool_args={"operation": "delete", "path": "~/x/y.txt"},
+        system_prompt="",
+        original_prompt="",
+        redacted_text="",
+        max_retries=0,
+    )
+    assert res_del.success is True
 
 
 @pytest.mark.unit

--- a/tests/test_undo_registry.py
+++ b/tests/test_undo_registry.py
@@ -1,0 +1,299 @@
+"""Unit tests for the undo_registry module."""
+
+import time
+import pytest
+
+from jarvis.undo_registry import (
+    UndoEntry,
+    UndoRegistry,
+    get_undo_registry,
+    push_undo,
+    pop_last_undo,
+    pop_undo_by_id,
+    MAX_ENTRIES,
+    DEFAULT_EXPIRY_SECONDS,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_entry(
+    step_id: str = "abc123",
+    description: str = "wrote notes.txt",
+    expires_in: float = DEFAULT_EXPIRY_SECONDS,
+) -> UndoEntry:
+    """Create a minimal valid UndoEntry."""
+    now = time.time()
+    return UndoEntry(
+        step_id=step_id,
+        description=description,
+        tool_name="localFiles",
+        tool_args={"operation": "write", "path": "notes.txt"},
+        undo_tool="localFiles",
+        undo_args={"operation": "write", "path": "notes.txt", "content": "original"},
+        snapshot="original",
+        created_at=now,
+        expires_at=now + expires_in,
+    )
+
+
+@pytest.fixture(autouse=True)
+def isolated_registry():
+    """Each test gets a fresh UndoRegistry to avoid state bleed."""
+    from jarvis import undo_registry as _mod
+    old = _mod._registry
+    _mod._registry = UndoRegistry()
+    yield _mod._registry
+    _mod._registry = old
+
+
+# ---------------------------------------------------------------------------
+# UndoEntry tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_entry_not_expired_when_fresh():
+    entry = _make_entry(expires_in=60.0)
+    assert entry.is_expired is False
+
+
+@pytest.mark.unit
+def test_entry_expired_after_deadline():
+    entry = _make_entry(expires_in=-1.0)  # deadline already in the past
+    assert entry.is_expired is True
+
+
+@pytest.mark.unit
+def test_entry_age_seconds_is_non_negative():
+    entry = _make_entry()
+    assert entry.age_seconds >= 0.0
+
+
+# ---------------------------------------------------------------------------
+# Push / size
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_push_increases_size():
+    reg = UndoRegistry()
+    assert reg.size == 0
+    reg.push(_make_entry("s1"))
+    assert reg.size == 1
+    reg.push(_make_entry("s2"))
+    assert reg.size == 2
+
+
+@pytest.mark.unit
+def test_len_equals_size():
+    reg = UndoRegistry()
+    reg.push(_make_entry("s1"))
+    assert len(reg) == reg.size
+
+
+@pytest.mark.unit
+def test_push_expired_entry_is_still_stored_but_not_counted():
+    """Expired entries are pruned on the *next* push, not immediately."""
+    reg = UndoRegistry()
+    expired = _make_entry("expired", expires_in=-1.0)
+    reg.push(expired)
+    # Because push prunes expired entries *before* adding the new one,
+    # adding the expired entry itself means: prune (nothing yet), append,
+    # so size is 1 immediately after push — but size ignores expired.
+    assert reg.size == 0  # counted as expired
+
+
+@pytest.mark.unit
+def test_expired_entries_pruned_on_next_push():
+    reg = UndoRegistry()
+    expired = _make_entry("exp", expires_in=-1.0)
+    # Directly append without pruning to seed an expired entry
+    reg._entries.append(expired)
+    assert len(reg._entries) == 1
+
+    # A new push triggers pruning of the expired entry
+    reg.push(_make_entry("fresh"))
+    assert reg.size == 1
+    assert reg._entries[0].step_id == "fresh"
+
+
+@pytest.mark.unit
+def test_cap_enforced_oldest_dropped():
+    reg = UndoRegistry(max_entries=3)
+    for i in range(5):
+        reg.push(_make_entry(step_id=f"s{i}", description=f"step {i}"))
+    # Only the 3 most-recent should remain
+    assert reg.size == 3
+    remaining_ids = [e.step_id for e in reg._entries]
+    assert "s0" not in remaining_ids
+    assert "s1" not in remaining_ids
+    assert "s4" in remaining_ids
+
+
+# ---------------------------------------------------------------------------
+# pop_last
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_pop_last_returns_most_recent_first():
+    reg = UndoRegistry()
+    reg.push(_make_entry("s1", expires_in=60))
+    reg.push(_make_entry("s2", expires_in=60))
+    reg.push(_make_entry("s3", expires_in=60))
+
+    result = reg.pop_last(2)
+    assert len(result) == 2
+    assert result[0].step_id == "s3"  # most-recent first
+    assert result[1].step_id == "s2"
+    assert reg.size == 1
+    assert reg._entries[0].step_id == "s1"
+
+
+@pytest.mark.unit
+def test_pop_last_1_removes_newest():
+    reg = UndoRegistry()
+    reg.push(_make_entry("older", expires_in=60))
+    reg.push(_make_entry("newer", expires_in=60))
+
+    result = reg.pop_last(1)
+    assert result[0].step_id == "newer"
+    assert reg.size == 1
+
+
+@pytest.mark.unit
+def test_pop_last_from_empty_registry_returns_empty():
+    reg = UndoRegistry()
+    assert reg.pop_last(3) == []
+
+
+@pytest.mark.unit
+def test_pop_last_skips_expired_entries():
+    reg = UndoRegistry()
+    reg._entries.append(_make_entry("e1", expires_in=-1.0))  # pre-expired
+    reg._entries.append(_make_entry("e2", expires_in=60))
+
+    result = reg.pop_last(1)
+    assert len(result) == 1
+    assert result[0].step_id == "e2"
+
+
+@pytest.mark.unit
+def test_pop_last_n_greater_than_stack():
+    reg = UndoRegistry()
+    reg.push(_make_entry("only", expires_in=60))
+
+    result = reg.pop_last(10)
+    assert len(result) == 1
+    assert reg.size == 0
+
+
+# ---------------------------------------------------------------------------
+# pop_by_id
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_pop_by_id_finds_and_removes_entry():
+    reg = UndoRegistry()
+    reg.push(_make_entry("target", expires_in=60))
+    reg.push(_make_entry("other", expires_in=60))
+
+    entry = reg.pop_by_id("target")
+    assert entry is not None
+    assert entry.step_id == "target"
+    assert reg.size == 1
+    assert reg._entries[0].step_id == "other"
+
+
+@pytest.mark.unit
+def test_pop_by_id_missing_step_returns_none():
+    reg = UndoRegistry()
+    assert reg.pop_by_id("nonexistent") is None
+
+
+@pytest.mark.unit
+def test_pop_by_id_expired_entry_returns_none_and_removes():
+    reg = UndoRegistry()
+    reg._entries.append(_make_entry("exp", expires_in=-1.0))
+
+    result = reg.pop_by_id("exp")
+    assert result is None
+    assert len(reg._entries) == 0  # expired entry removed
+
+
+# ---------------------------------------------------------------------------
+# peek_all
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_peek_all_returns_non_expired_oldest_first():
+    reg = UndoRegistry()
+    reg.push(_make_entry("s1", expires_in=60))
+    reg.push(_make_entry("s2", expires_in=60))
+
+    snapshot = reg.peek_all()
+    assert len(snapshot) == 2
+    assert snapshot[0].step_id == "s1"
+    assert snapshot[1].step_id == "s2"
+    # peek_all must not remove entries
+    assert reg.size == 2
+
+
+@pytest.mark.unit
+def test_peek_all_excludes_expired():
+    reg = UndoRegistry()
+    reg._entries.append(_make_entry("exp", expires_in=-1.0))
+    reg._entries.append(_make_entry("fresh", expires_in=60))
+
+    snapshot = reg.peek_all()
+    assert len(snapshot) == 1
+    assert snapshot[0].step_id == "fresh"
+
+
+# ---------------------------------------------------------------------------
+# clear
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_clear_empties_registry():
+    reg = UndoRegistry()
+    reg.push(_make_entry("s1", expires_in=60))
+    reg.push(_make_entry("s2", expires_in=60))
+    reg.clear()
+    assert reg.size == 0
+    assert reg.peek_all() == []
+
+
+# ---------------------------------------------------------------------------
+# Module-level singleton convenience wrappers
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_push_undo_and_pop_last_undo_via_singleton(isolated_registry):
+    push_undo(_make_entry("sin1", expires_in=60))
+    push_undo(_make_entry("sin2", expires_in=60))
+
+    result = pop_last_undo(1)
+    assert len(result) == 1
+    assert result[0].step_id == "sin2"
+
+
+@pytest.mark.unit
+def test_pop_undo_by_id_via_singleton(isolated_registry):
+    push_undo(_make_entry("find_me", expires_in=60))
+    push_undo(_make_entry("leave_me", expires_in=60))
+
+    entry = pop_undo_by_id("find_me")
+    assert entry is not None
+    assert entry.step_id == "find_me"
+
+    remaining = pop_last_undo(10)
+    assert len(remaining) == 1
+    assert remaining[0].step_id == "leave_me"
+
+
+@pytest.mark.unit
+def test_get_undo_registry_returns_singleton(isolated_registry):
+    reg = get_undo_registry()
+    push_undo(_make_entry("x", expires_in=60))
+    assert reg.size == 1

--- a/tests/test_undo_tool.py
+++ b/tests/test_undo_tool.py
@@ -1,0 +1,191 @@
+"""Unit tests for the UndoTool builtin."""
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+from jarvis.tools.builtin.undo import UndoTool
+from jarvis.tools.base import ToolContext
+from jarvis.tools.types import RiskLevel, ToolExecutionResult
+from jarvis.undo_registry import UndoEntry
+
+
+@pytest.fixture
+def undo_tool():
+    return UndoTool()
+
+
+@pytest.fixture
+def context():
+    return ToolContext(
+        db=MagicMock(),
+        cfg=MagicMock(),
+        system_prompt="",
+        original_prompt="",
+        redacted_text="",
+        max_retries=1,
+        user_print=lambda msg: None,
+    )
+
+
+def _make_entry(step_id="abc123", description="wrote notes.txt"):
+    return UndoEntry(
+        step_id=step_id,
+        description=description,
+        tool_name="localFiles",
+        tool_args={"operation": "write", "path": "notes.txt"},
+        undo_tool="localFiles",
+        undo_args={"operation": "write", "path": "notes.txt", "content": "original"},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Metadata
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_undo_tool_name(undo_tool):
+    assert undo_tool.name == "undo"
+
+
+@pytest.mark.unit
+def test_undo_tool_risk_is_moderate(undo_tool):
+    assert undo_tool.assess_risk() == RiskLevel.MODERATE
+    assert undo_tool.assess_risk({"count": 3}) == RiskLevel.MODERATE
+
+
+@pytest.mark.unit
+def test_undo_tool_schema_has_count_and_step_id(undo_tool):
+    props = undo_tool.inputSchema["properties"]
+    assert "count" in props
+    assert "step_id" in props
+
+
+# ---------------------------------------------------------------------------
+# Empty registry
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+@patch("jarvis.tools.builtin.undo.pop_last_undo", return_value=[])
+def test_nothing_to_undo(mock_pop, undo_tool, context):
+    result = undo_tool.run({}, context)
+    assert result.success is True
+    assert "nothing to undo" in result.reply_text.lower()
+
+
+# ---------------------------------------------------------------------------
+# Single undo (default count=1)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+@patch("jarvis.tools.builtin.undo.pop_last_undo")
+@patch("jarvis.tools.registry.run_tool_with_retries")
+def test_single_undo_executes_reversal(mock_run, mock_pop, undo_tool, context):
+    entry = _make_entry()
+    mock_pop.return_value = [entry]
+    mock_run.return_value = ToolExecutionResult(
+        success=True, reply_text="File written.", error_message=None
+    )
+
+    result = undo_tool.run({}, context)
+
+    assert result.success is True
+    assert "Reversed" in result.reply_text
+    mock_run.assert_called_once()
+    call_kwargs = mock_run.call_args[1]
+    assert call_kwargs["tool_name"] == "localFiles"
+    assert call_kwargs["tool_args"]["content"] == "original"
+
+
+# ---------------------------------------------------------------------------
+# Count parameter
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+@patch("jarvis.tools.builtin.undo.pop_last_undo")
+@patch("jarvis.tools.registry.run_tool_with_retries")
+def test_count_undoes_n_entries(mock_run, mock_pop, undo_tool, context):
+    entries = [_make_entry(step_id=f"id_{i}", description=f"action {i}") for i in range(3)]
+    mock_pop.return_value = entries
+    mock_run.return_value = ToolExecutionResult(
+        success=True, reply_text="done", error_message=None
+    )
+
+    result = undo_tool.run({"count": 3}, context)
+
+    assert result.success is True
+    assert mock_run.call_count == 3
+    mock_pop.assert_called_once_with(3)
+
+
+# ---------------------------------------------------------------------------
+# step_id parameter
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+@patch("jarvis.tools.builtin.undo.pop_undo_by_id")
+@patch("jarvis.tools.registry.run_tool_with_retries")
+def test_step_id_targets_specific_entry(mock_run, mock_pop_id, undo_tool, context):
+    entry = _make_entry(step_id="specific-id")
+    mock_pop_id.return_value = entry
+    mock_run.return_value = ToolExecutionResult(
+        success=True, reply_text="done", error_message=None
+    )
+
+    result = undo_tool.run({"step_id": "specific-id"}, context)
+
+    assert result.success is True
+    assert "Reversed" in result.reply_text
+    mock_pop_id.assert_called_once_with("specific-id")
+
+
+@pytest.mark.unit
+@patch("jarvis.tools.builtin.undo.pop_undo_by_id", return_value=None)
+def test_step_id_not_found(mock_pop_id, undo_tool, context):
+    result = undo_tool.run({"step_id": "nonexistent"}, context)
+
+    assert result.success is True
+    assert "nothing to undo" in result.reply_text.lower()
+
+
+# ---------------------------------------------------------------------------
+# Reversal failure handling
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+@patch("jarvis.tools.builtin.undo.pop_last_undo")
+@patch("jarvis.tools.registry.run_tool_with_retries")
+def test_reversal_tool_error_is_reported(mock_run, mock_pop, undo_tool, context):
+    entry = _make_entry()
+    mock_pop.return_value = [entry]
+    mock_run.return_value = ToolExecutionResult(
+        success=False, reply_text=None, error_message="disk full"
+    )
+
+    result = undo_tool.run({}, context)
+
+    assert result.success is True  # Tool itself succeeds, reports the failure
+    assert "could not reverse" in result.reply_text.lower() or "disk full" in result.reply_text.lower()
+
+
+@pytest.mark.unit
+@patch("jarvis.tools.builtin.undo.pop_last_undo")
+@patch("jarvis.tools.registry.run_tool_with_retries", side_effect=RuntimeError("boom"))
+def test_reversal_exception_is_caught(mock_run, mock_pop, undo_tool, context):
+    entry = _make_entry()
+    mock_pop.return_value = [entry]
+
+    result = undo_tool.run({}, context)
+
+    assert result.success is True
+    assert "boom" in result.reply_text.lower()
+
+
+# ---------------------------------------------------------------------------
+# Count capping
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+@patch("jarvis.tools.builtin.undo.pop_last_undo", return_value=[])
+def test_count_capped_at_20(mock_pop, undo_tool, context):
+    undo_tool.run({"count": 100}, context)
+    mock_pop.assert_called_once_with(20)

--- a/tests/tools/builtin/test_local_files.py
+++ b/tests/tools/builtin/test_local_files.py
@@ -19,6 +19,13 @@ class TestLocalFilesTool:
         self.tool = LocalFilesTool()
         self.context = Mock(spec=ToolContext)
         self.context.user_print = Mock()
+        # Community PRs added policy path guard which reads cfg from context
+        mock_cfg = Mock()
+        mock_cfg.workspace_roots = []
+        mock_cfg.blocked_roots = []
+        mock_cfg.read_only_roots = []
+        mock_cfg.local_files_mode = "unrestricted"
+        self.context.cfg = mock_cfg
 
     def test_tool_properties(self):
         """Test tool metadata properties."""
@@ -109,7 +116,7 @@ class TestLocalFilesTool:
 
         assert isinstance(result, ToolExecutionResult)
         assert result.success is False
-        assert "not allowed" in result.reply_text.lower()
+        assert "denied" in result.reply_text.lower() or "not allowed" in result.reply_text.lower()
 
     def test_run_unknown_operation(self):
         """Test with unknown operation."""

--- a/tests/tools/test_tool_risk.py
+++ b/tests/tools/test_tool_risk.py
@@ -1,0 +1,145 @@
+"""Tests for Tool.assess_risk() — each tool declares its own risk level."""
+
+import pytest
+
+from jarvis.tools.types import RiskLevel
+from jarvis.tools.registry import BUILTIN_TOOLS
+
+
+# ---------------------------------------------------------------------------
+# RiskLevel is now in tools.types, but approval re-exports it for compat
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_risk_level_importable_from_tools_types():
+    from jarvis.tools.types import RiskLevel as RL
+    assert RL.SAFE.value == "safe"
+    assert RL.MODERATE.value == "moderate"
+    assert RL.HIGH.value == "high"
+
+
+@pytest.mark.unit
+def test_risk_level_still_importable_from_approval_for_compat():
+    """Backward-compat: RiskLevel must remain importable via jarvis.approval."""
+    from jarvis.approval import RiskLevel as RL
+    assert RL.SAFE.value == "safe"
+
+
+# ---------------------------------------------------------------------------
+# Safe read-only tools
+# ---------------------------------------------------------------------------
+
+_SAFE_TOOLS = [
+    "screenshot",
+    "webSearch",
+    "fetchWebPage",
+    "recallConversation",
+    "fetchMeals",
+    "getWeather",
+    "refreshMCPTools",
+    "stop",
+]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("tool_name", _SAFE_TOOLS)
+def test_safe_tools_return_safe_risk(tool_name):
+    tool = BUILTIN_TOOLS[tool_name]
+    assert tool.assess_risk({}) == RiskLevel.SAFE
+    assert tool.assess_risk(None) == RiskLevel.SAFE
+
+
+# ---------------------------------------------------------------------------
+# localFiles — operation-specific risk
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+@pytest.mark.parametrize("operation", ["list", "read"])
+def test_local_files_safe_operations(operation):
+    tool = BUILTIN_TOOLS["localFiles"]
+    assert tool.assess_risk({"operation": operation}) == RiskLevel.SAFE
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("operation", ["write", "append"])
+def test_local_files_moderate_operations(operation):
+    tool = BUILTIN_TOOLS["localFiles"]
+    assert tool.assess_risk({"operation": operation}) == RiskLevel.MODERATE
+
+
+@pytest.mark.unit
+def test_local_files_delete_is_high():
+    tool = BUILTIN_TOOLS["localFiles"]
+    assert tool.assess_risk({"operation": "delete"}) == RiskLevel.HIGH
+
+
+@pytest.mark.unit
+def test_local_files_unknown_operation_is_moderate():
+    tool = BUILTIN_TOOLS["localFiles"]
+    assert tool.assess_risk({"operation": "chmod"}) == RiskLevel.MODERATE
+
+
+@pytest.mark.unit
+def test_local_files_no_args_is_moderate():
+    tool = BUILTIN_TOOLS["localFiles"]
+    assert tool.assess_risk(None) == RiskLevel.MODERATE
+    assert tool.assess_risk({}) == RiskLevel.MODERATE
+
+
+# ---------------------------------------------------------------------------
+# deleteMeal — always HIGH
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_delete_meal_is_high():
+    tool = BUILTIN_TOOLS["deleteMeal"]
+    assert tool.assess_risk({"id": 1}) == RiskLevel.HIGH
+    assert tool.assess_risk(None) == RiskLevel.HIGH
+
+
+# ---------------------------------------------------------------------------
+# logMeal — default MODERATE
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_log_meal_is_moderate():
+    tool = BUILTIN_TOOLS["logMeal"]
+    assert tool.assess_risk({"name": "apple"}) == RiskLevel.MODERATE
+
+
+# ---------------------------------------------------------------------------
+# assess_risk() fully drives approval.assess_risk() for builtins
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_approval_assess_risk_delegates_to_tool():
+    """approval.assess_risk() must return the same value as the tool's own method."""
+    from jarvis.approval import assess_risk
+
+    for tool_name, tool in BUILTIN_TOOLS.items():
+        # Use a generic empty args dict; tool-specific operation tests are above
+        expected = tool.assess_risk({})
+        actual = assess_risk(tool_name, {})
+        assert actual == expected, (
+            f"{tool_name}: approval.assess_risk returned {actual}, "
+            f"expected {expected} from tool.assess_risk"
+        )
+
+
+@pytest.mark.unit
+def test_approval_assess_risk_mcp_tool_is_moderate():
+    from jarvis.approval import assess_risk
+    assert assess_risk("myserver__doThing", {}) == RiskLevel.MODERATE
+
+
+@pytest.mark.unit
+def test_approval_assess_risk_unknown_tool_is_moderate():
+    from jarvis.approval import assess_risk
+    assert assess_risk("brandNewTool", {}) == RiskLevel.MODERATE
+
+
+@pytest.mark.unit
+def test_approval_assess_risk_none_is_safe():
+    from jarvis.approval import assess_risk
+    assert assess_risk(None, {}) == RiskLevel.SAFE
+    assert assess_risk("", {}) == RiskLevel.SAFE

--- a/tests/tools/test_tool_risk.py
+++ b/tests/tools/test_tool_risk.py
@@ -33,7 +33,6 @@ _SAFE_TOOLS = [
     "screenshot",
     "webSearch",
     "fetchWebPage",
-    "recallConversation",
     "fetchMeals",
     "getWeather",
     "refreshMCPTools",


### PR DESCRIPTION
## Summary

Brings sjackson0109's community governance work (the `develop-community` branch) into `develop`, rebased onto the current head with original authorship preserved. The five feature commits are cherry-picked verbatim under Simon Jackson's authorship; only conflict resolution and a small test-adaptation commit were added on top.

- **Task state tracking + undo registry** (community #131): session-scoped task/step state machine, risk assessment per tool, act-then-undo model with a language-agnostic `undo` tool (replaces English-only regex detection).
- **Policy engine + path guard + agent loop errors** (community #132): workspace confinement (`home_only` default), kill-switch policy mode, formal error taxonomy for the reply loop.
- **SQLite audit trail** (community #133): opt-in, PII-redacted task/step/policy decision logging.
- **Runtime health registry + graceful shutdown** (community #134): critical vs optional service tracking.
- **Process isolation for high-risk tools** (community #130): subprocess worker containment.

## Integration notes

- Rebased across 93 commits of drift: merged with the planner-era `reply/engine.py` (task steps, undo registration, and audit recording now coexist with the pre-flight planner, toolSearchTool allow-list widening, and tool-result digest), the `llm/` package refactor, and the removal of `recallConversation` (#255).
- `undo` registered alongside `toolSearchTool` in the builtin registry.
- Spec files for all five areas are included and registered in the CLAUDE.md spec table; `reply.spec.md` merged to describe classification, approval checking, and task-state transitions alongside the current TTS/planner flow.
- No new LLM contexts: all five features are deterministic, so `docs/llm_contexts.md` is unchanged.
- Test adaptations: removed `recallConversation` references; path-guard tests now use a home-directory path so `home_only` assertions hold on every platform.

## Tests

- All new suites pass: 131 tests across task state, approval, undo registry/tool, classification, audit, runner, and orchestration.
- Full suite vs develop baseline: zero regressions (the 68 pre-existing local Qt failures are identical on `origin/develop`).

Closes #130
Closes #131
Closes #132
Closes #133
Closes #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)