### PR TITLE
fix: low-VRAM model selection and sub-1B model detection

### DIFF
--- a/src/desktop_app/setup_wizard.py
+++ b/src/desktop_app/setup_wizard.py
@@ -2057,7 +2057,10 @@ class ModelsPage(QWizardPage):
             # leaves room for embeddings + whisper alongside the chat model.
             overhead = self._EMBED_VRAM_MB + self._whisper_vram_mb()
             usable_mb = self._detected_vram_mb - overhead
-            rec = get_recommended_model_id(usable_mb if usable_mb > 0 else None)
+            # usable_mb <= 0 means "no headroom", not "unknown VRAM": pass a
+            # minimal positive budget so the low-VRAM model is recommended
+            # instead of the 8GB default that None (unknown) resolves to.
+            rec = get_recommended_model_id(usable_mb if usable_mb > 0 else 1)
             if rec in self._ALL_MODELS:
                 self._chat_model = rec
                 # Fast model stays gemma4:e2b unless VRAM constrains it
@@ -2139,6 +2142,15 @@ class ModelsPage(QWizardPage):
                         self._fast_model = c
                         self._fast_combo.setCurrentIndex(self._fast_combo.findData(c))
                         break
+                else:
+                    # No candidate fits the budget: the smallest one is still
+                    # strictly better than keeping a fast model larger than
+                    # the chat model.
+                    smallest = min(
+                        self._FAST_MODEL_IDS, key=lambda m: required_vram_mb(m) or 0
+                    )
+                    self._fast_model = smallest
+                    self._fast_combo.setCurrentIndex(self._fast_combo.findData(smallest))
         self._refresh_vram_display()
         self._update_models_display()
 
@@ -2267,6 +2279,13 @@ class ModelsPage(QWizardPage):
                 if rc <= cv and fits_vram:
                     self._fast_model = c
                     break
+            else:
+                # No candidate fits the budget: the smallest one is still
+                # strictly better than keeping a fast model larger than
+                # the chat model.
+                self._fast_model = min(
+                    self._FAST_MODEL_IDS, key=lambda m: required_vram_mb(m) or 0
+                )
         # Default to unlinked — separate fast model is the recommended layout
         # even when both happen to be the same model ID.
         self._linked = False

