### PR TITLE
fix(config): make config.json writes atomic

### DIFF
--- a/src/jarvis/config.py
+++ b/src/jarvis/config.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import json
+import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, Optional
@@ -292,6 +293,10 @@ def _load_json(path: Path) -> Dict[str, Any]:
 def _save_json(path: Path, data: Dict[str, Any]) -> bool:
     """Save config data to JSON file. Returns True on success.
 
+    Writes to a temp file in the same directory and ``os.replace()``s it
+    over the target, so a crash mid-write leaves the existing config
+    untouched instead of truncated.
+
     Restricts the saved file to ``0o600`` on POSIX so credentials in
     config (``llm_api_key``, ``embedding_api_key``, ``brave_search_api_key``)
     are not readable by other users on multi-user systems. ``chmod`` is a
@@ -300,12 +305,24 @@ def _save_json(path: Path, data: Dict[str, Any]) -> bool:
     """
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
-        with path.open("w", encoding="utf-8") as f:
-            json.dump(data, f, indent=2)
+        fd, tmp_name = tempfile.mkstemp(
+            dir=str(path.parent), prefix=f".{path.name}.", suffix=".tmp"
+        )
+        tmp_path = Path(tmp_name)
         try:
-            path.chmod(0o600)
-        except OSError:
-            pass
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                json.dump(data, f, indent=2)
+            try:
+                tmp_path.chmod(0o600)
+            except OSError:
+                pass
+            os.replace(tmp_path, path)
+        except Exception:
+            try:
+                tmp_path.unlink()
+            except OSError:
+                pass
+            raise
         return True
     except Exception:
         return False

--- a/tests/test_config_atomic_save.py
+++ b/tests/test_config_atomic_save.py
@@ -1,0 +1,95 @@
+"""
+Regression tests: ``_save_json`` must never leave ``config.json`` truncated
+or partially written if the process dies mid-save.
+
+The config file can hold ``llm_api_key`` and every other user setting, so a
+crash between opening the file for writing and finishing the write used to
+leave the user with a corrupted or empty config. ``_save_json`` now writes
+to a temp file in the same directory and ``os.replace()``s it over the
+target, so the target either has the old contents or the new contents,
+never a partial write.
+"""
+
+import json
+import os
+
+import pytest
+
+from jarvis.config import _save_json
+
+
+def test_save_json_writes_new_contents_via_replace(tmp_path, monkeypatch):
+    """The temp file holds the old contents at the moment of the atomic swap."""
+    cfg_path = tmp_path / "config.json"
+    original = {"llm_api_key": "original-secret"}
+    cfg_path.write_text(json.dumps(original))
+
+    replace_calls = []
+    real_replace = os.replace
+
+    def spy_replace(src, dst):
+        # Destination must still hold the original bytes right up until the swap.
+        assert cfg_path.read_text() == json.dumps(original)
+        replace_calls.append((src, dst))
+        return real_replace(src, dst)
+
+    monkeypatch.setattr(os, "replace", spy_replace)
+
+    ok = _save_json(cfg_path, {"llm_api_key": "new-secret"})
+
+    assert ok is True
+    assert replace_calls
+    assert json.loads(cfg_path.read_text()) == {"llm_api_key": "new-secret"}
+
+
+def test_save_json_leaves_original_intact_on_failure_between_write_and_rename(
+    tmp_path, monkeypatch
+):
+    """A crash between the temp-file write and the rename must not corrupt the config."""
+    cfg_path = tmp_path / "config.json"
+    original = {"llm_api_key": "original-secret", "some_setting": True}
+    cfg_path.write_text(json.dumps(original))
+
+    def failing_replace(src, dst):
+        raise OSError("simulated crash between write and rename")
+
+    monkeypatch.setattr(os, "replace", failing_replace)
+
+    ok = _save_json(cfg_path, {"llm_api_key": "corrupted-write"})
+
+    assert ok is False
+    assert json.loads(cfg_path.read_text()) == original
+
+
+def test_save_json_leaves_no_leftover_temp_file_on_failure(tmp_path, monkeypatch):
+    cfg_path = tmp_path / "config.json"
+    cfg_path.write_text(json.dumps({"llm_api_key": "original-secret"}))
+
+    def failing_replace(src, dst):
+        raise OSError("simulated crash between write and rename")
+
+    monkeypatch.setattr(os, "replace", failing_replace)
+
+    _save_json(cfg_path, {"llm_api_key": "corrupted-write"})
+
+    leftover = [p for p in tmp_path.iterdir() if p != cfg_path]
+    assert leftover == []
+
+
+def test_save_json_no_leftover_temp_files_on_success(tmp_path):
+    cfg_path = tmp_path / "config.json"
+
+    ok = _save_json(cfg_path, {"a": 1})
+
+    assert ok is True
+    leftover = [p for p in tmp_path.iterdir() if p != cfg_path]
+    assert leftover == []
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX-only permission check")
+def test_save_json_sets_permissions_to_0600_on_posix(tmp_path):
+    cfg_path = tmp_path / "config.json"
+
+    _save_json(cfg_path, {"llm_api_key": "secret"})
+
+    assert (cfg_path.stat().st_mode & 0o777) == 0o600

