### PR TITLE
fix(config): expand tilde in user-supplied path settings

### DIFF
--- a/src/jarvis/config.py
+++ b/src/jarvis/config.py
@@ -396,7 +396,7 @@ def _ensure_list(value: Any) -> list[str]:
 def _expand_path(value: Any) -> Optional[str]:
     """Normalise a user-supplied path setting: tilde-expanded string or None.
 
-    Config files (including our own exported example config) use paths like
+    User-authored config files and our docs use paths like
     "~/.local/share/jarvis/jarvis.db"; without expansion, mkdir creates or
     fails on a literal '~' directory and the daemon dies at boot (#467).
     """
@@ -733,7 +733,9 @@ def load_settings() -> Settings:
     wake_word = str(merged.get("wake_word", "jarvis")).strip().lower()
     wake_aliases = [a.strip().lower() for a in _ensure_list(merged.get("wake_aliases")) if a.strip()]
     wake_fuzzy_ratio = float(merged.get("wake_fuzzy_ratio", 0.78))
-    whisper_model = str(merged.get("whisper_model", "medium"))
+    # whisper_model accepts a size name ("medium") or a local model
+    # directory; _expand_path is a no-op for plain names.
+    whisper_model = _expand_path(merged.get("whisper_model")) or "medium"
     whisper_backend = os.environ.get("JARVIS_WHISPER_BACKEND", "").lower() or str(merged.get("whisper_backend", "auto")).lower()
     if whisper_backend not in ("auto", "mlx", "faster-whisper"):
         whisper_backend = "auto"

--- a/src/jarvis/config.py
+++ b/src/jarvis/config.py
@@ -393,6 +393,21 @@ def _ensure_list(value: Any) -> list[str]:
     return [str(value)]
 
 
+def _expand_path(value: Any) -> Optional[str]:
+    """Normalise a user-supplied path setting: tilde-expanded string or None.
+
+    Config files (including our own exported example config) use paths like
+    "~/.local/share/jarvis/jarvis.db"; without expansion, mkdir creates or
+    fails on a literal '~' directory and the daemon dies at boot (#467).
+    """
+    if value in (None, "", "null"):
+        return None
+    try:
+        return str(Path(str(value)).expanduser())
+    except Exception:
+        return str(value)
+
+
 def _ensure_dict(value: Any) -> Dict[str, Any]:
     if isinstance(value, dict):
         return value
@@ -641,8 +656,8 @@ def load_settings() -> Settings:
     voice_debug = os.environ.get("JARVIS_VOICE_DEBUG", "0") == "1"
 
     # Normalize/convert fields
-    db_path = str(merged.get("db_path") or _default_db_path())
-    sqlite_vss_path = merged.get("sqlite_vss_path")
+    db_path = _expand_path(merged.get("db_path")) or _default_db_path()
+    sqlite_vss_path = _expand_path(merged.get("sqlite_vss_path"))
     allowlist_bundles = _ensure_list(merged.get("allowlist_bundles"))
 
     ollama_base_url = str(merged.get("ollama_base_url"))
@@ -694,14 +709,12 @@ def load_settings() -> Settings:
     tts_chatterbox_device = str(merged.get("tts_chatterbox_device", "cuda")).lower()
     if tts_chatterbox_device not in ("cuda", "auto", "cpu"):
         tts_chatterbox_device = "cuda"  # Default to cuda if invalid value
-    tts_chatterbox_audio_prompt_val = merged.get("tts_chatterbox_audio_prompt")
-    tts_chatterbox_audio_prompt = None if tts_chatterbox_audio_prompt_val in (None, "", "null") else str(tts_chatterbox_audio_prompt_val)
+    tts_chatterbox_audio_prompt = _expand_path(merged.get("tts_chatterbox_audio_prompt"))
     tts_chatterbox_exaggeration = float(merged.get("tts_chatterbox_exaggeration", 0.5))
     tts_chatterbox_cfg_weight = float(merged.get("tts_chatterbox_cfg_weight", 0.5))
 
     # Piper TTS settings
-    tts_piper_model_path_val = merged.get("tts_piper_model_path")
-    tts_piper_model_path = None if tts_piper_model_path_val in (None, "", "null") else str(tts_piper_model_path_val)
+    tts_piper_model_path = _expand_path(merged.get("tts_piper_model_path"))
     tts_piper_speaker_val = merged.get("tts_piper_speaker")
     try:
         tts_piper_speaker = None if tts_piper_speaker_val in (None, "", "null") else int(tts_piper_speaker_val)

--- a/tests/test_config_path_expansion.py
+++ b/tests/test_config_path_expansion.py
@@ -50,6 +50,25 @@ def test_other_path_settings_are_expanded(tmp_path, monkeypatch):
     assert cfg.tts_chatterbox_audio_prompt == str(Path("~/prompts/me.wav").expanduser())
 
 