--- a/src/jarvis/reply/engine.py
+++ b/src/jarvis/reply/engine.py
@@ -2401,8 +2401,7 @@ def run_reply_engine(db: "Database", cfg, tts: Optional[Any],
             malformed_fallback = False
         elif _is_malformed_json_response(content):
             debug_log(f"  ⚠️ Malformed content — delivering error reply: '{content[:80]}...'", "planning")
-            model_name = cfg.llm_chat_model.lower()
-            is_small = any(s in model_name for s in [":1b", ":3b", ":7b", "-1b", "-3b", "-7b"])
+            is_small = detect_model_size(cfg.llm_chat_model) == ModelSize.SMALL
             candidate_reply = (
                 "I had trouble understanding that request. "
                 "This can happen with smaller AI models. "

--- a/src/jarvis/reply/prompts/model_variants.py
+++ b/src/jarvis/reply/prompts/model_variants.py
@@ -24,6 +24,7 @@ class ModelSize(Enum):
 
 # Model size patterns - models matching these are considered SMALL
 _SMALL_MODEL_PATTERNS = (
+    ":0.8b", "-0.8b", "_0.8b",  # sub-1B tags (e.g. qwen3.5:0.8b, the low-VRAM path)
     ":1b", ":3b", ":7b",
     "-1b", "-3b", "-7b",
     "_1b", "_3b", "_7b",

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -23,9 +23,11 @@ class TestModelSizeDetection:
         ("gemma:7b", True),
         ("phi3:3b", True),
         ("qwen2:7b", True),
+        ("qwen3.5:0.8b", True),  # sub-1B, the official low-VRAM path
         # Various separators
         ("model-3b-instruct", True),
         ("model_1b_chat", True),
+        ("model_0.8b_chat", True),
         # Large models (should return LARGE)
         ("gpt-oss:20b", False),
         ("llama3.1:8b", False),

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -1151,9 +1151,22 @@ class TestModelsPageUI:
     def test_default_chat_model_is_default_config_model(self, qapp):
         from desktop_app.setup_wizard import ModelsPage
         from jarvis.config import DEFAULT_CHAT_MODEL
-        page = ModelsPage()
+        # Unknown VRAM keeps the default recommendation regardless of the
+        # machine running the tests.
+        with patch("desktop_app.setup_wizard.detect_total_vram_mb", return_value=None):
+            page = ModelsPage()
         assert page._chat_model == DEFAULT_CHAT_MODEL
         assert page._chat_combo.currentData() == DEFAULT_CHAT_MODEL
+
+    def test_no_vram_headroom_recommends_low_vram_chat_model(self, qapp):
+        """When companion overhead consumes the whole VRAM budget, the page
+        recommends the low-VRAM chat model rather than the unknown-VRAM
+        default (which needs far more VRAM than the machine has)."""
+        from desktop_app.setup_wizard import ModelsPage
+        from jarvis.utils.vram import get_recommended_model_id
+        with patch("desktop_app.setup_wizard.detect_total_vram_mb", return_value=2048):
+            page = ModelsPage()
+        assert page._chat_model == get_recommended_model_id(1)
 
     def test_initialize_page_stays_unlinked(self, qapp):
         from desktop_app.setup_wizard import ModelsPage
@@ -1175,7 +1188,8 @@ class TestModelsPageUI:
 
     def test_unlinked_mode_allows_independent_selection(self, qapp):
         from desktop_app.setup_wizard import ModelsPage
-        page = ModelsPage()
+        with patch("desktop_app.setup_wizard.detect_total_vram_mb", return_value=None):
+            page = ModelsPage()
         assert page._linked is False
         idx = page._fast_combo.findData("qwen3.5:0.8b")
         assert idx >= 0


### PR DESCRIPTION
## Summary

Four related fixes for machines where the companion-model overhead (embeddings + Whisper) consumes most or all of the detected VRAM budget. Found while setting Jarvis up on a GTX 1060 6GB / 8GB RAM Windows 10 machine, where the wizard recommended the 8GB default model.

- **ModelsPage recommendation**: when `usable_mb <= 0` the page passed `None` to `get_recommended_model_id`, and `None` means "unknown VRAM", which resolves to the 8GB default. "No headroom" and "unknown" now get opposite answers: a minimal positive budget is passed so the low-VRAM model is recommended.
- **Fast-model auto-downgrade**: both downgrade loops (combo change and `initializePage`) gave up when no candidate fitted the budget, silently keeping a fast model larger than the chat model. They now fall back to the smallest fast candidate.
- **Sub-1B detection**: `qwen3.5:0.8b` (the official low-VRAM path in the README) was classified as LARGE by `_SMALL_MODEL_PATTERNS`, so it lost the small-model prompts, memory digest and tool-result digest it needs most. Sub-1B tags are now SMALL.
- **Reply engine**: the malformed-JSON error path reimplemented small-model detection inline (missing `gemma4` and sub-1B), so gemma4 users never saw the "switch model" hint. It now reuses `detect_model_size`.

## Tests

- New: `test_no_vram_headroom_recommends_low_vram_chat_model` (fails on develop, passes with the fix) and sub-1B cases in `test_prompts.py`.
- Updated: the two ModelsPage UI tests now pin `detect_total_vram_mb`, making them deterministic on machines with real GPUs (on this 6GB machine they previously depended on the bug being present).
- Ran locally on Windows 10 / Python 3.13: `test_setup_wizard.py`, `test_setup_wizard_install_chain.py`, `test_prompts.py`, `test_vram.py`: 181 passed.

Marked as draft because I have not run the full suite or evals, only the files above. Happy to adjust anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)