### PR TITLE
feat(desktop): wire new HTML HUD into FaceWindow + auto-open shortcut support

### DIFF
--- a/scripts/run_desktop_app.bat
+++ b/scripts/run_desktop_app.bat
@@ -1,14 +1,20 @@
 @echo off
 REM Run script for the Jarvis Desktop App on Windows
 REM Uses the project's mamba environment
-REM Usage: run_desktop_app.bat [--voice-debug]
+REM Usage: run_desktop_app.bat [--voice-debug] [--hud]
 
 REM Parse arguments
 set "VOICE_DEBUG=0"
+set "SHOW_HUD=0"
 :parse_args
 if "%~1"=="" goto done_args
 if "%~1"=="--voice-debug" (
     set "VOICE_DEBUG=1"
+    shift
+    goto parse_args
+)
+if "%~1"=="--hud" (
+    set "SHOW_HUD=1"
     shift
     goto parse_args
 )
@@ -19,6 +25,9 @@ goto parse_args
 echo Testing Jarvis Desktop App locally...
 if "%VOICE_DEBUG%"=="1" (
     echo    Voice debug: ENABLED
+)
+if "%SHOW_HUD%"=="1" (
+    echo    HUD: auto-opening on startup
 )
 echo.
 
@@ -70,6 +79,11 @@ echo.
 REM Set voice debug environment variable if requested
 if "%VOICE_DEBUG%"=="1" (
     set "JARVIS_VOICE_DEBUG=1"
+)
+
+REM Set HUD auto-open environment variable if requested
+if "%SHOW_HUD%"=="1" (
+    set "JARVIS_SHOW_HUD=1"
 )
 
 "%MAMBA_ENV%\python.exe" -m desktop_app

--- a/scripts/run_desktop_app.bat
+++ b/scripts/run_desktop_app.bat
@@ -3,6 +3,12 @@ REM Run script for the Jarvis Desktop App on Windows
 REM Uses the project's mamba environment
 REM Usage: run_desktop_app.bat [--voice-debug] [--hud]
 
+REM Resolve the project root from this script's own location BEFORE any
+REM `shift` runs below. cmd.exe's %~dp0 becomes unreliable (resolves against
+REM the current directory instead of the script's folder) once `shift` has
+REM executed, so this must happen first.
+for %%I in ("%~dp0..") do set "PROJECT_ROOT=%%~fI"
+
 REM Parse arguments
 set "VOICE_DEBUG=0"
 set "SHOW_HUD=0"
@@ -31,8 +37,7 @@ if "%SHOW_HUD%"=="1" (
 )
 echo.
 
-REM Navigate to project root (use for-loop to resolve .. reliably across shells)
-for %%I in ("%~dp0..") do set "PROJECT_ROOT=%%~fI"
+REM Navigate to project root (resolved at the top of this script, see above)
 cd /d "%PROJECT_ROOT%"
 set "PYTHONPATH=%PROJECT_ROOT%\src;%PYTHONPATH%"
 

--- a/src/desktop_app/app.py
+++ b/src/desktop_app/app.py
@@ -258,6 +258,16 @@ def get_crash_paths() -> tuple[Path, Path, Path]:
     return crash_log, crash_marker, previous_crash
 
 
