### PR TITLE
test: fix full-suite failures on Windows (environmental test bugs)

### DIFF
--- a/src/desktop_app/app.py
+++ b/src/desktop_app/app.py
@@ -2357,7 +2357,7 @@ def _smoke_test_main() -> int:
             if _stream is None:
                 setattr(sys, _stream_name, io.StringIO())
             elif (getattr(sys, "frozen", False) or sys.platform == "win32") \
-                    and _stream is _real \
+                    and (getattr(sys, "frozen", False) or _stream is _real) \
                     and hasattr(_stream, "buffer") and hasattr(_stream.buffer, "write"):
                 setattr(sys, _stream_name, io.TextIOWrapper(
                     _stream.buffer, encoding="utf-8", errors="replace"))

--- a/src/desktop_app/app.py
+++ b/src/desktop_app/app.py
@@ -2346,16 +2346,18 @@ def _smoke_test_main() -> int:
     # AttributeError when stdout is None) and the smoke test exits 1 before
     # ever reaching the daemon.  Wrap in UTF-8 when a binary buffer is
     # available and fall back to a sink so prints can never crash the test.
-    # Only wrap bundled (frozen) runs and Windows: a plain dev run already
-    # gets correct locale handling from Python, and pytest swaps in its own
-    # capture objects that must not be re-wrapped.
+    # Only wrap the real console streams: pytest swaps in its own capture
+    # objects that must not be re-wrapped (wrapping them detaches and
+    # closes their buffers, corrupting output capture for the process).
     try:
         import io
         for _stream_name in ("stdout", "stderr"):
             _stream = getattr(sys, _stream_name)
+            _real = getattr(sys, "__" + _stream_name, None)
             if _stream is None:
                 setattr(sys, _stream_name, io.StringIO())
             elif (getattr(sys, "frozen", False) or sys.platform == "win32") \
+                    and _stream is _real \
                     and hasattr(_stream, "buffer") and hasattr(_stream.buffer, "write"):
                 setattr(sys, _stream_name, io.TextIOWrapper(
                     _stream.buffer, encoding="utf-8", errors="replace"))
@@ -2407,13 +2409,17 @@ def main() -> int:
 
     # Fix Windows console encoding for Unicode/emoji characters
     # Only for non-frozen apps - frozen apps redirect stdout to crash log
+    # Only wrap the real console streams (sys.__stdout__/sys.__stderr__):
+    # test harnesses replace sys.stdout with capture objects whose buffers
+    # must not be detached.
     if sys.platform == 'win32' and not getattr(sys, 'frozen', False):
         try:
             import io
-            # Only wrap if stdout has a proper binary buffer
-            if hasattr(sys.stdout, 'buffer') and hasattr(sys.stdout.buffer, 'write'):
+            if (sys.stdout is sys.__stdout__ and hasattr(sys.stdout, 'buffer')
+                    and hasattr(sys.stdout.buffer, 'write')):
                 sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8', errors='replace')
-            if hasattr(sys.stderr, 'buffer') and hasattr(sys.stderr.buffer, 'write'):
+            if (sys.stderr is sys.__stderr__ and hasattr(sys.stderr, 'buffer')
+                    and hasattr(sys.stderr.buffer, 'write')):
                 sys.stderr = io.TextIOWrapper(sys.stderr.buffer, encoding='utf-8', errors='replace')
         except Exception:
             pass

--- a/src/jarvis/daemon.py
+++ b/src/jarvis/daemon.py
@@ -21,10 +21,15 @@ os.environ.setdefault('OMP_NUM_THREADS', '1')
 if sys.platform == 'win32' and not getattr(sys, 'frozen', False):
     try:
         import io
-        # Only wrap if stdout has a proper binary buffer (not a custom writer)
-        if hasattr(sys.stdout, 'buffer') and hasattr(sys.stdout.buffer, 'write'):
+        # Only wrap the real console streams. Test harnesses (pytest) and
+        # embedding code replace sys.stdout/sys.stderr with their own capture
+        # objects; wrapping those detaches and closes their buffers, which
+        # corrupts output capture for the rest of the process.
+        if (sys.stdout is sys.__stdout__ and hasattr(sys.stdout, 'buffer')
+                and hasattr(sys.stdout.buffer, 'write')):
             sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8', errors='replace')
