### PR TITLE
fix: re-encode tool_calls arguments as JSON strings for OpenAI compat

### DIFF
--- a/src/jarvis/llm/openai_compatible.py
+++ b/src/jarvis/llm/openai_compatible.py
@@ -238,6 +238,32 @@ class OpenAICompatibleBackend(LLMBackend):
         except Exception:
             return None
 
+    @staticmethod
+    def _encode_tool_call_arguments(
+        messages: List[Dict[str, Any]],
+    ) -> List[Dict[str, Any]]:
+        """JSON-encode ``tool_calls[*].function.arguments`` in assistant messages.
+
+        The OpenAI API spec requires ``arguments`` to be a JSON string, but
+        ``normalise_openai_response`` decodes it to a dict for internal use.
+        When that assistant message is sent back to the server on the next
+        turn, we must re-encode it.
+        """
+        for msg in messages:
+            if msg.get("role") != "assistant":
+                continue
+            tc_list = msg.get("tool_calls")
+            if not isinstance(tc_list, list):
+                continue
+            for tc in tc_list:
+                func = tc.get("function")
+                if not isinstance(func, dict):
+                    continue
+                args = func.get("arguments")
+                if isinstance(args, dict):
+                    func["arguments"] = json.dumps(args)
+        return messages
+
     def chat(
         self,
         chat_model: str,
@@ -248,6 +274,7 @@ class OpenAICompatibleBackend(LLMBackend):
         thinking: bool = False,
     ) -> Optional[Dict[str, Any]]:
         sanitised = strip_nonstandard_message_fields(messages)