+def should_show_hud_on_startup() -> bool:
+    """Whether the face/HUD window should auto-open on startup.
+
+    Controlled by JARVIS_SHOW_HUD, mirroring the JARVIS_VOICE_DEBUG pattern
+    (see src/jarvis/config.py) so shortcuts/launchers can request the HUD
+    without a dedicated CLI flag.
+    """
+    return os.environ.get("JARVIS_SHOW_HUD", "0") == "1"
+
+
 def check_previous_crash() -> Optional[str]:
     """
     Check if previous session crashed and return crash details if so.
@@ -1295,6 +1305,11 @@ class JarvisSystemTray:
 
         # Show tray icon
         self.tray_icon.show()
+
+        # Auto-open the face/HUD window when requested (e.g. by a launcher shortcut)
+        if should_show_hud_on_startup():
+            debug_log("JARVIS_SHOW_HUD set, auto-opening face window", "desktop")
+            self.show_face_window()
 
         # Register cleanup on app exit
         self.app.aboutToQuit.connect(self.cleanup_on_exit)

--- a/src/desktop_app/app.py
+++ b/src/desktop_app/app.py
@@ -62,7 +62,7 @@ from jarvis.debug import debug_log
 from jarvis.config import default_config_path, _default_db_path, SUPPORTED_CHAT_MODELS, get_supported_model_ids
 from desktop_app.diary_dialog import DiaryUpdateDialog
 from desktop_app.themes import JARVIS_THEME_STYLESHEET
-from desktop_app.face_widget import FaceWindow
+from desktop_app.hud_window import HudFaceWindow
 
 
 _LOG_SEPARATOR = "─" * 50
@@ -1280,7 +1280,8 @@ class JarvisSystemTray:
         # Create face window (hidden by default)
         # Note: Creating the face window also initializes the SpeakingState singleton
         # in the main thread, which is important for cross-thread signal delivery
-        self.face_window = FaceWindow()
+        self.face_window = HudFaceWindow()
+        self.log_signals.new_log.connect(self.face_window.add_log_line)
 
         # Create dictation history window (hidden by default)
         from desktop_app.dictation_history import DictationHistoryWindow

--- a/src/desktop_app/desktop_app.spec.md
+++ b/src/desktop_app/desktop_app.spec.md
@@ -19,7 +19,8 @@ src/desktop_app/
 ├── splash_screen.py     # Animated startup splash
 ├── setup_wizard.py      # First-run setup wizard
 ├── settings_window.py   # Auto-generated settings UI from config metadata
-├── face_widget.py       # Animated face visualization
+├── face_widget.py       # Animated face visualization (fallback when QtWebEngine unavailable)
+├── hud_window.py        # HudFaceWindow: HTML/JS HUD (face_hud.html) driven by real state/log data
 ├── themes.py            # Qt stylesheets and color palette
 ├── diary_dialog.py      # End-of-session diary update dialog
 ├── memory_viewer.py     # Flask-based memory browser
@@ -90,12 +91,19 @@ The central controller that manages:
 |--------|---------|
 | **LogViewerWindow** | Real-time log output from the daemon, with "Report Issue" button |
 | **MemoryViewerWindow** | Web-based memory browser (Flask server) |
-| **FaceWindow** | Animated face that reacts to speaking state |
+| **HudFaceWindow** | HTML/JS HUD (`desktop_assets/face_hud.html`) rendered in a QWebEngineView; falls back to the old painted `LowPolyFaceWidget` (`face_widget.py`) when QtWebEngine is unavailable |
 | **SettingsWindow** | Auto-generated config editor with tabbed categories |
 | **SetupWizard** | First-run configuration (Ollama, models, profile) |
 | **DictationHistoryWindow** | Scrollable list of past dictations with copy/delete/clear actions |
 
-**Auto-opening the FaceWindow (HUD) on startup**: set `JARVIS_SHOW_HUD=1` in the environment (mirrors the `JARVIS_VOICE_DEBUG` pattern in `jarvis.config`) and the tray calls `show_face_window()` right after the tray icon is shown. `scripts/run_desktop_app.bat` exposes this as a `--hud` flag for local runs; a desktop shortcut can set the env var directly to launch straight into the HUD.
+**Auto-opening the HudFaceWindow (HUD) on startup**: set `JARVIS_SHOW_HUD=1` in the environment (mirrors the `JARVIS_VOICE_DEBUG` pattern in `jarvis.config`) and the tray calls `show_face_window()` right after the tray icon is shown. `scripts/run_desktop_app.bat` exposes this as a `--hud` flag for local runs; a desktop shortcut can set the env var directly to launch straight into the HUD.
+
+**HudFaceWindow (`hud_window.py`)**: hosts `face_hud.html` in a `QWebEngineView` and drives its existing JS hooks with real assistant data instead of the HTML's own placeholder data:
+- `window.setJarvisState(state)` — a `QTimer` polls `JarvisStateManager.state` (from `face_widget.py`) every 300ms and calls this on change. Polling (not just the manager's Qt signal) is required because in dev mode the daemon runs as a separate process and only shares state via the cross-process state file.
+- `window.addJarvisLogLine(line)` — connected directly to the same `log_signals.new_log` stream `LogViewerWindow` already receives from the daemon (both bundled-QThread and subprocess-dev modes), so the HUD's "REGISTO DO SISTEMA" panel shows genuine `debug_log` lines rather than fictional content.
+- `window.playJarvisAudio(dataUrl)` — **not wired yet**. Feeding real TTS audio into the HUD's analyser needs new cross-process IPC to ship audio bytes from the daemon (subprocess in dev mode) to the desktop app process; out of scope until that IPC exists.
+
+All JS calls go through `page().runJavaScript()` with the argument JSON-encoded (`json.dumps`), since log lines are untrusted daemon stdout and must be embedded as a proper string literal rather than concatenated raw.
 
 ### Tray Menu: GPU Library Recovery (Windows)
 

--- a/src/desktop_app/desktop_app.spec.md
+++ b/src/desktop_app/desktop_app.spec.md
@@ -95,6 +95,8 @@ The central controller that manages:
 | **SetupWizard** | First-run configuration (Ollama, models, profile) |
 | **DictationHistoryWindow** | Scrollable list of past dictations with copy/delete/clear actions |
 
+**Auto-opening the FaceWindow (HUD) on startup**: set `JARVIS_SHOW_HUD=1` in the environment (mirrors the `JARVIS_VOICE_DEBUG` pattern in `jarvis.config`) and the tray calls `show_face_window()` right after the tray icon is shown. `scripts/run_desktop_app.bat` exposes this as a `--hud` flag for local runs; a desktop shortcut can set the env var directly to launch straight into the HUD.
+
 ### Tray Menu: GPU Library Recovery (Windows)
 
 `cuda_recovery.py` exposes the `🎮 Reinstall GPU libraries` action. The tray adds it only when running on Windows, an NVIDIA driver is detected (`%SystemRoot%\System32\nvcuda.dll` exists), and the bundled `install_cuda.ps1` script is on disk. Clicking it confirms with the user, then re-runs `install_cuda.ps1` via `ShellExecuteW` with the `runas` verb so UAC elevates the process before it writes into `Program Files\Jarvis\cuda`. This is the only user-facing recovery path when the original Inno Setup install of cuBLAS/cuDNN fails — the installer's own task fires once per install and the script's marker file used to make subsequent reinstalls skip the CUDA step. The runtime probe in `jarvis.listening.listener._print_cuda_unavailable_hint` points users at this action by name when it falls back to CPU.

--- a/src/desktop_app/hud_window.py
+++ b/src/desktop_app/hud_window.py
@@ -1,0 +1,102 @@
+"""
+HUD-style Jarvis face window.
+
+Hosts desktop_assets/face_hud.html in a QWebEngineView and drives it with the
+real assistant state (JarvisStateManager, see face_widget.py) and live daemon
+log lines, rather than the HTML's own placeholder data. See the comments
+around window.setJarvisState / window.addJarvisLogLine in face_hud.html for
+the JS side of this contract.
+
+Falls back to the original low-poly painted face (LowPolyFaceWidget) when
+QtWebEngine isn't available, so the window still shows something useful.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Optional
+
+from PyQt6.QtCore import QTimer, QUrl
+from PyQt6.QtWidgets import QVBoxLayout, QWidget, QApplication
+
+from jarvis.debug import debug_log
+from desktop_app.face_widget import LowPolyFaceWidget, get_jarvis_state
+
+try:
+    from PyQt6.QtWebEngineWidgets import QWebEngineView
+    HAS_WEBENGINE = True
+except ImportError:
+    QWebEngineView = None
+    HAS_WEBENGINE = False
+
+# How often to check for a Jarvis state change. Polling (rather than only
+# relying on JarvisStateManager's Qt signal) is required because in dev mode
+# the daemon runs as a separate process and only communicates state via the
+# cross-process state file that JarvisStateManager reads.
+_STATE_POLL_INTERVAL_MS = 300
+
+
+class HudFaceWindow(QWidget):
+    """Standalone window hosting the HTML/JS Jarvis HUD."""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("🤖 Jarvis")
+        self.setMinimumSize(900, 600)
+        self.resize(1400, 900)
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+
+        self._last_state: Optional[str] = None
+        self._view: Optional["QWebEngineView"] = None
+
+        if HAS_WEBENGINE:
+            self._view = QWebEngineView()
+            html_path = Path(__file__).parent / "desktop_assets" / "face_hud.html"
+            self._view.load(QUrl.fromLocalFile(str(html_path)))
+            layout.addWidget(self._view)
+        else:
+            debug_log("QtWebEngine unavailable, HUD falling back to low-poly face", "desktop")
+            layout.addWidget(LowPolyFaceWidget())
+
+        self._position_on_right()
+
+        self._state_timer = QTimer(self)
+        self._state_timer.timeout.connect(self._poll_state)
+        self._state_timer.start(_STATE_POLL_INTERVAL_MS)
+        self._poll_state()
+
+    def _position_on_right(self) -> None:
+        """Position the window on the right side of the screen, vertically centered."""
+        screen = QApplication.primaryScreen()
+        if screen is None:
+            return
+
+        geo = screen.availableGeometry()
+        x = geo.right() - self.width() - 20
+        y = geo.top() + (geo.height() - self.height()) // 2
+        self.move(max(geo.left(), x), max(geo.top(), y))
+
+    def _poll_state(self) -> None:
+        state = get_jarvis_state().state.value
+        if state == self._last_state:
+            return
+        self._last_state = state
+        self._run_js(f"window.setJarvisState && window.setJarvisState({json.dumps(state)});")
+
+    def add_log_line(self, line: str) -> None:
+        """Forward a real daemon log line into the HUD's system log panel."""
+        line = line.strip()
+        if not line:
+            return
+        self._run_js(f"window.addJarvisLogLine && window.addJarvisLogLine({json.dumps(line)});")
+
+    def _run_js(self, script: str) -> None:
+        if self._view is None:
+            return
+        try:
+            self._view.page().runJavaScript(script)
+        except RuntimeError as e:
+            debug_log(f"HUD runJavaScript failed: {e}", "desktop")