+def test_null_db_path_falls_back_to_default(tmp_path, monkeypatch):
+    """A 'null' db_path uses the default location instead of a literal path."""
+    _write_config(tmp_path, monkeypatch, {"db_path": "null"})
+
+    cfg = load_settings()
+
+    assert "null" not in cfg.db_path
+    assert cfg.db_path.endswith("jarvis.db")
+
+
+def test_tilde_whisper_model_path_is_expanded(tmp_path, monkeypatch):
+    """whisper_model accepts a local model directory; tilde must expand, names pass through."""
+    _write_config(tmp_path, monkeypatch, {"whisper_model": "~/models/faster-whisper-medium"})
+    assert load_settings().whisper_model == str(Path("~/models/faster-whisper-medium").expanduser())
+
+    _write_config(tmp_path, monkeypatch, {"whisper_model": "medium"})
+    assert load_settings().whisper_model == "medium"
+
+
 def test_absolute_and_unset_paths_are_untouched(tmp_path, monkeypatch):
     """Absolute paths pass through unchanged; unset optional paths stay None."""
     db = tmp_path / "jarvis.db"

--- a/tests/test_config_path_expansion.py
+++ b/tests/test_config_path_expansion.py
@@ -1,0 +1,63 @@
+"""
+Regression tests for #467: tilde paths in config.json crash the daemon.
+
+The app's own example config uses "~/.local/share/jarvis/jarvis.db", but
+``load_settings`` passed path-like values through verbatim. ``mkdir`` then
+created (or failed to create) a literal ``~`` directory — on macOS the
+daemon died at boot with ``OSError: [Errno 30] Read-only file system: '~'``.
+
+All user-supplied path-like settings must be tilde-expanded on load.
+"""
+
+import json
+from pathlib import Path
+
+from jarvis.config import load_settings
+
+
+def _write_config(tmp_path, monkeypatch, values):
+    cfg_path = tmp_path / "config.json"
+    cfg_path.write_text(json.dumps(values))
+    monkeypatch.setenv("JARVIS_CONFIG_PATH", str(cfg_path))
+
+
+def test_tilde_db_path_is_expanded(tmp_path, monkeypatch):
+    """The example-config db_path value must never produce a literal '~' path."""
+    _write_config(tmp_path, monkeypatch, {"db_path": "~/.local/share/jarvis/jarvis.db"})
+
+    cfg = load_settings()
+
+    assert "~" not in cfg.db_path
+    assert cfg.db_path == str(Path("~/.local/share/jarvis/jarvis.db").expanduser())
+
+
+def test_other_path_settings_are_expanded(tmp_path, monkeypatch):
+    """All path-like settings honour tilde notation."""
+    _write_config(
+        tmp_path,
+        monkeypatch,
+        {
+            "sqlite_vss_path": "~/vss/vss0.dylib",
+            "tts_piper_model_path": "~/models/voice.onnx",
+            "tts_chatterbox_audio_prompt": "~/prompts/me.wav",
+        },
+    )
+
+    cfg = load_settings()
+
+    assert cfg.sqlite_vss_path == str(Path("~/vss/vss0.dylib").expanduser())
+    assert cfg.tts_piper_model_path == str(Path("~/models/voice.onnx").expanduser())
+    assert cfg.tts_chatterbox_audio_prompt == str(Path("~/prompts/me.wav").expanduser())
+
+
+def test_absolute_and_unset_paths_are_untouched(tmp_path, monkeypatch):
+    """Absolute paths pass through unchanged; unset optional paths stay None."""
+    db = tmp_path / "jarvis.db"
+    _write_config(tmp_path, monkeypatch, {"db_path": str(db)})
+
+    cfg = load_settings()
+
+    assert cfg.db_path == str(db)
+    assert cfg.sqlite_vss_path is None
+    assert cfg.tts_piper_model_path is None
+    assert cfg.tts_chatterbox_audio_prompt is None


### PR DESCRIPTION
## Summary

Fixes #467: daemon dies at boot with `OSError: [Errno 30] Read-only file system: '~'` on macOS.

**Root cause:** user-authored configs (and our docs) use paths like `~/.local/share/jarvis/jarvis.db`, but `load_settings` passed path-like values through verbatim. `Database.__init__` then ran `mkdir` on a path starting with a literal `~` directory, which fails at the filesystem root on macOS and kills the daemon.

**Fix:** `db_path`, `sqlite_vss_path`, `tts_piper_model_path`, `tts_chatterbox_audio_prompt`, and `whisper_model` (which accepts a local model directory as well as a size name) are now normalised through a shared `_expand_path` helper in `src/jarvis/config.py` — tilde-expanded string, or `None` for unset/empty values, preserving the previous None/""/"null" semantics of the optional fields and falling back to the previous verbatim value if expansion itself fails (e.g. no resolvable home).

The adversarial review verified: no other `merged.get` value in `load_settings` is path-like; MCP server args are already expanded in `mcp_client.py`; the settings window round-trips `config.json` raw, so a user's `~` still persists on disk and the minimal-diff invariant is unaffected.

## Tests

New `tests/test_config_path_expansion.py`: the exact #467 value expands with no `~` remaining (failed before the fix), all path settings honour tilde notation, `whisper_model` names pass through unchanged, `"null"` db_path falls back to the default location, and absolute/unset values are untouched. Config/settings suites pass with no new failures versus develop.

Closes #467