### PR TITLE
docs: fix stale Ollama-only prerequisite messaging (README + release notes)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -332,7 +332,7 @@ jobs:
             ---
 
             ### ⚡ Prerequisites
-            - [Ollama](https://ollama.com/download) (all platforms)
+            - [Ollama](https://ollama.com/download) (default), or any OpenAI-compatible server (LM Studio, Jan, llama.cpp, vLLM, oMLX, LocalAI, …)
 
             ### 📦 Downloads
             | Platform | File | Notes |
@@ -471,7 +471,7 @@ jobs:
             ---
 
             ### ⚡ Prerequisites
-            - [Ollama](https://ollama.com/download) (all platforms)
+            - [Ollama](https://ollama.com/download) (default), or any OpenAI-compatible server (LM Studio, Jan, llama.cpp, vLLM, oMLX, LocalAI, …)
 
             ### 📦 Downloads
             | Platform | File | Notes |

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ I have opened YouTube for you.
 
 | Platform | Requirement |
 |----------|-------------|
-| **All** | [Ollama](https://ollama.com/download) |
+| **All** | [Ollama](https://ollama.com/download) (default), or any OpenAI-compatible server you already run (LM Studio, Jan, llama.cpp, vLLM, oMLX, LocalAI, …) — see [Configuration → LLM Provider](#configuration) |
 
 ### 2. Download Jarvis
 
@@ -179,7 +179,7 @@ Jarvis starts listening automatically — just say "Jarvis" and talk!
 | Better quality | 16GB+ | `gemma4:e4b` |
 | High-end | 24GB+ | `gpt-oss:20b` |
 
-> **Note:** VRAM requirements include the intent judge model (`gemma4:e2b`) which is always loaded alongside the chat model for voice intent classification. The default model shares this, so no extra VRAM is needed.
+> **Note:** VRAM requirements include the fast model (`gemma4:e2b`) which is always loaded alongside the chat model for voice intent classification and other real-time work. The default chat model shares this, so no extra VRAM is needed.
 
 The setup wizard will guide you through model selection and installation on first launch.
 


### PR DESCRIPTION
## Summary
- README Quick Install → Prerequisites listed **Ollama** as the sole requirement for all platforms. The wizard has offered an equally first-class OpenAI-compatible path (LM Studio, Jan, llama.cpp, vLLM, oMLX, LocalAI, ...) since #457 — the table now says so.
- README System Requirements' VRAM note still said "intent judge model", a name retired by the `fast_model` rename in #525.
- The release workflow's auto-generated GitHub Releases body (both the stable release and develop pre-release templates) had the identical stale "Prerequisites: Ollama (all platforms)" claim — every future release publishes this to users. Fixed to match the README wording.

Docs/CI-config only, no application code touched.