--- a/tests/test_desktop_app.py
+++ b/tests/test_desktop_app.py
@@ -184,6 +184,32 @@ class TestGetCrashPaths:
             assert "Library" in str(crash_log) or "Logs" in str(crash_log)
 
 
+class TestShouldShowHudOnStartup:
+    """Tests for should_show_hud_on_startup() - the JARVIS_SHOW_HUD gate that
+    lets a launcher shortcut auto-open the face/HUD window on startup."""
+
+    def test_false_when_env_var_unset(self):
+        from desktop_app.app import should_show_hud_on_startup
+
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("JARVIS_SHOW_HUD", None)
+            assert should_show_hud_on_startup() is False
+
+    def test_true_when_env_var_is_1(self):
+        from desktop_app.app import should_show_hud_on_startup
+
+        with patch.dict(os.environ, {"JARVIS_SHOW_HUD": "1"}):
+            assert should_show_hud_on_startup() is True
+
+    def test_false_for_other_values(self):
+        from desktop_app.app import should_show_hud_on_startup
+
+        with patch.dict(os.environ, {"JARVIS_SHOW_HUD": "0"}):
+            assert should_show_hud_on_startup() is False
+        with patch.dict(os.environ, {"JARVIS_SHOW_HUD": "true"}):
+            assert should_show_hud_on_startup() is False
+
+
 class TestCrashMarkerFunctions:
     """Tests for mark_session_started() and mark_session_clean_exit()."""
 