-        if hasattr(sys.stderr, 'buffer') and hasattr(sys.stderr.buffer, 'write'):
+        if (sys.stderr is sys.__stderr__ and hasattr(sys.stderr, 'buffer')
+                and hasattr(sys.stderr.buffer, 'write')):
             sys.stderr = io.TextIOWrapper(sys.stderr.buffer, encoding='utf-8', errors='replace')
     except Exception:
         pass

--- a/tests/test_desktop_app.py
+++ b/tests/test_desktop_app.py
@@ -233,6 +233,23 @@ class TestCrashMarkerFunctions:
 class TestCheckPreviousCrash:
     """Tests for check_previous_crash() function."""
 
+    @pytest.fixture(autouse=True)
+    def _sandbox_crash_paths(self, tmp_path, monkeypatch):
+        """Point crash log/marker paths at a temp dir.
+
+        The real log dir (LOCALAPPDATA\\Jarvis) belongs to a running Jarvis
+        instance; tests must never write to, rename, or delete files there
+        (they are locked while the app runs).
+        """
+        from desktop_app.paths import get_log_dir
+
+        log_dir = tmp_path / "jarvis_logs"
+        log_dir.mkdir(parents=True, exist_ok=True)
+        monkeypatch.setattr(
+            "desktop_app.paths.get_log_dir",
+            lambda: log_dir,
+        )
+
     def test_returns_none_when_no_marker(self):
         """check_previous_crash() should return None if no crash marker exists."""
         from desktop_app import get_crash_paths, check_previous_crash, mark_session_clean_exit

--- a/tests/test_diary_import.py
+++ b/tests/test_diary_import.py
@@ -14,19 +14,43 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-# Mock modules that may not be available in the test environment
+# Stub optional third-party modules that may be missing from the environment.
+# NOTE: this must NOT leak into other test files. Injecting MagicMock objects
+# into sys.modules at module level poisons the whole session: when a later
+# test imports a real package that was stubbed (e.g. PyQt6), the import
+# system reuses the stale mock entry and every Qt widget then subclasses a
+# MagicMock ("issubclass() arg 1 must be a class"). The fixture below
+# scopes the stubs to this file and only stubs modules that are genuinely
+# unavailable.
 _MOCK_MODULES = [
     "PyQt6", "PyQt6.QtWidgets", "PyQt6.QtCore", "PyQt6.QtGui",
     "PyQt6.QtWebEngineWidgets", "PyQt6.sip",
     "requests", "requests.exceptions",
     "psutil",
 ]
-for _mod in _MOCK_MODULES:
-    if _mod not in sys.modules:
-        sys.modules[_mod] = MagicMock()
 
-# Ensure requests.exceptions.Timeout is a proper exception class
-sys.modules["requests"].exceptions.Timeout = type("Timeout", (Exception,), {})
+
+@pytest.fixture(autouse=True)
+def _stub_missing_modules(monkeypatch):
+    """Stub optional modules that are missing, restoring sys.modules after
+    each test so later test files see the real packages."""
+    import importlib.util
+
+    for mod_name in _MOCK_MODULES:
+        if mod_name in sys.modules:
+            continue
+        try:
+            spec = importlib.util.find_spec(mod_name)
+        except (ImportError, ModuleNotFoundError, ValueError):
+            spec = None
+        if spec is not None:
+            continue  # Real package importable; no stubbing needed.
+        monkeypatch.setitem(sys.modules, mod_name, MagicMock())
+
+    # Ensure requests.exceptions.Timeout is a proper exception class
+    requests_mod = sys.modules.get("requests")
+    if requests_mod is not None:
+        requests_mod.exceptions.Timeout = type("Timeout", (Exception,), {})
 
 from src.jarvis.memory.db import Database
 

--- a/tests/test_eval_helpers.py
+++ b/tests/test_eval_helpers.py
@@ -76,7 +76,7 @@ class TestFallbackPhrasesAgainstEngineSource:
     """
 
     def test_every_phrase_appears_in_engine_source(self):
-        engine_src = (_ROOT / "src" / "jarvis" / "reply" / "engine.py").read_text()
+        engine_src = (_ROOT / "src" / "jarvis" / "reply" / "engine.py").read_text(encoding="utf-8")
         engine_src_lower = engine_src.lower()
         for phrase in FALLBACK_REPLY_PHRASES:
             assert phrase in engine_src_lower, (
@@ -159,7 +159,7 @@ class TestMaxTurnsPhrasesAgainstEnrichmentSource:
     """
 
     def test_digest_prompt_mentions_fully_finish(self):
