### PR TITLE
fix(audio): serialise PortAudio stream lifecycle across threads

### DIFF
--- a/src/jarvis/dictation/dictation.spec.md
+++ b/src/jarvis/dictation/dictation.spec.md
@@ -73,6 +73,17 @@ After transcription, text passes through these stages in order:
   modifying the complex listener code.
 - **Pause flag** on the main listener to prevent dictation speech being
   interpreted as commands.
+- **No PortAudio work on the pynput hook thread.** The hotkey callbacks only
+  flip state; stream open/start runs on a worker thread (`_begin_recording`)
+  and stop/transcribe already ran on one. Windows silently unhooks slow hook
+  callbacks, and opening streams there raced other audio threads into a
+  native abort (#462). If recording is stopped before the worker finishes
+  opening the stream, the worker closes it rather than leaking a live capture.
+- **All PortAudio stream lifecycle calls** (open/start/stop/close, and
+  `sd.play` for beeps) run under the process-wide
+  `jarvis.utils.audio_lock.portaudio_lock` — PortAudio documents stream
+  open/close as not thread safe, and unserialised calls abort the whole app
+  on Windows.
 
 ### Optional Dependencies
 

--- a/src/jarvis/dictation/dictation_engine.py
+++ b/src/jarvis/dictation/dictation_engine.py
@@ -19,6 +19,7 @@ import time
 from typing import Any, Callable, Optional
 
 from ..debug import debug_log
+from ..utils.audio_lock import portaudio_lock
 from .history import DictationHistory
 
 # Optional imports — graceful degradation when dependencies are missing.
@@ -128,8 +129,11 @@ def _play_beep_sd(wav_data: bytes) -> None:
     data_start = idx + 8  # skip 'data' + size u32
     pcm = wav_data[data_start:]
     samples = np.frombuffer(pcm, dtype=np.int16).astype(np.float32) / 32768.0
-    with _suppress_stderr():
-        sd.play(samples, samplerate=44100, blocking=True)
+    # sd.play opens and closes a stream internally — lifecycle work that
+    # must be serialised with every other PortAudio user (see audio_lock).
+    with portaudio_lock:
+        with _suppress_stderr():
+            sd.play(samples, samplerate=44100, blocking=True)
 
 
 # ---------------------------------------------------------------------------
@@ -555,14 +559,15 @@ def _close_stream(stream: Any) -> None:
     """Stop and close a sounddevice InputStream, swallowing errors."""
     if stream is None:
         return
-    try:
-        stream.stop()
-    except Exception as exc:
-        debug_log(f"stream.stop() failed: {exc}", "dictation")
-    try:
-        stream.close()
-    except Exception as exc:
-        debug_log(f"stream.close() failed: {exc}", "dictation")
+    with portaudio_lock:
+        try:
+            stream.stop()
+        except Exception as exc:
+            debug_log(f"stream.stop() failed: {exc}", "dictation")
+        try:
+            stream.close()
+        except Exception as exc:
+            debug_log(f"stream.close() failed: {exc}", "dictation")
 
 
 # ---------------------------------------------------------------------------
@@ -842,11 +847,20 @@ class DictationEngine:
     # ------------------------------------------------------------------
 
     def _start_recording(self) -> None:
+        # Flip state only, then hand the heavy work (device query, stream
+        # open/start, beep) to a worker thread. This runs on the pynput
+        # hook thread: Windows silently unhooks callbacks that take too
+        # long, and opening PortAudio streams there raced the listener's
+        # audio threads into a native abort (#462).
         with self._lock:
             if self._recording:
                 return
             self._recording = True
 
+        threading.Thread(target=self._begin_recording, daemon=True).start()
+
+    def _begin_recording(self) -> None:
+        """Worker: open the audio stream and start capturing."""
         # Check Whisper readiness
         model = self._whisper_model_ref()
         backend = self._whisper_backend_ref()
@@ -891,15 +905,16 @@ class DictationEngine:
             native_rate = self._target_sample_rate
 
         try:
-            with _suppress_stderr():
-                self._stream = sd.InputStream(
-                    samplerate=native_rate,
-                    channels=1,
-                    dtype="float32",
-                    blocksize=int(native_rate * 0.1),
-                    callback=self._audio_callback,
-                    **stream_kwargs,
-                )
+            with portaudio_lock:
+                with _suppress_stderr():
+                    stream = sd.InputStream(
+                        samplerate=native_rate,
+                        channels=1,
+                        dtype="float32",
+                        blocksize=int(native_rate * 0.1),
+                        callback=self._audio_callback,
+                        **stream_kwargs,
+                    )
             self._stream_sample_rate = native_rate
             if native_rate != self._target_sample_rate:
                 debug_log(f"dictation stream at native {native_rate} Hz (will resample to {self._target_sample_rate})", "dictation")
@@ -911,12 +926,26 @@ class DictationEngine:
             return
 
         try:
-            self._stream.start()
+            with portaudio_lock:
+                stream.start()
         except Exception as exc:
             debug_log(f"failed to start dictation audio stream: {exc}", "dictation")
+            _close_stream(stream)
             self._recording = False
             if self._on_dictation_end:
                 self._on_dictation_end()
+            return
+
+        # The hotkey may have been released while the stream was opening
+        # (this now runs on a worker thread). If recording already stopped,
+        # tear the stream down instead of leaking a live capture.
+        with self._lock:
+            if self._recording:
+                self._stream = stream
+                stream = None
+        if stream is not None:
+            debug_log("dictation stopped before stream opened — closing", "dictation")
+            _close_stream(stream)
 
     def _audio_callback(self, indata, frames, time_info, status) -> None:
         """sounddevice callback — accumulate audio frames."""

--- a/src/jarvis/dictation/dictation_engine.py
+++ b/src/jarvis/dictation/dictation_engine.py
@@ -662,6 +662,11 @@ class DictationEngine:
         self._max_frames = MAX_RECORD_SECONDS * sample_rate
         self._lock = threading.Lock()
         self._started = False
+        # Monotonic recording-session token. Each press increments it; the
+        # _begin_recording worker only mutates engine state while its token
+        # is still current, so a stale worker from a superseded press can
+        # never clobber a newer session or leak a live stream.
+        self._session = 0
 
         # Double-tap detection for hands-free mode
         self._last_hotkey_release_time: float = 0.0
@@ -856,18 +861,41 @@ class DictationEngine:
             if self._recording:
                 return
             self._recording = True
+            self._session += 1
+            token = self._session
 
-        threading.Thread(target=self._begin_recording, daemon=True).start()
+        threading.Thread(
+            target=self._begin_recording, args=(token,), daemon=True
+        ).start()
 
-    def _begin_recording(self) -> None:
+    def _abandon_session(self, token: int) -> bool:
+        """Roll back a failed session if *token* is still current.
+
+        Returns True when this worker owned the active session (so the
+        caller should fire the end callback); False when a newer press has
+        superseded it and no state may be touched.
+        """
+        with self._lock:
+            if self._session != token or not self._recording:
+                return False
+            self._recording = False
+            return True
+
+    def _begin_recording(self, token: int) -> None:
         """Worker: open the audio stream and start capturing."""
         # Check Whisper readiness
         model = self._whisper_model_ref()
         backend = self._whisper_backend_ref()
         if model is None and backend != "mlx":
             debug_log("whisper model not loaded — dictation skipped", "dictation")
-            self._recording = False
+            self._abandon_session(token)
             return
+
+        # Bail early if the press was already released/superseded while the
+        # worker was starting up — avoids firing callbacks for a dead press.
+        with self._lock:
+            if self._session != token or not self._recording:
+                return
 
         debug_log("dictation recording started", "dictation")
         self._audio_frames = []
@@ -920,8 +948,7 @@ class DictationEngine:
                 debug_log(f"dictation stream at native {native_rate} Hz (will resample to {self._target_sample_rate})", "dictation")
         except Exception as exc:
             debug_log(f"failed to open dictation audio stream: {exc}", "dictation")
-            self._recording = False
-            if self._on_dictation_end:
+            if self._abandon_session(token) and self._on_dictation_end:
                 self._on_dictation_end()
             return
 
@@ -931,20 +958,20 @@ class DictationEngine:
         except Exception as exc:
             debug_log(f"failed to start dictation audio stream: {exc}", "dictation")
             _close_stream(stream)
-            self._recording = False
-            if self._on_dictation_end:
+            if self._abandon_session(token) and self._on_dictation_end:
                 self._on_dictation_end()
             return
 
-        # The hotkey may have been released while the stream was opening
-        # (this now runs on a worker thread). If recording already stopped,
-        # tear the stream down instead of leaking a live capture.
+        # The hotkey may have been released (or pressed again, starting a
+        # newer session) while the stream was opening on this worker. Only
+        # the still-current session may store its stream; anything else is
+        # torn down instead of leaking a live microphone capture.
         with self._lock:
-            if self._recording:
+            if self._session == token and self._recording:
                 self._stream = stream
                 stream = None
         if stream is not None:
-            debug_log("dictation stopped before stream opened — closing", "dictation")
+            debug_log("dictation session superseded before stream opened — closing", "dictation")
             _close_stream(stream)
 
     def _audio_callback(self, indata, frames, time_info, status) -> None:

--- a/src/jarvis/listening/listener.py
+++ b/src/jarvis/listening/listener.py
@@ -17,8 +17,11 @@ from typing import Optional, TYPE_CHECKING, Any
 from datetime import datetime
 
 from rapidfuzz import fuzz
+from contextlib import contextmanager
+
 from .echo_detection import EchoDetector
 from .state_manager import StateManager, ListeningState
+from ..utils.audio_lock import portaudio_lock
 from .wake_detection import is_wake_word_detected, extract_query_after_wake, is_stop_command
 from .transcript_buffer import TranscriptBuffer
 from .intent_judge import IntentJudge, create_intent_judge, warm_up_chat_model
@@ -337,6 +340,31 @@ def _clear_corrupted_whisper_cache(error_message: str) -> bool:
     except OSError as e:
         debug_log(f"failed to clear corrupted cache: {e}", "voice")
         return False
+
+
+
+@contextmanager
+def _serialised_stream(stream):
+    """Like ``with stream:`` but with lifecycle calls under portaudio_lock.
+
+    sounddevice's context manager calls start() on enter and stop()/close()
+    on exit; those are the thread-unsafe PortAudio lifecycle operations that
+    must be serialised process-wide (see jarvis.utils.audio_lock).
+    """
+    with portaudio_lock:
+        stream.start()
+    try:
+        yield stream
+    finally:
+        with portaudio_lock:
+            try:
+                stream.stop()
+            except Exception:
+                pass
+            try:
+                stream.close()
+            except Exception:
+                pass
 
 
 class VoiceListener(threading.Thread):
@@ -1615,20 +1643,20 @@ class VoiceListener(threading.Thread):
                 print("  🔐 Checking microphone permission...", flush=True)
                 mic_ok = threading.Event()
                 mic_error: list = [None]
-                mic_stream: list = [None]
 
                 def _mic_check():
                     try:
-                        stream = sd.InputStream(
-                            samplerate=self._samplerate, channels=1,
-                            dtype="float32", blocksize=int(self._samplerate * 0.1),
-                        )
-                        mic_stream[0] = stream
-                        stream.start()
+                        with portaudio_lock:
+                            stream = sd.InputStream(
+                                samplerate=self._samplerate, channels=1,
+                                dtype="float32", blocksize=int(self._samplerate * 0.1),
+                            )
+                            mic_stream[0] = stream
+                            stream.start()
                         time.sleep(0.15)
-                        stream.stop()
-                        stream.close()
-                        mic_stream[0] = None
+                        with portaudio_lock:
+                            stream.stop()
+                            stream.close()
                         mic_ok.set()
                     except Exception as exc:
                         mic_error[0] = exc
@@ -1638,15 +1666,13 @@ class VoiceListener(threading.Thread):
                 check_thread.join(timeout=5.0)
 
                 if check_thread.is_alive():
-                    # Clean up the stream if the thread is still blocked
+                    # Do NOT abort/close the stream from this thread: the
+                    # check thread may still be blocked inside start()/stop()
+                    # on it, and closing a stream under another thread's feet
+                    # is a native use-after-free that aborts the whole app on
+                    # Windows (#401). Abandon it — the daemon check thread
+                    # will finish the stop/close itself if it ever unblocks.
                     debug_log("microphone permission check timed out after 5s", "voice")
-                    stream_ref = mic_stream[0]
-                    if stream_ref is not None:
-                        try:
-                            stream_ref.abort()
-                            stream_ref.close()
-                        except Exception:
-                            pass
                     print("  ⚠️  Microphone permission check timed out", flush=True)
                     print("     This may indicate Windows is blocking microphone access.", flush=True)
                     print("     Continuing anyway — voice input may not work.", flush=True)
@@ -2043,14 +2069,15 @@ class VoiceListener(threading.Thread):
         self._stream_samplerate = self._samplerate
         open_error = None
         try:
-            stream = sd.InputStream(
-                samplerate=self._samplerate,
-                channels=1,
-                dtype="float32",
-                blocksize=self._frame_samples,
-                callback=self._on_audio,
-                **stream_kwargs,
-            )
+            with portaudio_lock:
+                stream = sd.InputStream(
+                    samplerate=self._samplerate,
+                    channels=1,
+                    dtype="float32",
+                    blocksize=self._frame_samples,
+                    callback=self._on_audio,
+                    **stream_kwargs,
+                )
         except Exception as e:
             error_msg = str(e).lower()
             is_rate_error = "sample rate" in error_msg or "9987" in error_msg
@@ -2067,14 +2094,15 @@ class VoiceListener(threading.Thread):
                         native_frame_samples = max(1, int(native_rate * 30 / 1000))
                         print(f"  ⚠️  Device doesn't support {self._samplerate} Hz — using {native_rate} Hz with resampling", flush=True)
                         debug_log(f"retrying stream at native {native_rate} Hz", "voice")
-                        stream = sd.InputStream(
-                            samplerate=native_rate,
-                            channels=1,
-                            dtype="float32",
-                            blocksize=native_frame_samples,
-                            callback=self._on_audio,
-                            **stream_kwargs,
-                        )
+                        with portaudio_lock:
+                            stream = sd.InputStream(
+                                samplerate=native_rate,
+                                channels=1,
+                                dtype="float32",
+                                blocksize=native_frame_samples,
+                                callback=self._on_audio,
+                                **stream_kwargs,
+                            )
                     else:
                         open_error = e
                 except Exception:
@@ -2099,11 +2127,12 @@ class VoiceListener(threading.Thread):
             return
 
         # Main audio processing loop
-        with stream:
+        with _serialised_stream(stream):
             # Verify stream is actually recording (helps catch permission issues)
             if not stream.active:
                 try:
-                    stream.start()
+                    with portaudio_lock:
+                        stream.start()
                 except Exception as e:
                     error_msg = str(e).lower()
                     debug_log(f"failed to start audio stream: {e}", "voice")

--- a/src/jarvis/listening/listener.py
+++ b/src/jarvis/listening/listener.py
@@ -1645,21 +1645,36 @@ class VoiceListener(threading.Thread):
                 mic_error: list = [None]
 
                 def _mic_check():
+                    # Deliberately NOT under portaudio_lock: this probe's
+                    # open/start can hang indefinitely when Windows blocks
+                    # mic access at the system level (that is what the 5s
+                    # timeout below is for), and hanging while holding the
+                    # process-wide lock would freeze every other audio user
+                    # (listener, dictation, TTS). The probe runs once at
+                    # startup before the listener's main stream opens, so
+                    # the residual open/open race is minimal; the quick
+                    # stop/close after a successful start stays guarded.
+                    stream = None
                     try:
-                        with portaudio_lock:
-                            stream = sd.InputStream(
-                                samplerate=self._samplerate, channels=1,
-                                dtype="float32", blocksize=int(self._samplerate * 0.1),
-                            )
-                            mic_stream[0] = stream
-                            stream.start()
+                        stream = sd.InputStream(
+                            samplerate=self._samplerate, channels=1,
+                            dtype="float32", blocksize=int(self._samplerate * 0.1),
+                        )
+                        stream.start()
                         time.sleep(0.15)
                         with portaudio_lock:
                             stream.stop()
                             stream.close()
+                        stream = None
                         mic_ok.set()
                     except Exception as exc:
                         mic_error[0] = exc
+                        if stream is not None:
+                            try:
+                                with portaudio_lock:
+                                    stream.close()
+                            except Exception:
+                                pass
 
                 check_thread = threading.Thread(target=_mic_check, daemon=True)
                 check_thread.start()

--- a/src/jarvis/listening/listening.spec.md
+++ b/src/jarvis/listening/listening.spec.md
@@ -60,6 +60,20 @@ This document outlines the voice listening architecture. The system uses a **tra
 
 ## Key Design Principles
 
+### 0. Serialised PortAudio Lifecycle
+
+All stream lifecycle calls (`InputStream`/`OutputStream` construction,
+`start`/`stop`/`close`/`abort`) run under the process-wide
+`jarvis.utils.audio_lock.portaudio_lock`, shared with the dictation engine,
+TTS, and the thinking tune. PortAudio documents stream open/close as not
+thread safe; unserialised calls across threads abort the whole app on
+Windows (#462, #401, #422). The run loop uses `_serialised_stream` instead
+of the raw `with stream:` context manager. The Windows mic-permission
+check's timeout path deliberately abandons a blocked stream instead of
+aborting/closing it from another thread — the check thread may still be
+inside `start()`/`stop()` on it, and a cross-thread close is a native
+use-after-free.
+
 ### 1. Transcript-First
 
 Instead of extracting post-wake-word audio, we:

--- a/src/jarvis/listening/listening.spec.md
+++ b/src/jarvis/listening/listening.spec.md
@@ -68,11 +68,13 @@ All stream lifecycle calls (`InputStream`/`OutputStream` construction,
 TTS, and the thinking tune. PortAudio documents stream open/close as not
 thread safe; unserialised calls across threads abort the whole app on
 Windows (#462, #401, #422). The run loop uses `_serialised_stream` instead
-of the raw `with stream:` context manager. The Windows mic-permission
-check's timeout path deliberately abandons a blocked stream instead of
-aborting/closing it from another thread — the check thread may still be
-inside `start()`/`stop()` on it, and a cross-thread close is a native
-use-after-free.
+of the raw `with stream:` context manager. Two deliberate exceptions: the
+Windows mic-permission probe opens its stream *without* the lock (that open
+can hang indefinitely when Windows blocks mic access, and hanging while
+holding the process-wide lock would freeze every audio user), and its
+timeout path abandons a blocked stream instead of aborting/closing it from
+another thread — the check thread may still be inside `start()`/`stop()`
+on it, and a cross-thread close is a native use-after-free.
 
 ### 1. Transcript-First
 

--- a/src/jarvis/output/tts.py
+++ b/src/jarvis/output/tts.py
@@ -16,6 +16,7 @@ from typing import Optional, Callable
 from urllib.parse import urlparse
 
 from ..debug import debug_log
+from ..utils.audio_lock import portaudio_lock
 
 
 # ============================================================================
@@ -786,7 +787,8 @@ class PiperTTS:
         with self._audio_lock:
             if self._audio_stream is not None:
                 try:
-                    self._audio_stream.abort()
+                    with portaudio_lock:
+                        self._audio_stream.abort()
                 except Exception:
                     pass
 
@@ -897,14 +899,15 @@ class PiperTTS:
                 play_position[0] = end
 
             with self._audio_lock:
-                self._audio_stream = sd.OutputStream(
-                    samplerate=self._sample_rate,
-                    channels=1,
-                    dtype='int16',
-                    blocksize=blocksize,
-                    callback=audio_callback,
-                )
-                self._audio_stream.start()
+                with portaudio_lock:
+                    self._audio_stream = sd.OutputStream(
+                        samplerate=self._sample_rate,
+                        channels=1,
+                        dtype='int16',
+                        blocksize=blocksize,
+                        callback=audio_callback,
+                    )
+                    self._audio_stream.start()
 
             # Wait for playback to complete
             try:
@@ -913,14 +916,16 @@ class PiperTTS:
                         interrupted = True
                         with self._audio_lock:
                             if self._audio_stream is not None:
-                                self._audio_stream.abort()
+                                with portaudio_lock:
+                                    self._audio_stream.abort()
                         break
                     time.sleep(0.05)
             finally:
                 with self._audio_lock:
                     if self._audio_stream is not None:
                         try:
-                            self._audio_stream.close()
+                            with portaudio_lock:
+                                self._audio_stream.close()
                         except Exception:
                             pass
                         self._audio_stream = None

--- a/src/jarvis/output/tune_player.py
+++ b/src/jarvis/output/tune_player.py
@@ -8,6 +8,7 @@ from typing import Optional
 import numpy as np
 
 from ..debug import debug_log
+from ..utils.audio_lock import portaudio_lock
 
 
 def _generate_thinking_pad_samples() -> tuple[np.ndarray, int]:
@@ -232,24 +233,26 @@ class TunePlayer:
                     position[0] = remainder
 
             try:
-                stream = sd.OutputStream(
-                    samplerate=sample_rate,
-                    channels=1,
-                    dtype='int16',
-                    # Large block + high latency: fewer callbacks, fewer
-                    # GIL acquisitions, lighter touch on the rest of the
-                    # app. 8192 frames ≈ 186ms per wakeup vs 23ms before.
-                    blocksize=8192,
-                    latency='high',
-                    callback=callback,
-                )
+                with portaudio_lock:
+                    stream = sd.OutputStream(
+                        samplerate=sample_rate,
+                        channels=1,
+                        dtype='int16',
+                        # Large block + high latency: fewer callbacks, fewer
+                        # GIL acquisitions, lighter touch on the rest of the
+                        # app. 8192 frames ≈ 186ms per wakeup vs 23ms before.
+                        blocksize=8192,
+                        latency='high',
+                        callback=callback,
+                    )
             except Exception as exc:
                 debug_log(f"thinking tune: stream open failed: {exc!r}", category="tune")
                 self._play_fallback_tune()
                 return
 
             try:
-                stream.start()
+                with portaudio_lock:
+                    stream.start()
                 # Hand off to the OS audio thread. Wake when stop is
                 # requested — no polling loop, no per-iteration gap.
                 self._stop_event.wait()
@@ -257,7 +260,8 @@ class TunePlayer:
                 debug_log(f"thinking tune: stream playback failed: {exc!r}", category="tune")
             finally:
                 try:
-                    stream.close()
+                    with portaudio_lock:
+                        stream.close()
                 except Exception as exc:
                     debug_log(f"thinking tune: stream close failed: {exc!r}", category="tune")
         finally:

--- a/src/jarvis/utils/audio_lock.py
+++ b/src/jarvis/utils/audio_lock.py
@@ -1,0 +1,25 @@
+"""
+Process-wide serialisation of PortAudio stream lifecycle calls.
+
+PortAudio explicitly documents opening and closing streams as NOT thread
+safe (https://github.com/PortAudio/portaudio/wiki/Tips_Threading), and its
+Windows host APIs abort the whole process on internal assertion failures.
+Jarvis touches PortAudio from several independent threads — the voice
+listener's run loop, the Windows mic-permission check thread, the dictation
+engine's worker threads, the TTS playback thread, and the thinking-tune
+player. Unserialised open/start/stop/close/abort calls across those threads
+are the root cause of the Windows "Fatal Python error: Aborted" crash
+family (#462, #401, #422).
+
+Every stream lifecycle call (constructing an ``InputStream``/``OutputStream``
+and calling ``start``/``stop``/``close``/``abort`` on it, plus blocking
+``sd.play`` which opens a stream internally) must run inside
+``portaudio_lock``. Do NOT hold the lock across playback waits or other
+blocking work, and never acquire another lock while holding it — take it
+innermost, around the direct sounddevice call only.
+"""
+
+import threading
+
+# Re-entrant so a guarded close inside a guarded open-fallback path is safe.
+portaudio_lock = threading.RLock()

--- a/src/jarvis/utils/audio_lock.py
+++ b/src/jarvis/utils/audio_lock.py
@@ -17,6 +17,14 @@ and calling ``start``/``stop``/``close``/``abort`` on it, plus blocking
 ``portaudio_lock``. Do NOT hold the lock across playback waits or other
 blocking work, and never acquire another lock while holding it — take it
 innermost, around the direct sounddevice call only.
+
+Accepted exceptions:
+- The dictation beep holds the lock across its blocking ``sd.play`` —
+  sub-200ms, and splitting play/wait would leave the internal stream's
+  teardown unguarded.
+- The Windows mic-permission probe opens its stream WITHOUT the lock: that
+  open can hang indefinitely when Windows blocks mic access, and hanging
+  while holding this lock would freeze every audio user in the process.
 """
 
 import threading

--- a/tests/test_portaudio_serialisation.py
+++ b/tests/test_portaudio_serialisation.py
@@ -1,0 +1,177 @@
+"""
+Regression tests for the Windows "Fatal Python error: Aborted" family
+(#462, #401, #422): PortAudio stream lifecycle calls made concurrently
+from independent threads.
+
+PortAudio documents stream open/close as not thread safe; on Windows an
+internal assertion failure aborts the whole process, which cannot be
+caught from Python. The defence is behavioural and testable on any
+platform:
+
+1. Every stream lifecycle call goes through the process-wide
+   ``portaudio_lock``, so two threads can never be inside PortAudio
+   lifecycle code at the same time.
+2. The dictation engine never opens streams on the pynput hook thread —
+   the hotkey callback returns immediately and stream work happens on a
+   worker thread (Windows silently unhooks slow hook callbacks, and the
+   hook thread has no COM/PortAudio affinity guarantees).
+
+These tests install a fake ``sounddevice`` whose lifecycle entry points
+record concurrency and calling thread, then drive the real engine code.
+"""
+
+import threading
+import time
+
+import jarvis.dictation.dictation_engine as de
+from jarvis.utils.audio_lock import portaudio_lock
+
+
+class _ConcurrencyProbe:
+    """Counts how many threads are inside a lifecycle call simultaneously."""
+
+    def __init__(self):
+        self._lock = threading.Lock()
+        self.active = 0
+        self.max_active = 0
+        self.calls = []
+
+    def enter(self, name):
+        with self._lock:
+            self.active += 1
+            self.max_active = max(self.max_active, self.active)
+            self.calls.append((name, threading.get_ident()))
+        time.sleep(0.02)  # widen the overlap window
+
+    def exit(self):
+        with self._lock:
+            self.active -= 1
+
+
+class _FakeStream:
+    def __init__(self, probe, **kwargs):
+        probe.enter("open")
+        self._probe = probe
+        self.closed = False
+        probe.exit()
+
+    def start(self):
+        self._probe.enter("start")
+        self._probe.exit()
+
+    def stop(self):
+        self._probe.enter("stop")
+        self._probe.exit()
+
+    def close(self):
+        self._probe.enter("close")
+        self.closed = True
+        self._probe.exit()
+
+
+class _FakeSounddevice:
+    def __init__(self, probe):
+        self._probe = probe
+
+    def InputStream(self, **kwargs):
+        return _FakeStream(self._probe, **kwargs)
+
+    def query_devices(self, *args, **kwargs):
+        return {"default_samplerate": 16000}
+
+
+def _make_engine(monkeypatch, probe):
+    fake_sd = _FakeSounddevice(probe)
+    monkeypatch.setattr(de, "sd", fake_sd)
+    engine = de.DictationEngine(
+        whisper_model_ref=lambda: object(),
+        whisper_backend_ref=lambda: "faster-whisper",
+        mlx_repo_ref=lambda: None,
+    )
+    return engine
+
+
+def test_hotkey_press_does_not_open_stream_on_calling_thread(monkeypatch):
+    """The (pynput) calling thread must return without touching PortAudio."""
+    probe = _ConcurrencyProbe()
+    engine = _make_engine(monkeypatch, probe)
+
+    hook_thread_ident = [None]
+
+    def press():
+        hook_thread_ident[0] = threading.get_ident()
+        engine._start_recording()
+
+    t = threading.Thread(target=press)
+    t.start()
+    t.join(timeout=5)
+
+    # Wait for the worker to open the stream.
+    deadline = time.time() + 5
+    while time.time() < deadline and not any(n == "open" for n, _ in probe.calls):
+        time.sleep(0.01)
+
+    open_threads = [ident for name, ident in probe.calls if name in ("open", "start")]
+    assert open_threads, "stream was never opened"
+    assert hook_thread_ident[0] not in open_threads, (
+        "stream lifecycle ran on the hotkey callback thread"
+    )
+    engine._stop_recording(discard=True)
+
+
+def test_stop_before_stream_opens_still_closes_stream(monkeypatch):
+    """Press/release faster than the stream opens: no leaked live stream."""
+    probe = _ConcurrencyProbe()
+    engine = _make_engine(monkeypatch, probe)
+
+    engine._start_recording()
+    engine._stop_recording(discard=True)  # may run before the worker opened it
+
+    # Whatever the interleaving, the engine must settle on: not recording,
+    # no stored stream, and any opened stream closed.
+    deadline = time.time() + 5
+    while time.time() < deadline:
+        opened = [c for c in probe.calls if c[0] == "open"]
+        closed = [c for c in probe.calls if c[0] == "close"]
+        if not engine.is_recording and engine._stream is None and (not opened or closed):
+            break
+        time.sleep(0.01)
+
+    assert not engine.is_recording
+    assert engine._stream is None
+    opened = [c for c in probe.calls if c[0] == "open"]
+    closed = [c for c in probe.calls if c[0] == "close"]
+    assert not opened or closed, "stream opened after stop was never closed"
+
+
+def test_lifecycle_calls_are_serialised_with_portaudio_lock(monkeypatch):
+    """No lifecycle call may overlap another thread holding portaudio_lock."""
+    probe = _ConcurrencyProbe()
+    engine = _make_engine(monkeypatch, probe)
+
+    stop = threading.Event()
+
+    def competitor():
+        # Simulates any other subsystem (listener, TTS, tune player) doing
+        # guarded lifecycle work in a tight loop.
+        while not stop.is_set():
+            with portaudio_lock:
+                probe.enter("competitor-lifecycle")
+                probe.exit()
+
+    t = threading.Thread(target=competitor, daemon=True)
+    t.start()
+    try:
+        for _ in range(5):
+            engine._start_recording()
+            deadline = time.time() + 5
+            while time.time() < deadline and engine._stream is None:
+                time.sleep(0.005)
+            engine._stop_recording(discard=True)
+    finally:
+        stop.set()
+        t.join(timeout=5)
+
+    assert probe.max_active == 1, (
+        f"PortAudio lifecycle calls overlapped (max concurrency {probe.max_active})"
+    )

--- a/tests/test_portaudio_serialisation.py
+++ b/tests/test_portaudio_serialisation.py
@@ -49,8 +49,10 @@ class _ConcurrencyProbe:
 
 
 class _FakeStream:
-    def __init__(self, probe, **kwargs):
+    def __init__(self, probe, gate=None, **kwargs):
         probe.enter("open")
+        if gate is not None:
+            gate.wait(timeout=5)  # let tests pin the open/stop interleaving
         self._probe = probe
         self.closed = False
         probe.exit()
@@ -70,18 +72,27 @@ class _FakeStream:
 
 
 class _FakeSounddevice:
-    def __init__(self, probe):
+    def __init__(self, probe, open_gate=None):
         self._probe = probe
+        self._open_gate = open_gate
 
     def InputStream(self, **kwargs):
-        return _FakeStream(self._probe, **kwargs)
+        return _FakeStream(self._probe, gate=self._open_gate, **kwargs)
 
     def query_devices(self, *args, **kwargs):
         return {"default_samplerate": 16000}
 
 
-def _make_engine(monkeypatch, probe):
-    fake_sd = _FakeSounddevice(probe)
+def _drain_worker_threads(baseline):
+    """Join threads spawned during a test so a late worker can't run against
+    the next test's monkeypatched fake sounddevice."""
+    for t in threading.enumerate():
+        if t not in baseline and t is not threading.current_thread():
+            t.join(timeout=5)
+
+
+def _make_engine(monkeypatch, probe, open_gate=None):
+    fake_sd = _FakeSounddevice(probe, open_gate=open_gate)
     monkeypatch.setattr(de, "sd", fake_sd)
     engine = de.DictationEngine(
         whisper_model_ref=lambda: object(),
@@ -93,6 +104,7 @@ def _make_engine(monkeypatch, probe):
 
 def test_hotkey_press_does_not_open_stream_on_calling_thread(monkeypatch):
     """The (pynput) calling thread must return without touching PortAudio."""
+    baseline = set(threading.enumerate())
     probe = _ConcurrencyProbe()
     engine = _make_engine(monkeypatch, probe)
 
@@ -117,15 +129,19 @@ def test_hotkey_press_does_not_open_stream_on_calling_thread(monkeypatch):
         "stream lifecycle ran on the hotkey callback thread"
     )
     engine._stop_recording(discard=True)
+    _drain_worker_threads(baseline)
 
 
 def test_stop_before_stream_opens_still_closes_stream(monkeypatch):
     """Press/release faster than the stream opens: no leaked live stream."""
+    baseline = set(threading.enumerate())
     probe = _ConcurrencyProbe()
-    engine = _make_engine(monkeypatch, probe)
+    open_gate = threading.Event()
+    engine = _make_engine(monkeypatch, probe, open_gate=open_gate)
 
     engine._start_recording()
-    engine._stop_recording(discard=True)  # may run before the worker opened it
+    engine._stop_recording(discard=True)  # guaranteed before the open finishes
+    open_gate.set()  # now let the worker's stream open complete
 
     # Whatever the interleaving, the engine must settle on: not recording,
     # no stored stream, and any opened stream closed.
@@ -142,10 +158,55 @@ def test_stop_before_stream_opens_still_closes_stream(monkeypatch):
     opened = [c for c in probe.calls if c[0] == "open"]
     closed = [c for c in probe.calls if c[0] == "close"]
     assert not opened or closed, "stream opened after stop was never closed"
+    _drain_worker_threads(baseline)
+
+
+def test_stale_worker_from_superseded_press_never_stores_its_stream(monkeypatch):
+    """press → release → press again while the first open is stalled.
+
+    The first (stale) worker must not attach its stream to the second
+    session — that would leak a live microphone capture (#462 family).
+    """
+    baseline = set(threading.enumerate())
+    probe = _ConcurrencyProbe()
+    open_gate = threading.Event()
+    engine = _make_engine(monkeypatch, probe, open_gate=open_gate)
+
+    engine._start_recording()          # session 1, worker A stalls in open
+    deadline = time.time() + 5         # wait until A is pinned inside the open
+    while time.time() < deadline and not any(c[0] == "open" for c in probe.calls):
+        time.sleep(0.005)
+    assert any(c[0] == "open" for c in probe.calls), "worker A never reached open"
+    engine._stop_recording(discard=True)   # release while A is mid-open
+
+    # Second press with instant opens.
+    open_gate.set()
+    engine._start_recording()          # session 2
+
+    deadline = time.time() + 5
+    while time.time() < deadline and engine._stream is None:
+        time.sleep(0.01)
+    session_stream = engine._stream
+    assert session_stream is not None, "second session never got its stream"
+
+    # Wait for worker A to finish; it must have closed its own stream and
+    # left session 2's stream in place.
+    deadline = time.time() + 5
+    while time.time() < deadline and not any(c[0] == "close" for c in probe.calls):
+        time.sleep(0.01)
+    assert engine._stream is session_stream
+    opened = [c for c in probe.calls if c[0] == "open"]
+    closed = [c for c in probe.calls if c[0] == "close"]
+    assert len(opened) == 2
+    assert len(closed) >= 1, "stale worker's stream was never closed"
+
+    engine._stop_recording(discard=True)
+    _drain_worker_threads(baseline)
 
 
 def test_lifecycle_calls_are_serialised_with_portaudio_lock(monkeypatch):
     """No lifecycle call may overlap another thread holding portaudio_lock."""
+    baseline = set(threading.enumerate())
     probe = _ConcurrencyProbe()
     engine = _make_engine(monkeypatch, probe)
 
@@ -175,3 +236,4 @@ def test_lifecycle_calls_are_serialised_with_portaudio_lock(monkeypatch):
     assert probe.max_active == 1, (
         f"PortAudio lifecycle calls overlapped (max concurrency {probe.max_active})"
     )
+    _drain_worker_threads(baseline)


### PR DESCRIPTION
## Summary

Tackles the Windows `Fatal Python error: Aborted` crash family (#462, #401, #422) — the biggest remaining crash group.

**Diagnosis (from the crash traces + PortAudio docs):** PortAudio explicitly documents opening and closing streams as [not thread safe](https://github.com/PortAudio/portaudio/wiki/Tips_Threading), and its Windows host APIs abort the whole process on internal assertion failures, which Python cannot catch. Jarvis touched PortAudio from five uncoordinated threads (listener run loop, Windows mic-check thread, pynput keyboard-hook thread, TTS playback, thinking tune). The traces capture the overlaps directly: #462 aborts opening the dictation `InputStream` **on the pynput hook thread**; #401 aborts in `stream.stop()` on the mic-check thread concurrent with other audio work; #422 aborts on a native PortAudio thread while the listener stream was live.

**Fix (three layers):**
1. **Process-wide lifecycle lock** — new `jarvis.utils.audio_lock.portaudio_lock`; every stream open/start/stop/close/abort (and beep `sd.play`) across the listener, dictation engine, TTS, and tune player runs under it, held only around the direct sounddevice calls. Two documented exceptions: the sub-200ms beep, and the Windows mic-permission probe's open/start, which can hang indefinitely when Windows blocks mic access and must not hang holding the process-wide lock.
2. **No PortAudio work on the pynput hook thread** — the hotkey press callback flips state and hands stream open/start to a worker (`_begin_recording`), mirroring the existing stop path. Sessions carry a monotonic token so a stale worker from a superseded press can never store its stream into a newer session (which would leak a live microphone capture) or clobber its state; a press released before the stream opens tears the stream down.
3. **Mic-check timeout use-after-free removed** — the run thread no longer aborts/closes the check thread's stream while that thread may still be blocked inside `start()`/`stop()` on it; the stream is abandoned and finished by its owner.

Specs updated (`dictation.spec.md`, `listening.spec.md`) with the lock contract, worker-thread rule, and both exceptions.

An adversarial multi-agent review ran on the first revision and found two genuine blockers (a leftover `mic_stream` NameError in the rewritten Windows mic check, and the probe holding the global lock across a potentially-hanging open) plus the stale-worker race — all fixed in the follow-up commit. The review also verified the full lock-order graph: no sounddevice callback acquires the lock (so `stream.stop()` under the lock cannot deadlock against a callback), and lock nesting is consistently outer→inner everywhere.

**Honesty note:** the abort itself only reproduces on Windows audio stacks, which I cannot run here. The fix follows PortAudio's documented threading contract, and the enforced invariants are covered by behavioural tests that run on all platforms.

## Tests

`tests/test_portaudio_serialisation.py` (fake sounddevice + real engine code, interleavings pinned with gates, worker threads drained between tests):
- hotkey press never runs stream lifecycle on the calling (hook) thread — failed before the fix;
- press/release faster than the stream opens still ends with the stream closed and the engine idle;
- a stale worker from a superseded press never stores its stream into a newer session;
- lifecycle calls never overlap another thread holding `portaudio_lock` — failed before the fix.

Stable across 5 consecutive runs; full suite failure set identical to clean develop locally (pre-existing env failures only).

Closes #462
Closes #401
Closes #422