### PR TITLE
fix: strip non-standard message fields before sending to LLM API

### DIFF
--- a/src/jarvis/llm/backend.py
+++ b/src/jarvis/llm/backend.py
@@ -17,6 +17,51 @@ from abc import ABC, abstractmethod
 from typing import Any, Callable, Dict, List, Optional
 
 
+# Fields allowed per message ``role`` in the OpenAI Chat Completions schema.
+# Any field outside this set (e.g. engine-internal annotations like
+# ``tool_name``, ``tool_failed``, ``_is_context_injected``) MUST be
+# stripped before the message reaches the wire, because strict servers
+# (llama.cpp, vLLM, etc.) reject unknown fields with 400.
+_ALLOWED_FIELDS_BY_ROLE: Dict[str, set[str]] = {
+    "system": {"role", "content", "name"},
+    "user": {"role", "content", "name"},
+    "assistant": {"role", "content", "tool_calls", "name", "reasoning_content"},
+    "tool": {"role", "tool_call_id", "content"},
+}
+
+
+def strip_nonstandard_message_fields(
+    messages: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Return a new list of messages with fields not in the OpenAI Chat
+    Completions schema removed.
+
+    The reply engine annotates some messages with internal fields it
+    uses for duplicate detection and carry-over logic (``tool_name``,
+    ``tool_failed`` on tool messages, ``_is_context_injected`` on
+    system messages).  These must be stripped before the payload is
+    serialised because strict servers (e.g. llama.cpp serving Gemma-4)
+    reject unknown fields with a 400 ``Invalid 'messages'`` error.
+
+    Each message retains only the fields allowed for its ``role``;
+    messages whose role is not in the known set are returned as-is
+    (empty dict fallback) so future roles (``developer``, ``function``)
+    are not silently dropped.
+    """
+    allowed = _ALLOWED_FIELDS_BY_ROLE.get
+    cleaned: List[Dict[str, Any]] = []
+    for msg in messages:
+        role = msg.get("role", "")
+        fields = allowed(role)
+        if fields is not None:
+            cleaned.append({k: v for k, v in msg.items() if k in fields})
+        else:
+            # Unknown role — keep all fields rather than risk dropping
+            # functionality the caller depends on.
+            cleaned.append(dict(msg))
+    return cleaned
+
+
 class ToolsNotSupportedError(Exception):
     """Raised when a backend rejects the ``tools`` parameter.
 

--- a/src/jarvis/llm/ollama.py
+++ b/src/jarvis/llm/ollama.py
@@ -20,7 +20,7 @@ import json
 import requests
 
 from ..debug import debug_log
-from .backend import LLMBackend, ToolsNotSupportedError
+from .backend import LLMBackend, ToolsNotSupportedError, strip_nonstandard_message_fields
 
 
 def check_version(base_url: str, timeout: float = 5.0) -> tuple[bool, str | None]:
@@ -236,9 +236,10 @@ class OllamaBackend(LLMBackend):
         models like ``gemma4:e2b`` then fall back to pre-trained
         ``tool_code`` scaffolding instead of producing valid tool calls.
         """
+        sanitised = strip_nonstandard_message_fields(messages)
         payload: Dict[str, Any] = {
             "model": chat_model,
-            "messages": messages,
+            "messages": sanitised,
             "stream": False,
             "options": {"num_ctx": 8192},
             "think": thinking,

--- a/src/jarvis/llm/openai_compatible.py
+++ b/src/jarvis/llm/openai_compatible.py
@@ -30,7 +30,7 @@ import json
 import requests
 
 from ..debug import debug_log
-from .backend import LLMBackend, ToolsNotSupportedError
+from .backend import LLMBackend, ToolsNotSupportedError, strip_nonstandard_message_fields
 
 
 @dataclass
@@ -247,9 +247,10 @@ class OpenAICompatibleBackend(LLMBackend):
         tools: Optional[List[Dict[str, Any]]] = None,
         thinking: bool = False,
     ) -> Optional[Dict[str, Any]]:
+        sanitised = strip_nonstandard_message_fields(messages)
         payload: Dict[str, Any] = {
             "model": chat_model,
-            "messages": messages,
+            "messages": sanitised,
             "stream": False,
         }
         if extra_options and isinstance(extra_options, dict):

--- a/tests/test_llm_backend.py
+++ b/tests/test_llm_backend.py
@@ -670,3 +670,195 @@ class TestFunctionStyleEntryPoints:
         from jarvis.llm import extract_text_from_response
 
         assert extract_text_from_response({"message": {"content": "hi"}}) == "hi"
+
+
+class TestStripNonstandardMessageFields:
+    """``strip_nonstandard_message_fields`` strips engine-internal annotation
+    fields from each message, keeping only the subset allowed by the OpenAI
+    Chat Completions schema for that role."""
+
+    def test_removes_tool_failed_from_tool_message(self):
+        from jarvis.llm.backend import strip_nonstandard_message_fields
+
+        messages = [
+            {
+                "role": "tool",
+                "tool_call_id": "call_123",
+                "content": "sunny, 22°C",
+                "tool_name": "getWeather",
+                "tool_failed": False,
+            }
+        ]
+        result = strip_nonstandard_message_fields(messages)
+
+        assert result[0] == {
+            "role": "tool",
+            "tool_call_id": "call_123",
+            "content": "sunny, 22°C",
+        }
+
+    def test_removes_tool_name_and_is_context_injected_from_system(self):
+        from jarvis.llm.backend import strip_nonstandard_message_fields
+
+        messages = [
+            {
+                "role": "system",
+                "content": "You are a helpful assistant.",
+                "_is_context_injected": True,
+            }
+        ]
+        result = strip_nonstandard_message_fields(messages)
+
+        assert result[0] == {
+            "role": "system",
+            "content": "You are a helpful assistant.",
+        }
+
+    def test_preserves_allowed_assistant_fields(self):
+        from jarvis.llm.backend import strip_nonstandard_message_fields
+
+        messages = [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [{"type": "function", "function": {"name": "getWeather"}}],
+                "unknown_field": "should_be_removed",
+            }
+        ]
+        result = strip_nonstandard_message_fields(messages)
+
+        assert "unknown_field" not in result[0]
+        assert result[0]["role"] == "assistant"
+        assert result[0]["content"] == ""
+        assert len(result[0]["tool_calls"]) == 1
+
+    def test_preserves_user_content(self):
+        from jarvis.llm.backend import strip_nonstandard_message_fields
+
+        messages = [{"role": "user", "content": "How's the weather?", "tool_name": "getWeather"}]
+        result = strip_nonstandard_message_fields(messages)
+
+        assert result[0] == {"role": "user", "content": "How's the weather?"}
+
+    def test_preserves_unknown_role_unchanged(self):
+        from jarvis.llm.backend import strip_nonstandard_message_fields
+
+        messages = [{"role": "developer", "content": "some instruction", "custom": True}]
+        result = strip_nonstandard_message_fields(messages)
+
+        assert result[0] == messages[0]
+
+    def test_original_messages_not_mutated(self):
+        from jarvis.llm.backend import strip_nonstandard_message_fields
+
+        original = [
+            {
+                "role": "tool",
+                "tool_call_id": "c1",
+                "content": "data",
+                "tool_name": "getWeather",
+                "tool_failed": False,
+            }
+        ]
+        original_copy = [dict(m) for m in original]
+
+        strip_nonstandard_message_fields(original)
+
+        assert original == original_copy
+
+    def test_multiple_messages_in_sequence(self):
+        from jarvis.llm.backend import strip_nonstandard_message_fields
+
+        messages = [
+            {"role": "system", "content": "Be helpful.", "_is_context_injected": True},
+            {"role": "user", "content": "Hi"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [{"type": "function", "function": {"name": "x"}}],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "c1",
+                "content": "result",
+                "tool_name": "x",
+                "tool_failed": False,
+            },
+        ]
+        result = strip_nonstandard_message_fields(messages)
+
+        assert len(result) == 4
+        assert "_is_context_injected" not in result[0]
+        assert "tool_name" not in result[3]
+        assert "tool_failed" not in result[3]
+        assert result[3]["role"] == "tool"
+        assert result[3]["tool_call_id"] == "c1"
+        assert result[3]["content"] == "result"
+
+
+class TestOllamaBackendSanitizesMessages:
+    """OllamaBackend.chat() strips non-standard fields from messages before
+    sending them to the wire."""
+
+    @patch("jarvis.llm.ollama.requests.post")
+    def test_tool_name_not_in_wire_payload(self, mock_post):
+        from jarvis.llm import OllamaBackend
+
+        mock_post.return_value = _make_response(
+            json_data={"message": {"content": "done", "tool_calls": []}}
+        )
+        backend = OllamaBackend("http://localhost:11434")
+
+        backend.chat(
+            "gemma4:e2b",
+            [
+                {"role": "user", "content": "How's the weather?"},
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [{"id": "1", "type": "function", "function": {"name": "getWeather"}}],
+                },
+                {
+                    "role": "tool",
+                    "tool_call_id": "1",
+                    "content": "Error: no location",
+                    "tool_name": "getWeather",
+                    "tool_failed": True,
+                },
+            ],
+        )
+
+        sent = mock_post.call_args.kwargs["json"]
+        tool_msg = sent["messages"][2]
+        assert tool_msg["role"] == "tool"
+        assert tool_msg["tool_call_id"] == "1"
+        assert tool_msg["content"] == "Error: no location"
+        assert "tool_name" not in tool_msg, "tool_name field must be stripped"
+        assert "tool_failed" not in tool_msg, "tool_failed field must be stripped"
+
+    @patch("jarvis.llm.ollama.requests.post")
+    def test_system_is_context_injected_stripped(self, mock_post):
+        from jarvis.llm import OllamaBackend
+
+        mock_post.return_value = _make_response(
+            json_data={"message": {"content": "hello", "tool_calls": []}}
+        )
+        backend = OllamaBackend("http://localhost:11434")
+
+        backend.chat(
+            "gemma4:e2b",
+            [
+                {
+                    "role": "system",
+                    "content": "You are a helpful assistant.",
+                    "_is_context_injected": True,
+                },
+                {"role": "user", "content": "Hi"},
+            ],
+        )
+
+        sent = mock_post.call_args.kwargs["json"]
+        sys_msg = sent["messages"][0]
+        assert sys_msg["role"] == "system"
+        assert sys_msg["content"] == "You are a helpful assistant."
+        assert "_is_context_injected" not in sys_msg

--- a/tests/test_llm_openai_compatible.py
+++ b/tests/test_llm_openai_compatible.py
@@ -717,3 +717,76 @@ class TestNormaliseResponse:
 
         tc = result["message"]["tool_calls"][0]
         assert tc["function"]["arguments"] == "not valid json"
+
+
+# ---------------------------------------------------------------------------
+# chat() — message sanitization
+# ---------------------------------------------------------------------------
+
+
+class TestOpenAICompatibleSanitizesMessages:
+    """OpenAICompatibleBackend.chat() strips non-standard fields from
+    messages before sending them to the wire."""
+
+    @patch("jarvis.llm.openai_compatible.requests.post")
+    def test_tool_name_not_in_wire_payload(self, mock_post):
+        from jarvis.llm import OpenAICompatibleBackend
+
+        mock_post.return_value = _make_response(
+            json_data={"choices": [{"message": {"content": "done"}}]}
+        )
+        backend = OpenAICompatibleBackend("http://localhost:1234/v1")
+
+        backend.chat(
+            "gemma-4-e2b",
+            [
+                {"role": "user", "content": "How's the weather?"},
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [{"id": "1", "type": "function", "function": {"name": "getWeather"}}],
+                },
+                {
+                    "role": "tool",
+                    "tool_call_id": "1",
+                    "content": "Error: no location",
+                    "tool_name": "getWeather",
+                    "tool_failed": True,
+                },
+            ],
+        )
+
+        sent = mock_post.call_args.kwargs["json"]
+        tool_msg = sent["messages"][2]
+        assert tool_msg["role"] == "tool"
+        assert tool_msg["tool_call_id"] == "1"
+        assert tool_msg["content"] == "Error: no location"
+        assert "tool_name" not in tool_msg, "tool_name field must be stripped"
+        assert "tool_failed" not in tool_msg, "tool_failed field must be stripped"
+
+    @patch("jarvis.llm.openai_compatible.requests.post")
+    def test_system_is_context_injected_stripped(self, mock_post):
+        from jarvis.llm import OpenAICompatibleBackend
+
+        mock_post.return_value = _make_response(
+            json_data={"choices": [{"message": {"content": "hello"}}]}
+        )
+        backend = OpenAICompatibleBackend("http://localhost:1234/v1")
+
+        backend.chat(
+            "gemma-4-e2b",
+            [
+                {
+                    "role": "system",
+                    "content": "You are a helpful assistant.",
+                    "_is_context_injected": True,
+                },
+                {"role": "user", "content": "Hi"},
+            ],
+        )
+
+        sent = mock_post.call_args.kwargs["json"]
+        sys_msg = sent["messages"][0]
+        assert sys_msg["role"] == "system"
+        assert sys_msg["content"] == "You are a helpful assistant."
+        assert "_is_context_injected" not in sys_msg


### PR DESCRIPTION
Engine-internal annotations (tool_name, tool_failed on tool messages,
_is_context_injected on system messages) survive to the wire because
the LLM backends pass the messages dict through unchanged. Strict
servers like llama.cpp with Gemma-4 reject these unknown fields with
a 400 'Invalid messages' error, causing the LLM call to fail silently.

Fix: add strip_nonstandard_message_fields() to backend.py that filters
each message dict against the OpenAI Chat Completions schema (role,
content, tool_call_id, tool_calls, name), and call it from both
OllamaBackend.chat() and OpenAICompatibleBackend.chat() before
serialising the payload.