--- a/tests/test_config_atomic_save.py
+++ b/tests/test_config_atomic_save.py
@@ -1,13 +1,11 @@
 """
-Regression tests: ``_save_json`` must never leave ``config.json`` truncated
-or partially written if the process dies mid-save.
+Regression tests for ``_save_json``'s atomic-write guarantee.
 
-The config file can hold ``llm_api_key`` and every other user setting, so a
-crash between opening the file for writing and finishing the write used to
-leave the user with a corrupted or empty config. ``_save_json`` now writes
-to a temp file in the same directory and ``os.replace()``s it over the
-target, so the target either has the old contents or the new contents,
-never a partial write.
+The config file can hold ``llm_api_key`` and every other user setting, so
+``_save_json`` must never leave it truncated or partially written if the
+process dies mid-save. It writes to a temp file in the same directory and
+``os.replace()``s it over the target, so the target always ends up holding
+either the old contents or the new contents, never a partial write.
 """
 
 import json
@@ -93,3 +91,15 @@ def test_save_json_sets_permissions_to_0600_on_posix(tmp_path):
     _save_json(cfg_path, {"llm_api_key": "secret"})
 
     assert (cfg_path.stat().st_mode & 0o777) == 0o600
+
+
+def test_save_json_creates_missing_parent_directory(tmp_path):
+    """A brand-new install has no config directory yet; the first save must create it."""
+    cfg_path = tmp_path / "newuser" / ".config" / "jarvis" / "config.json"
+
+    ok = _save_json(cfg_path, {"llm_api_key": "first-save"})
+
+    assert ok is True
+    assert json.loads(cfg_path.read_text()) == {"llm_api_key": "first-save"}
+    leftover = [p for p in cfg_path.parent.iterdir() if p != cfg_path]
+    assert leftover == []


### PR DESCRIPTION
## Summary
- `_save_json` wrote directly to `config.json` in place, so a crash between opening the file and finishing the write could truncate or corrupt it, including the `llm_api_key` and every other user setting it holds.
- Now writes to a temp file in the same directory (0o600 on POSIX), then `os.replace()`s it over the target, so the file always ends up either fully old or fully new.
- Function signature and return semantics (`bool`) are unchanged; all existing call sites work as-is.

## Test plan
- [x] New tests in `tests/test_config_atomic_save.py` cover: successful atomic swap, a simulated failure between the temp-file write and the rename (original file left intact, no leftover temp file), a clean success path with no leftover temp files, and the existing 0o600 permission behaviour.
- [x] `pytest tests/test_config_atomic_save.py tests/test_config_mcps.py tests/test_config_models.py tests/test_config_path_expansion.py tests/test_settings_window.py tests/test_piper_tts.py tests/test_setup_wizard.py` — 214 passed.
- [x] Confirmed unrelated pre-existing GUI test-isolation failures on `develop` are unaffected by this change (same failures reproduce with the change stashed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)