--- a/tests/test_hud_window.py
+++ b/tests/test_hud_window.py
@@ -1,0 +1,105 @@
+"""
+Tests for HudFaceWindow (src/desktop_app/hud_window.py) - the QWebEngineView
+face window that hosts face_hud.html and drives its JS hooks
+(window.setJarvisState / window.addJarvisLogLine) with real assistant state.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _make_window():
+    """Build a HudFaceWindow without running Qt widget __init__."""
+    from desktop_app.hud_window import HudFaceWindow
+
+    window = HudFaceWindow.__new__(HudFaceWindow)
+    window._view = MagicMock()
+    window._last_state = None
+    return window
+
+
+class TestPollState:
+    """_poll_state() reads the real JarvisStateManager state and forwards it
+    to the HUD's window.setJarvisState JS hook, only on change."""
+
+    def test_calls_set_jarvis_state_with_current_state(self):
+        window = _make_window()
+        mock_state_mgr = MagicMock()
+        mock_state_mgr.state.value = "listening"
+
+        with patch("desktop_app.hud_window.get_jarvis_state", return_value=mock_state_mgr):
+            window._poll_state()
+
+        window._view.page.return_value.runJavaScript.assert_called_once()
+        script = window._view.page.return_value.runJavaScript.call_args[0][0]
+        assert "setJarvisState" in script
+        assert '"listening"' in script
+
+    def test_skips_js_call_when_state_unchanged(self):
+        window = _make_window()
+        window._last_state = "idle"
+        mock_state_mgr = MagicMock()
+        mock_state_mgr.state.value = "idle"
+
+        with patch("desktop_app.hud_window.get_jarvis_state", return_value=mock_state_mgr):
+            window._poll_state()
+
+        window._view.page.return_value.runJavaScript.assert_not_called()
+
+    def test_updates_last_state_on_change(self):
+        window = _make_window()
+        window._last_state = "idle"
+        mock_state_mgr = MagicMock()
+        mock_state_mgr.state.value = "thinking"
+
+        with patch("desktop_app.hud_window.get_jarvis_state", return_value=mock_state_mgr):
+            window._poll_state()
+
+        assert window._last_state == "thinking"
+
+
+class TestAddLogLine:
+    """add_log_line() forwards real daemon log lines to the HUD's
+    window.addJarvisLogLine JS hook."""
+
+    def test_forwards_non_empty_line(self):
+        window = _make_window()
+        window.add_log_line("daemon started")
+
+        window._view.page.return_value.runJavaScript.assert_called_once()
+        script = window._view.page.return_value.runJavaScript.call_args[0][0]
+        assert "addJarvisLogLine" in script
+        assert "daemon started" in script
+
+    def test_skips_blank_line(self):
+        window = _make_window()
+        window.add_log_line("   \n")
+
+        window._view.page.return_value.runJavaScript.assert_not_called()
+
+    def test_escapes_quotes_and_special_characters_safely(self):
+        """Log content is untrusted (daemon stdout) so it must be embedded as
+        a properly-escaped JS string literal, not concatenated raw."""
+        window = _make_window()
+        window.add_log_line('bad "quote" and \\ backslash and \n newline')
+
+        script = window._view.page.return_value.runJavaScript.call_args[0][0]
+        # json.dumps produces a single valid JS/JSON string literal argument
+        import re
+        match = re.search(r"addJarvisLogLine\((.*)\);", script)
+        assert match is not None
+        import json
+        parsed = json.loads(match.group(1))
+        assert "quote" in parsed
+
+
+class TestNoWebEngineFallback:
+    """When QtWebEngine isn't available, _run_js must no-op instead of
+    raising, since there's no page() to call."""
+
+    def test_run_js_noop_when_view_is_none(self):
+        window = _make_window()
+        window._view = None
+        # Should not raise
+        window._run_js("window.setJarvisState('idle');")


