### PR TITLE
docs: add triage patterns from full-log review, wake word no-query, hallucination scripts

### DIFF
--- a/.claude/skills/triage/SKILL.md
+++ b/.claude/skills/triage/SKILL.md
@@ -60,6 +60,12 @@ look for.
 interaction lines (`📝 Heard:`) often appear near the bottom, past a 2000-char
 cutoff. Use the unbounded jq selector (`.body`) and read every line.
 
+**Read the log top to bottom, don't stop at the startup section.** The startup
+(lines like "Whisper loaded", "Piper download 73%") is often misleading — a
+Piper download that shows 73% in the truncated view may have completed at 100%
+ten lines later. Always scroll to the end to check for `📝 Heard:`, `🧠 Intent
+judge:`, or `❌ Failed` lines before diagnosing.
+
 **Scan for `📝 Heard:` lines first.** They are the most actionable signal in any
 log. If a `Heard:` line exists, the system detected speech — the question is
 what it heard and whether it matches the wake word. Do not ask "did it hear
@@ -74,16 +80,18 @@ answer is almost always there. Follow this diagnosis flow:
 
 | Symptom in log | Likely cause | Action |
 |----------------|--------------|--------|
+| `📝 Heard: "Jarvis."` then `🧠 Intent (wake word): not directed (Wake word detected, but no query followed it.)` | User said the wake word but didn't follow with a command. The wake word alone does nothing. | Explain that they need to say a command after the wake word (e.g. "Jarvis, what time is it?"). |
 | `📝 Heard: "...George..."` or `"...Georg..."` | Wake word "Jarvis" misheard as "George" by Whisper (very common phonetic confusion). | Tell them to use the correct wake word. |
 | `📝 Heard: "Jarvis, ..."` then `🧠 Intent judge: unavailable (timeout)` | Intent judge model too slow for hardware. Usually CPU-only or large model mismatch. | Advise running setup wizard lowest option. |
 | `📝 Heard: "Jarvis, ..."` then `⏱️ LLM request timed out` | Chat model too slow for hardware. Same root cause as above. | Advise running setup wizard lowest option. |
-| Repeated `📝 Heard: "Thank you."` / `"you..."` / `"Thanks for watching!"` with no real commands | Whisper hallucinations on near-silent audio. Wrong default mic or broken mic/driver. | Check input level in OS sound settings; confirm intended mic. |
+| Repeated `📝 Heard: "Thank you."` / `"you..."` / `"Thanks for watching!"` / garbled text (e.g. Devanagari characters, random phrases like "Mission success!") with no real commands | Whisper hallucinations on near-silent audio. Wrong default mic or broken mic/driver. | Check input level in OS sound settings; confirm intended mic. If garbled text appears in a different script, it's still a hallucination — the script doesn't matter. |
 | `Low confidence` lines only, no `Heard:` ever | Mic captures audio but utterances are under the confidence floor. Wrong device or mic placement. | Same as above. |
 | `⚠️  Chat model '...' warmup failed` + `⚠️  Intent judge '...' warmup failed` | Two different model variants loaded (e.g. gemma4:e4b for chat, gemma4:e2b for intent). The `ℹ️ CUDA not available` warning in the log is Whisper-only (STT speed), but the LLM models (intent judge, chat) are served by Ollama and may also be on CPU. Two variants competing on CPU overwhelms most machines. | Run setup wizard lowest option to use one model for everything. |
 | Normal startup log, zero interaction lines (`📝 Heard:`, `🧠 Intent judge:`, `💬 Generating`) | User never spoke after launch, or didn't use the wake word. This is by far the most common. | Ask what they said and whether they said "Jarvis" first. |
 | `huggingface_hub.snapshot_download` crash (thread pool / ssl.create_default_context) | Platform-specific download crash. | Manual `ollama pull ...` workaround. |
 | `LLM connection error: ... RemoteDisconnected` | Ollama process crashed or unreachable. | `ollama run <model>` health check; Ollama version. |
-| Piper voice download stuck (percentage stops advancing) | First-run ~60 MB TTS voice download with slow/unstable connection. | Wait or relaunch; check internet. |
+| `⚠️  large-v3-turbo is not supported by the installed Whisper engine, using large-v3 instead` | User selected `large-v3-turbo` as Whisper model but the installed engine doesn't support it. Falls back to `large-v3`, which is much larger and slower. | Run setup wizard and pick a supported model like `medium` or `small`. |
+| Piper voice download stuck (percentage stops advancing) | First-run ~60 MB TTS voice download with slow/unstable connection. Check the log fully — if download reached 100%, this isn't the issue. | Wait or relaunch; check internet. |
 | `❌ Failed to load Whisper model: ConnectTimeout` | HF blocked by firewall (common in China). | `HF_ENDPOINT=https://hf-mirror.com` env var or VPN. |
 | `❌ Microphone permission check failed: Error querying device -1` | No microphone detected on Windows. | Check Windows Sound Settings for input devices. |
 | `🔊 Downloading Piper voice` line at startup, nothing after | First launch — Piper voice is still downloading. Normal, just slow. | Reassure, ask them to wait or relaunch. |


### PR DESCRIPTION

## Summary

Follow-up to #536. Adds triage patterns discovered by re-reading full logs during the triage session.

## Changes

- **Read the full log to the end** — don't stop at startup; Piper downloads that show 73% in a truncated view may have completed at 100% ten lines later
- **'Wake word detected but no query followed'** — user said 'Jarvis.' without a command. Different from wake word not being used.
- **Whisper hallucinations in any script** — garbled Devanagari text or random phrases like 'Mission success!' are still hallucinations, just in a different language/script
- **large-v3-turbo not supported** — falls back to slower large-v3, user needs a different Whisper model
- **Clarified Piper download row** — always check if it reached 100% before calling it stuck