-        src = (_ROOT / "src" / "jarvis" / "reply" / "enrichment.py").read_text()
+        src = (_ROOT / "src" / "jarvis" / "reply" / "enrichment.py").read_text(encoding="utf-8")
         # The digest prompt instructs the LLM to open with a caveat about
         # not being able to fully finish; the anchor phrase here is
         # ``fully finish``, which is the semantic core every canonical

--- a/tests/test_missing_portaudio.py
+++ b/tests/test_missing_portaudio.py
@@ -13,6 +13,7 @@ raises at import time, and assert the modules still load with the
 feature disabled (behaviour: app keeps running without audio).
 """
 
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -44,8 +45,15 @@ print("OK")
 
 def _run(module: str, dep: str, error: str, attr: str, extra: str = "") -> subprocess.CompletedProcess:
     code = SCENARIO.format(src=str(ROOT / "src"), module=module, dep=dep, error=error, attr=attr, extra=extra)
+    # The subprocess inherits the Windows console codepage (cp1252) by
+    # default, which cannot encode the emoji in listener.py's graceful
+    # PortAudio-failure message — force UTF-8 so the module actually reaches
+    # the "loads with the feature disabled" assertion instead of dying on print.
+    env = os.environ.copy()
+    env["PYTHONIOENCODING"] = "utf-8"
     return subprocess.run(
-        [sys.executable, "-c", code], capture_output=True, text=True, timeout=60
+        [sys.executable, "-c", code], capture_output=True, text=True,
+        encoding="utf-8", timeout=60, env=env,
     )
 
 

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -8,6 +8,19 @@ from unittest.mock import patch, MagicMock
 
 from pathlib import Path
 
+# The macOS update-script tests execute generated POSIX bash. On Windows
+# that requires a real bash (WSL or Git Bash); the wsl.exe shim in PATH is
+# not one and reports "WSL is not supported" on machines without WSL.
+def _bash_available() -> bool:
+    try:
+        result = subprocess.run(
+            ["bash", "-c", "exit 0"], capture_output=True, timeout=15
+        )
+        return result.returncode == 0
+    except Exception:
+        return False
+
+
 from desktop_app.updater import (
     check_for_updates,
     parse_version,
@@ -1053,6 +1066,11 @@ class TestInstallUpdateMacos:
         This test executes the generated script in a sandbox where `open` is
         stubbed to exit non-zero, and asserts the fallback binary runs.
         """
+        # The script is POSIX bash; on Windows this only works when a real
+        # bash (WSL / Git Bash) is on PATH — the wsl.exe shim prints "WSL is
+        # not supported" and exits non-zero on machines without WSL.
+        if sys.platform == "win32" and not _bash_available():
+            pytest.skip("a POSIX bash (WSL or Git Bash) is required on Windows")
         import plistlib
         import re
         import time

--- a/tests/test_voice_listener.py
+++ b/tests/test_voice_listener.py
@@ -940,15 +940,16 @@ class TestCrossPlatformAudioHealthWarning:
                             listener._audio_q.get = fake_get
                             listener._callback_count = 0
 
-                            # time.time() is called first for _audio_start_time (baseline),
-                            # then in the loop for the health check (needs to be 6s later)
+                            # time.time() is called for the LLM-warmup baseline,
+                            # then for _audio_start_time (both baselines), then in
+                            # the loop for the health check (needs to be 6s later)
                             _base = time.time()
                             time_calls = [0]
 
                             def advancing_time():
                                 time_calls[0] += 1
-                                # First call sets _audio_start_time baseline
-                                if time_calls[0] == 1:
+                                # First two calls set baselines (LLM warmup + audio start)
+                                if time_calls[0] <= 2:
                                     return _base
                                 # Subsequent calls return 6s later
                                 return _base + 6
@@ -957,7 +958,14 @@ class TestCrossPlatformAudioHealthWarning:
                                 mock_time.time.side_effect = advancing_time
                                 mock_time.sleep = time.sleep
 
-                                listener.run()
+                                # No LLM warmup threads: keeps time.time() call
+                                # counting deterministic (the warmup join would
+                                # consume mock values racy in a full-suite run).
+                                with patch(
+                                    "jarvis.listening.listener.VoiceListener._start_llm_warmup",
+                                    return_value=[],
+                                ):
+                                    listener.run()
 
                             captured = capsys.readouterr()
                             assert "No audio received after 5 seconds" in captured.out

--- a/tests/tools/builtin/test_screenshot.py
+++ b/tests/tools/builtin/test_screenshot.py
@@ -29,7 +29,11 @@ class TestScreenshotTool:
     @patch('subprocess.run')
     def test_run_success(self, mock_run, mock_which):
         """Test successful screenshot capture with inlined OCR logic."""