### PR DESCRIPTION
## Summary
- **Wires the new HTML/JS HUD**: `desktop_assets/face_hud.html` ("Jarvis HUD v6.4") existed in the repo but nothing loaded it — the tray's Face window still showed the old painted `LowPolyFaceWidget`. Adds `HudFaceWindow` (`src/desktop_app/hud_window.py`), which hosts `face_hud.html` in a `QWebEngineView` and drives its existing JS hooks with real data:
  - `window.setJarvisState(state)` — polled from the real `JarvisStateManager` every 300ms (polling, not just the Qt signal, because in dev mode the daemon is a separate process and only shares state via its cross-process state file)
  - `window.addJarvisLogLine(line)` — wired to the same `log_signals.new_log` stream `LogViewerWindow` already gets from the daemon, so the HUD's "REGISTO DO SISTEMA" panel shows genuine `debug_log` lines
  - `window.playJarvisAudio` (audio-reactive visualization) is **left unwired** — needs new cross-process IPC to ship TTS audio from the daemon subprocess to the desktop app, a separate larger piece of work
  - Falls back to the original `LowPolyFaceWidget` when QtWebEngine isn't available
- **Auto-open the HUD on startup**: `JARVIS_SHOW_HUD=1` env var (mirrors `JARVIS_VOICE_DEBUG`) makes the tray auto-open the HUD right after the tray icon shows. Exposed as `--hud` on `scripts/run_desktop_app.bat`, so a desktop shortcut can launch straight into it.
- **Bugfix**: `run_desktop_app.bat` resolved `PROJECT_ROOT` from `%~dp0` *after* the argument-parsing loop's `shift` had already run. cmd.exe's `%~dp0` stops reflecting the script's own folder once any `shift` has executed in the same invocation, so passing any flag (`--voice-debug`, or the new `--hud`) from a different working directory (e.g. a desktop shortcut) silently resolved the wrong project root and failed with "Mamba environment not found". Fixed by resolving `PROJECT_ROOT` at the very top of the script, before any `shift`.
- Documents `HudFaceWindow` in `desktop_app.spec.md`.

## Test plan
- [x] `pytest tests/test_desktop_app.py tests/test_face_widget.py tests/test_hud_window.py -q` (83 passed)
- [x] New `TestShouldShowHudOnStartup` covers the `JARVIS_SHOW_HUD` env var gate
- [x] New `TestPollState` / `TestAddLogLine` / `TestNoWebEngineFallback` cover `HudFaceWindow`'s JS-call construction and escaping
- [x] Manually launched the real desktop app end-to-end (double-click-style launch via a Desktop shortcut) and confirmed: PROJECT_ROOT resolves correctly, the HUD window opens automatically, real assistant state shows ("EM ESPERA" for idle), and live debug_log lines flow into the HUD's core log panel — screenshot of the running window confirmed all of the above