+        sanitised = self._encode_tool_call_arguments(sanitised)
         payload: Dict[str, Any] = {
             "model": chat_model,
             "messages": sanitised,

--- a/src/jarvis/reply/engine.py
+++ b/src/jarvis/reply/engine.py
@@ -2063,11 +2063,6 @@ def run_reply_engine(db: "Database", cfg, tts: Optional[Any],
                     assistant_msg["thinking"] = msg["thinking"]
                 if "tool_calls" in msg and msg["tool_calls"]:
                     assistant_msg["tool_calls"] = msg["tool_calls"]
-                    # OpenAI-compatible APIs require content to be absent (or
-                    # null) when tool_calls is present; empty string causes 400
-                    # errors on strict servers (e.g. Gemma-4 via OpenRouter).
-                    if not content:
-                        assistant_msg.pop("content", None)
 
         messages.append(assistant_msg)
 

--- a/src/jarvis/reply/reply.spec.md
+++ b/src/jarvis/reply/reply.spec.md
@@ -261,23 +261,23 @@ The system injects fresh contextual information before each LLM call in the agen
 **Simple Single-Tool Flow:**
 ```
 User: "What's the weather in London?"
-Turn 1: LLM → {tool_calls: [{function: {name: "webSearch", arguments: {query: "London weather today"}}}]}
+Turn 1: LLM → {content: "", tool_calls: [{function: {name: "webSearch", arguments: {query: "London weather today"}}}]}
 Turn 2: LLM → {content: "It's 18°C and sunny in London today with light winds."}
 ```
 
 **Multi-Step Planning Flow:**
 ```
 User: "Book sushi for two tonight at seven"
-Turn 1: LLM → {thinking: "I need to check restaurant availability first", tool_calls: [{function: {name: "checkAvailability", arguments: {cuisine: "sushi", time: "19:00", party: 2}}}]}
+Turn 1: LLM → {content: "", thinking: "I need to check restaurant availability first", tool_calls: [{function: {name: "checkAvailability", arguments: {cuisine: "sushi", time: "19:00", party: 2}}}]}
 Turn 2: LLM → {content: "7:00 is fully booked. Would you prefer 6:30 PM or 8:15 PM?", thinking: "7:00 is unavailable, I should offer alternatives"}
 ```
 
 **Iterative Research Flow:**
 ```
 User: "Compare the latest iPhone models"
-Turn 1: LLM → {tool_calls: [{function: {name: "webSearch", arguments: {query: "iPhone 15 models comparison 2024"}}}]}
-Turn 2: LLM → {thinking: "I have basic specs but need pricing information", tool_calls: [{function: {name: "webSearch", arguments: {query: "iPhone 15 Pro Max price official"}}}]}
-Turn 3: LLM → {thinking: "I should also get user reviews for a complete comparison", tool_calls: [{function: {name: "webSearch", arguments: {query: "iPhone 15 Pro vs Pro Max reviews"}}}]}
+Turn 1: LLM → {content: "", tool_calls: [{function: {name: "webSearch", arguments: {query: "iPhone 15 models comparison 2024"}}}]}
+Turn 2: LLM → {content: "", thinking: "I have basic specs but need pricing information", tool_calls: [{function: {name: "webSearch", arguments: {query: "iPhone 15 Pro Max price official"}}}]}
+Turn 3: LLM → {content: "", thinking: "I should also get user reviews for a complete comparison", tool_calls: [{function: {name: "webSearch", arguments: {query: "iPhone 15 Pro vs Pro Max reviews"}}}]}
 Turn 4: LLM → {content: "Here's a comprehensive comparison of the iPhone 15 models: [detailed response]"}
 ```
 

--- a/tests/test_llm_arguments_encoding.py
+++ b/tests/test_llm_arguments_encoding.py
@@ -1,0 +1,183 @@
+"""Test that tool_calls arguments are properly encoded for the wire format.
+
+The OpenAI API spec requires ``tool_calls[*].function.arguments`` to be a
+JSON-encoded string. The ``normalise_openai_response`` helper decodes it to a
+dict for internal use, but when that assistant message is sent back to the
+server on the next turn, the dict must be re-encoded as a string.
+
+This test verifies the round-trip: decode -> store -> re-encode before send.
+"""
+
+import json
+import pytest
+from unittest.mock import patch, MagicMock
+
+
+class TestToolCallArgumentsWireFormat:
+    """Verifies that tool_calls arguments are JSON-encoded strings on the wire."""
+
+    def _make_backend(self):
+        from jarvis.llm.openai_compatible import OpenAICompatibleBackend
+
+        return OpenAICompatibleBackend(base_url="http://localhost:11434")
+
+    def _patch_post(self, backend, messages, model="some-model"):
+        """Call backend.chat() with a mocked POST and return the sent payload."""
+        with patch("requests.post") as mock_post:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.json.return_value = {
+                "choices": [{"message": {"content": "OK", "role": "assistant"}}]
+            }
+            mock_post.return_value = mock_response
+            backend.chat(model, messages)
+        return mock_post.call_args[1]["json"]
+
+    def test_dict_arguments_encoded_as_json_string(self):
+        """Empty dict arguments -> JSON string."""
+        backend = self._make_backend()
+        messages = [
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "What's the weather?"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_abc",
+                        "type": "function",
+                        "function": {"name": "getWeather", "arguments": {}},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_abc", "content": "Sunny"},
+        ]
+        payload = self._patch_post(backend, messages)
+
+        for msg in payload["messages"]:
+            if msg.get("role") == "assistant" and "tool_calls" in msg:
+                args = msg["tool_calls"][0]["function"]["arguments"]
+                assert isinstance(args, str), f"Expected str, got {type(args).__name__}"
+                assert json.loads(args) == {}
+                return
+        pytest.fail("No assistant message with tool_calls found")
+
+    def test_nested_dict_arguments(self):
+        """Nested dict arguments (e.g. location, units) -> valid JSON string."""
+        backend = self._make_backend()
+        messages = [
+            {"role": "system", "content": "Assistant."},
+            {"role": "user", "content": "Weather in London?"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_xyz",
+                        "type": "function",
+                        "function": {
+                            "name": "getWeather",
+                            "arguments": {
+                                "location": "London",
+                                "units": "metric",
+                                "days": 3,
+                            },
+                        },
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_xyz", "content": "15C rainy"},
+        ]
+        payload = self._patch_post(backend, messages)
+
+        for msg in payload["messages"]:
+            if msg.get("role") == "assistant" and "tool_calls" in msg:
+                args = msg["tool_calls"][0]["function"]["arguments"]
+                assert isinstance(args, str), f"Expected str, got {type(args).__name__}"
+                decoded = json.loads(args)
+                assert decoded["location"] == "London"
+                assert decoded["units"] == "metric"
+                assert decoded["days"] == 3
+                return
+        pytest.fail("No assistant message with tool_calls found")
+
+    def test_string_arguments_left_as_is(self):
+        """Already-encoded string arguments must not be double-encoded."""
+        backend = self._make_backend()
+        messages = [
+            {"role": "system", "content": "Assistant."},
+            {"role": "user", "content": "Hi"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {
+                            "name": "search",
+                            "arguments": '{"query": "test"}',  # already a string
+                        },
+                    }
+                ],
+            },
+        ]
+        payload = self._patch_post(backend, messages)
+
+        for msg in payload["messages"]:
+            if msg.get("role") == "assistant" and "tool_calls" in msg:
+                args = msg["tool_calls"][0]["function"]["arguments"]
+                assert isinstance(args, str)
+                # Should still be the exact same string, not double-encoded
+                assert args == '{"query": "test"}'
+                return
+        pytest.fail("No assistant message with tool_calls found")
+
+    def test_no_tool_calls_unchanged(self):
+        """Messages without tool_calls should be left as-is."""
+        backend = self._make_backend()
+        messages = [
+            {"role": "system", "content": "Assistant."},
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi there!"},
+        ]
+        payload = self._patch_post(backend, messages)
+        assert payload["messages"] == messages
+
+    def test_multiple_tool_calls_all_encoded(self):
+        """All tool_calls in an assistant message should have encoded arguments."""
+        backend = self._make_backend()
+        messages = [
+            {"role": "system", "content": "Assistant."},
+            {"role": "user", "content": "Compare weather in Paris and Tokyo"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "getWeather", "arguments": {"location": "Paris"}},
+                    },
+                    {
+                        "id": "call_2",
+                        "type": "function",
+                        "function": {"name": "getWeather", "arguments": {"location": "Tokyo"}},
+                    },
+                ],
+            },
+        ]
+        payload = self._patch_post(backend, messages)
+
+        for msg in payload["messages"]:
+            if msg.get("role") == "assistant" and "tool_calls" in msg:
+                for tc in msg["tool_calls"]:
+                    args = tc["function"]["arguments"]
+                    assert isinstance(args, str), f"Expected str, got {type(args).__name__}"
+                    json.loads(args)  # must be valid JSON
+                # Verify both locations present
+                decoded = [json.loads(tc["function"]["arguments"]) for tc in msg["tool_calls"]]
+                assert {"location": "Paris"} in decoded
+                assert {"location": "Tokyo"} in decoded
+                return
+        pytest.fail("No assistant message with tool_calls found")


### PR DESCRIPTION
The OpenAI API spec requires tool_calls[*].function.arguments to be a
JSON-encoded string, but normalise_openai_response decodes it to a dict
for internal use. When that assistant message is sent back to the server on
the next turn, the dict must be re-encoded. Omitting this caused 400 errors
on strict servers (e.g. google/gemma-4-e2b via OpenRouter).

- Adds _encode_tool_call_arguments() static method to
  OpenAICompatibleBackend that walks assistant messages and JSON-encodes
  any arguments dicts before serialising the payload.
- Called after strip_nonstandard_message_fields and before payload
  construction in chat().
- Already-string arguments are left as-is (no double encoding).
- Ollama is unaffected (its API accepts both formats natively).