-        # Lightweight stubs so dynamic imports succeed without heavy deps
+        # Lightweight stubs so dynamic imports succeed without heavy deps.
+        # Saved and restored so the stubs don't leak into later tests that
+        # import the real pytesseract / PIL modules.
+        _saved_modules = {name: sys.modules.get(name) for name in
+                          ("pytesseract", "PIL", "PIL.Image")}
         class _StubImgCtx:
             def __enter__(self):
                 return self
@@ -55,11 +59,18 @@ class TestScreenshotTool:
         mock_proc.returncode = 0
         mock_run.return_value = mock_proc
 
-        with patch('tempfile.mkdtemp', return_value='/tmp/jarvis_ocr_test'), \
-             patch('os.path.exists', return_value=True), \
-             patch('os.remove'), \
-             patch('os.rmdir'):
-            result = self.tool.run({}, self.context)
+        try:
+            with patch('tempfile.mkdtemp', return_value='/tmp/jarvis_ocr_test'), \
+                 patch('os.path.exists', return_value=True), \
+                 patch('os.remove'), \
+                 patch('os.rmdir'):
+                result = self.tool.run({}, self.context)
+        finally:
+            for _name, _saved in _saved_modules.items():
+                if _saved is None:
+                    sys.modules.pop(_name, None)
+                else:
+                    sys.modules[_name] = _saved
 
         assert isinstance(result, ToolExecutionResult)
         assert result.success is True


### PR DESCRIPTION
## What

The full test suite failed with 105 failures on a clean `develop` checkout. This PR fixes six pre-existing, environment-independent bugs that poisoned the suite (several compounded into hundreds of cascading errors). After the fix the suite is fully green: **2176 passed, 0 failed** (4 skipped are WSL-dependent, 2 deselected are performance).

## Root causes

1. **`tests/test_diary_import.py` leaked `MagicMock` objects into `sys.modules`** (the big one, ~90 failures). It stubbed PyQt6/requests/psutil at module level and never restored them. Any later test importing a real stubbed package got the stale mock, so every Qt widget subclassed a MagicMock (`issubclass() arg 1 must be a class`) and mid-suite Qt tests (wizard pages, splash, dictation window, face widget) exploded. The stubs are now scoped to the file via an autouse fixture that only mocks genuinely-unavailable modules and restores `sys.modules` afterwards. The same latent leak in `tests/tools/builtin/test_screenshot.py` is fixed with a `try/finally` restore.

2. **Windows console-encoding wrappers corrupted pytest capture.** `jarvis/daemon.py` and `desktop_app/app.py` replaced `sys.stdout`/`sys.stderr` with `TextIOWrapper`s, detaching and closing pytest's capture file, which cascaded "I/O operation on closed file" into every later test. Both now wrap only the real console streams (`sys.stdout is sys.__stdout__`), preserving UTF-8 emoji behaviour for real console runs.

3. **`TestCheckPreviousCrash` wrote to and deleted files in the real `LOCALAPPDATA\Jarvis` crash-log dir**, colliding with a running Jarvis instance (the file was locked, so the tests failed with `PermissionError`). The class now sandboxes `get_log_dir` to a tmp dir.

4. **cp1252 console encoding on Windows** broke `tests/test_missing_portaudio.py` (subprocess printed the listener's emoji and died on encode) and `tests/test_eval_helpers.py` (source files read with the cp1252 default). Both now force UTF-8.

5. **`tests/test_updater.py` executed POSIX bash through the `wsl.exe` shim**, which reports "WSL is not supported" on machines without WSL. The test now skips when no real bash is available.

6. **Flaky time-mock in `TestCrossPlatformAudioHealthWarning`.** The listener's LLM-warmup join consumed mocked `time.time()` calls nondeterministically, so the health-warning assertion fired depending on suite state. The test now disables warmup threads and counts both baselines before time advances.

## Verification

- `python -m pytest tests/` on Windows with a live Jarvis instance: **2176 passed, 0 failed** (was 105 failed on the same machine before this PR).
- The individual fixed test files also pass in isolation and in combination.

## Notes

- No user-facing behaviour changes: the console-encoding guards still wrap real console runs, and frozen builds keep the existing wrap path.
- `_smoke_test_main`'s wrap keeps applying in frozen runs (where `sys.__stdout__` may be `None`) while skipping pytest's capture objects in dev runs.
