### PR TITLE
fix(desktop): stop startup QThread teardown from aborting the app (#584)

### DIFF
--- a/src/desktop_app/app.py
+++ b/src/desktop_app/app.py
@@ -40,6 +40,7 @@ if TYPE_CHECKING:
 from PyQt6.QtWidgets import QApplication, QSystemTrayIcon, QMenu, QMainWindow, QTextEdit, QVBoxLayout, QHBoxLayout, QWidget, QLabel, QDialog, QPushButton
 from PyQt6.QtGui import QIcon, QAction, QFont, QTextCursor
 from PyQt6.QtCore import QTimer, Qt, pyqtSignal, QObject, QThread, QUrl
+from desktop_app.qt_worker import KeepAliveWorker
 
 # Global lock file handle (must remain open for the lock to persist)
 _lock_file_handle = None
@@ -258,6 +259,102 @@ def get_crash_paths() -> tuple[Path, Path, Path]:
     return crash_log, crash_marker, previous_crash
 
 
+def collect_macos_crash_report(
+    crash_log_path: Path,
+    diagnostics_dir: Optional[Path] = None,
+    max_frames: int = 20,
+) -> Optional[str]:
+    """Collect the macOS native crash report (``.ips``) for a crashed
+    session, if one exists.
+
+    "Fatal Python error: Aborted" crashes are C-level aborts whose native
+    stack faulthandler cannot capture (it only dumps Python frames). The
+    OS still writes a full report to ``~/Library/Logs/DiagnosticReports/``;
+    surfacing its exception type and top native frames alongside the Python
+    dump makes these crashes diagnosable (#584/#575/#576).
+
+    Returns a short human-readable excerpt (exception type, termination
+    indicator, process name and the top native frames of the crashed
+    thread), or ``None`` when no report applies: non-macOS platform,
+    missing/empty diagnostics directory, no report newer than the crash
+    log, or unparseable content.
+    """
+    if sys.platform != "darwin":
+        return None
+    try:
+        if diagnostics_dir is None:
+            diagnostics_dir = Path.home() / "Library" / "Logs" / "DiagnosticReports"
+        if not diagnostics_dir.is_dir():
+            return None
+
+        app_name = "Jarvis"
+        since = crash_log_path.stat().st_mtime if crash_log_path.exists() else 0.0
+
+        candidates = []
+        for report in diagnostics_dir.glob(f"{app_name}-*.ips"):
+            try:
+                if report.stat().st_mtime >= since:
+                    candidates.append(report)
+            except OSError:
+                continue
+        if not candidates:
+            return None
+        newest = max(candidates, key=lambda p: p.stat().st_mtime)
+
+        raw_text = newest.read_text(encoding="utf-8", errors="replace")
+        # .ips files are usually two lines (metadata dict, then the JSON
+        # payload), but the payload can also span multiple lines when the
+        # system pretty-prints it. Try the whole file, then everything after
+        # the first (metadata) line, then the last line alone.
+        import json as _json
+        lines = raw_text.splitlines()
+        candidates = [raw_text]
+        if lines:
+            candidates.append("\n".join(lines[1:]))
+            candidates.append(lines[-1])
+        data = None
+        for candidate in candidates:
+            stripped = candidate.strip()
+            if not stripped.startswith("{"):
+                continue
+            try:
+                data = _json.loads(stripped)
+                break
+            except Exception:
+                continue
+        if not isinstance(data, dict):
+            return None
+
+        parts = [f"🧵 Native crash report: {newest.name}"]
+        exc = data.get("exception") or {}
+        if exc.get("type"):
+            parts.append(f"  Exception: {exc['type']}")
+        term = data.get("termination") or {}
+        if term.get("indicator"):
+            parts.append(f"  Termination: {term['indicator']}")
+
+        crashed = None
+        for thread in data.get("threads") or []:
+            if thread.get("triggered"):
+                crashed = thread
+                break
+        if crashed is None and data.get("threads"):
+            crashed = data["threads"][0]
+        frames = (crashed or {}).get("frames") or []
+        if frames:
+            parts.append("  Native frames (crashed thread):")
+            for frame in frames[:max_frames]:
+                # ``symbol`` is the demangled name; ``symbolLocation`` is a
+                # byte offset — never fall back to it for display.
+                symbol = frame.get("symbol")
+                if not isinstance(symbol, str) or not symbol:
+                    symbol = "?"
+                parts.append(f"    {symbol}")
+        return "\n".join(parts)
+    except Exception:
+        return None
+
+
 def check_previous_crash() -> Optional[str]:
     """
     Check if previous session crashed and return crash details if so.
@@ -279,8 +376,14 @@ def check_previous_crash() -> Optional[str]:
                 # Only report if there's actual crash info (faulthandler output or errors)
                 if 'Fatal' in content or 'Error' in content or 'Traceback' in content:
                     crash_content = content
+                    # On macOS, append the native .ips stack so the crash
+                    # dialog and report-issue body carry the C-level abort
+                    # source faulthandler cannot show.
+                    native = collect_macos_crash_report(crash_log)
+                    if native:
+                        crash_content += f"\n{native}\n"
                     # Save to previous_crash for reference
-                    previous_crash.write_text(content, encoding='utf-8')
+                    previous_crash.write_text(crash_content, encoding='utf-8')
 
             return crash_content
 
@@ -1240,6 +1343,93 @@ class MemoryViewerWindow(QMainWindow):
         event.accept()
 
 
+class DaemonThread(KeepAliveWorker):
+    """QThread that runs the Jarvis daemon inside the bundled app.
+
+    Inherits ``KeepAliveWorker`` so the object stays referenced in the
+    registry until its OS thread has fully finished: ``_on_daemon_finished``
+    clears ``tray.daemon_thread`` from a ``finished``-connected slot, and
+    dropping that last reference while the thread is still winding down
+    would destroy a running QThread and abort the whole app ("Fatal Python
+    error: Aborted" — #584/#575/#576, same class as #509/#407/#239).
+    """
+
+    def __init__(self, log_signals):
+        super().__init__()
+        self.log_signals = log_signals
+
+    def run(self):
+        """Run the daemon in this QThread."""
+        import sys as sys_module
+        old_stdout = sys_module.stdout
+        old_stderr = sys_module.stderr
+
+        try:
+            # Redirect stdout/stderr to capture logs
+            class LogWriter:
+                def __init__(self, emit_func):
+                    self.emit_func = emit_func
+                    self.buffer = ""
+
+                def write(self, text):
+                    if text:
+                        # Handle both bytes and str (Flask can send bytes)
+                        if isinstance(text, bytes):
+                            text = text.decode('utf-8', errors='replace')
+                        self.buffer += text
+                        if '\n' in self.buffer:
+                            lines = self.buffer.split('\n')
+                            self.buffer = lines[-1]
+                            for line in lines[:-1]:
+                                if line.strip():
+                                    self.emit_func(line + '\n')
+
+                def flush(self):
+                    if self.buffer.strip():
+                        self.emit_func(self.buffer)
+                        self.buffer = ""
+
+            log_writer = LogWriter(self.log_signals.new_log.emit)
+            sys_module.stdout = log_writer
+            sys_module.stderr = log_writer
+
+            try:
+                # Import and run the daemon
+                from jarvis.daemon import main as daemon_main
+                self.log_signals.new_log.emit("🚀 Jarvis daemon started\n")
+                self.log_signals.new_log.emit("📋 Initializing daemon components...\n")
+
+                # Run daemon - this should run the main loop
+                daemon_main()
+
+                from jarvis.daemon import is_stop_requested
+                if is_stop_requested():
+                    self.log_signals.new_log.emit("✅ Daemon stopped gracefully\n")
+                else:
+                    self.log_signals.new_log.emit("⚠️ Daemon exited unexpectedly\n")
+            except KeyboardInterrupt:
+                self.log_signals.new_log.emit("⏸️ Daemon interrupted\n")
+            except Exception as e:
+                error_msg = f"❌ Daemon runtime error: {str(e)}\n{traceback.format_exc()}\n"
+                self.log_signals.new_log.emit(error_msg)
+                # Also try to log via debug_log (though it might not work)
+                try:
+                    debug_log(f"daemon thread error: {e}", "desktop")
+                except Exception:
+                    pass
+            finally:
+                sys_module.stdout = old_stdout
+                sys_module.stderr = old_stderr
+        except Exception as e:
+            # Outer exception handler for setup errors
+            error_msg = f"❌ Daemon setup error: {str(e)}\n{traceback.format_exc()}\n"
+            try:
+                self.log_signals.new_log.emit(error_msg)
+            except Exception:
+                # If we can't emit, at least try stdout
+                print(error_msg, file=old_stderr)
+
+
 class JarvisSystemTray:
     """System tray application for Jarvis voice assistant."""
 
@@ -1757,87 +1947,15 @@ class JarvisSystemTray:
         try:
             if self.is_bundled:
                 # When bundled, run daemon in a QThread since Qt components may be used
-
-                class DaemonThread(QThread):
-                    """QThread to run the daemon."""
-                    def __init__(self, log_signals):
-                        super().__init__()
-                        self.log_signals = log_signals
-
-                    def run(self):
-                        """Run the daemon in this QThread."""
-                        import sys as sys_module
-                        old_stdout = sys_module.stdout
-                        old_stderr = sys_module.stderr
-
-                        try:
-                            # Redirect stdout/stderr to capture logs
-                            class LogWriter:
-                                def __init__(self, emit_func):
-                                    self.emit_func = emit_func
-                                    self.buffer = ""
-
-                                def write(self, text):
-                                    if text:
-                                        # Handle both bytes and str (Flask can send bytes)
-                                        if isinstance(text, bytes):
-                                            text = text.decode('utf-8', errors='replace')
-                                        self.buffer += text
-                                        if '\n' in self.buffer:
-                                            lines = self.buffer.split('\n')
-                                            self.buffer = lines[-1]
-                                            for line in lines[:-1]:
-                                                if line.strip():
-                                                    self.emit_func(line + '\n')
-
-                                def flush(self):
-                                    if self.buffer.strip():
-                                        self.emit_func(self.buffer)
-                                        self.buffer = ""
-
-                            log_writer = LogWriter(self.log_signals.new_log.emit)
-                            sys_module.stdout = log_writer
-                            sys_module.stderr = log_writer
-
-                            try:
-                                # Import and run the daemon
-                                from jarvis.daemon import main as daemon_main
-                                self.log_signals.new_log.emit("🚀 Jarvis daemon started\n")
-                                self.log_signals.new_log.emit("📋 Initializing daemon components...\n")
-
-                                # Run daemon - this should run the main loop
-                                daemon_main()
-
-                                from jarvis.daemon import is_stop_requested
-                                if is_stop_requested():
-                                    self.log_signals.new_log.emit("✅ Daemon stopped gracefully\n")
-                                else:
-                                    self.log_signals.new_log.emit("⚠️ Daemon exited unexpectedly\n")
-                            except KeyboardInterrupt:
-                                self.log_signals.new_log.emit("⏸️ Daemon interrupted\n")
-                            except Exception as e:
-                                error_msg = f"❌ Daemon runtime error: {str(e)}\n{traceback.format_exc()}\n"
-                                self.log_signals.new_log.emit(error_msg)
-                                # Also try to log via debug_log (though it might not work)
-                                try:
-                                    debug_log(f"daemon thread error: {e}", "desktop")
-                                except Exception:
-                                    pass
-                            finally:
-                                sys_module.stdout = old_stdout
-                                sys_module.stderr = old_stderr
-                        except Exception as e:
-                            # Outer exception handler for setup errors
-                            error_msg = f"❌ Daemon setup error: {str(e)}\n{traceback.format_exc()}\n"
-                            try:
-                                self.log_signals.new_log.emit(error_msg)
-                            except Exception:
-                                # If we can't emit, at least try stdout
-                                print(error_msg, file=old_stderr)
-
                 self.daemon_thread = DaemonThread(self.log_signals)
-                # Connect finished signal to reset UI state
-                self.daemon_thread.finished.connect(lambda: self._on_daemon_finished())
+                # Reset UI state on completion. QueuedConnection guarantees the
+                # slot runs on the main thread (the finished signal is emitted
+                # from the worker's OS thread) and the KeepAliveWorker registry
+                # keeps the object alive until that thread has fully exited.
+                self.daemon_thread.finished.connect(
+                    self._on_daemon_finished,
+                    Qt.ConnectionType.QueuedConnection,
+                )
                 self.daemon_thread.start()
 
                 # Connect dictation engine to history window once daemon is ready
@@ -2401,6 +2519,65 @@ def _smoke_test_main() -> int:
     return 0
 
 
+class SetupCheckWorker(KeepAliveWorker):
+    """Worker thread to check setup status without blocking the UI.
+
+    Inherits ``KeepAliveWorker`` so dropping the local reference after the
+    check completes can never destroy a running QThread ("Fatal Python
+    error: Aborted" — #584/#575/#576). The completion signal is named
+    ``check_done`` so it does not shadow QThread's built-in ``finished``.
+    """
+
+    check_done = pyqtSignal(bool)  # Emits True if setup wizard needed
+
+    def run(self):
+        try:
+            # Lazy import: app.py keeps setup_wizard loading deferred past
+            # crash-logging setup, so resolve it from the worker thread.
+            from desktop_app.setup_wizard import should_show_setup_wizard
+            result = should_show_setup_wizard()
+            self.check_done.emit(result)
+        except Exception as e:
+            print(f"  ❌ Setup check failed: {e}", flush=True)
+            # On error, show wizard to let user fix issues
+            self.check_done.emit(True)
+
+
+class _LLMReachWorker(KeepAliveWorker):
+    """Worker thread that probes the configured OpenAI-compatible server.
+
+    Emits via ``check_done`` — never by shadowing QThread's built-in
+    ``finished`` (the keep-alive registry relies on ``finished`` to know
+    when releasing the worker is safe).
+    """
+
+    check_done = pyqtSignal(bool)
+
+    def __init__(self, provider_cfg):
+        super().__init__()
+        self.provider_cfg = provider_cfg
+
+    def run(self):
+        self.check_done.emit(_check_openai_compat_reachable(self.provider_cfg))
+
+
+class ServerCheckWorker(KeepAliveWorker):
+    """Worker thread to check Ollama server status without blocking the UI."""
+
+    # Named check_done so it does not shadow QThread's built-in finished.
+    check_done = pyqtSignal(bool, object)  # Emits (is_running, version)
+
+    def run(self):
+        try:
+            # Lazy import: resolves the Ollama helpers from the worker thread.
+            from desktop_app.setup_wizard import check_ollama_server
+            running, ver = check_ollama_server()
+            self.check_done.emit(running, ver)
+        except Exception as e:
+            print(f"  ❌ Server check failed: {e}", flush=True)
+            self.check_done.emit(False, None)
+
+
 def main() -> int:
     """Main entry point for the desktop app."""
     # Smoke-test fast path: runs before any UI, crash logging, or setup checks.
@@ -2531,7 +2708,6 @@ def main() -> int:
         print("  Loading setup wizard module...", flush=True)
         try:
             from desktop_app.setup_wizard import (
-                should_show_setup_wizard,
                 check_ollama_server, check_ollama_cli,
                 get_required_models, check_installed_models,
                 resolve_ollama_path,
@@ -2543,22 +2719,7 @@ def main() -> int:
             raise
 
         # Run setup check in background thread to keep splash animation alive
-        from PyQt6.QtCore import QThread, pyqtSignal, QEventLoop
-
-        class SetupCheckWorker(QThread):
-            """Worker thread to check setup status without blocking UI."""
-            # Named check_done so it does not shadow QThread's built-in
-            # finished signal (see _KeepAliveWorker in setup_wizard.py).
-            check_done = pyqtSignal(bool)  # Emits True if setup wizard needed
-
-            def run(self):
-                try:
-                    result = should_show_setup_wizard()
-                    self.check_done.emit(result)
-                except Exception as e:
-                    print(f"  ❌ Setup check failed: {e}", flush=True)
-                    # On error, show wizard to let user fix issues
-                    self.check_done.emit(True)
+        from PyQt6.QtCore import QEventLoop
 
         setup_check_result = [None]  # Use list to allow modification in closure
 
@@ -2610,17 +2771,11 @@ def main() -> int:
             splash.set_status("Checking your LLM server...")
             app.processEvents()
 
-            class _LLMReachWorker(QThread):
-                finished = pyqtSignal(bool)
-
-                def run(self):
-                    self.finished.emit(_check_openai_compat_reachable(_provider_cfg))
-
             _reach = [True]
-            _reach_worker = _LLMReachWorker()
-            _reach_worker.finished.connect(lambda ok: _reach.__setitem__(0, ok))
+            _reach_worker = _LLMReachWorker(_provider_cfg)
+            _reach_worker.check_done.connect(lambda ok: _reach.__setitem__(0, ok))
             _reach_loop = QEventLoop()
-            _reach_worker.finished.connect(_reach_loop.quit)
+            _reach_worker.check_done.connect(_reach_loop.quit)
             _reach_worker.start()
             _reach_loop.exec()
 
@@ -2635,20 +2790,6 @@ def main() -> int:
             app.processEvents()
 
             # Run server check in background thread to keep splash animation alive
-            class ServerCheckWorker(QThread):
-                """Worker thread to check Ollama server status without blocking UI."""
-                # Named check_done so it does not shadow QThread's built-in
-                # finished signal (see _KeepAliveWorker in setup_wizard.py).
-                check_done = pyqtSignal(bool, object)  # Emits (is_running, version)
-
-                def run(self):
-                    try:
-                        running, ver = check_ollama_server()
-                        self.check_done.emit(running, ver)
-                    except Exception as e:
-                        print(f"  ❌ Server check failed: {e}", flush=True)
-                        self.check_done.emit(False, None)
-
             server_check_result = [None, None]  # [is_running, version]
 
             def on_server_check_done(running: bool, ver):

--- a/src/desktop_app/desktop_app.spec.md
+++ b/src/desktop_app/desktop_app.spec.md
@@ -161,6 +161,26 @@ The desktop app runs the Jarvis daemon in a **QThread** (bundled mode) or **subp
 └─────────────────────────────────────────┘
 ```
 
+### Threading: worker QThreads never die while running
+
+All long-lived worker QThreads in the desktop app inherit `KeepAliveWorker`
+(`src/desktop_app/qt_worker.py`): `DaemonThread`, `SetupCheckWorker`,
+`_LLMReachWorker`, `ServerCheckWorker` (app.py) and every setup-wizard
+worker. The class keeps each started worker referenced in a class-level
+registry until its OS thread has fully finished (released via the built-in
+`finished` signal). Dropping the last Python reference to a winding-down
+QThread — for example from a completion slot that clears the attribute
+holding it — destroys a running QThread and Qt aborts the whole app with
+"Fatal Python error: Aborted" on the main thread (#584/#575/#576; the
+setup-wizard crash class #509/#407/#239). Because of this, worker
+subclasses must never shadow the built-in `finished` signal — custom
+completion signals use other names (`check_done`, `completed`, `done`).
+
+`DaemonThread`'s `finished` slot (`_on_daemon_finished`) is connected with
+`Qt.QueuedConnection`: the signal is emitted from the worker's OS thread,
+and the slot mutates Qt UI state (menu actions, tray icon, face state), so
+it must run on the main thread.
+
 ### Daemon Callbacks
 
 The desktop app registers callbacks with the daemon for:
@@ -269,6 +289,18 @@ A Flask-based web interface for browsing conversation history:
 2. On clean exit, removes the marker
 3. On next startup, if marker exists → previous session crashed
 4. Offers to submit crash report to GitHub Issues
+
+### Crash Reports Carry the Native Stack (macOS)
+
+"Fatal Python error: Aborted" crashes are C-level aborts whose native
+stack faulthandler cannot capture — it only dumps Python frames, which for
+the abort family (#584/#575/#576) shows nothing but the main thread parked
+in `app.exec()`. On macOS the OS still writes a full report with native
+frames to `~/Library/Logs/DiagnosticReports/Jarvis-*.ips`. On the next
+launch, `collect_macos_crash_report()` finds the newest report newer than
+the previous crash log and appends its exception type, termination
+indicator and the crashed thread's top native frames to the crash-dialog
+content and the report-issue body, so these aborts become diagnosable.
 
 ### Fallbacks
 

--- a/src/desktop_app/qt_worker.py
+++ b/src/desktop_app/qt_worker.py
@@ -1,0 +1,44 @@
+"""
+Process-wide keep-alive registry for desktop-app worker QThreads.
+
+Qt's ``QThread`` destructor aborts the whole process ("Fatal Python
+error: Aborted") when the last Python reference to the object is dropped
+while its OS thread is still alive — a hazard that hits whenever a
+completion slot (invoked while the thread is still winding down after
+``run()`` returned) rebinds or clears the attribute holding the worker
+(see the setup-wizard fix for #509/#407/#239, and the desktop-startup
+crash family #584/#575/#576).
+
+``KeepAliveWorker`` keeps every started worker referenced in a class-level
+registry until the built-in ``finished`` signal fires, so the C++ object
+can never be destroyed before its OS thread has fully exited. Subclasses
+must NOT shadow the built-in ``finished`` signal — the registry relies on
+it to know when release is safe; custom completion signals must use other
+names (``check_done``, ``completed``, ``status_ready``, ``done``).
+"""
+
+from typing import ClassVar, Set
+
+from PyQt6.QtCore import QThread
+
+
+class KeepAliveWorker(QThread):
+    """QThread that keeps itself referenced until its OS thread has fully
+    finished.
+
+    ``start()`` adds the worker to a class-level registry and connects the
+    built-in ``finished`` signal to retirement; the registry holds a strong
+    reference until the OS thread has truly exited, so dropping the last
+    application reference (for example from a completion slot) can never
+    destroy a running QThread and abort the app.
+    """
+
+    _active: ClassVar[Set["KeepAliveWorker"]] = set()
+
+    def start(self, *args, **kwargs):
+        KeepAliveWorker._active.add(self)
+        self.finished.connect(self._retire)
+        super().start(*args, **kwargs)
+
+    def _retire(self) -> None:
+        KeepAliveWorker._active.discard(self)

--- a/src/desktop_app/setup_wizard.py
+++ b/src/desktop_app/setup_wizard.py
@@ -14,7 +14,7 @@ import platform
 import webbrowser
 import json
 from pathlib import Path
-from typing import ClassVar, Optional, List, Tuple, Dict
+from typing import Optional, List, Tuple, Dict
 from dataclasses import dataclass
 from enum import Enum, auto
 
@@ -379,6 +379,7 @@ try:
     from PyQt6.QtCore import Qt, QTimer, pyqtSignal, QThread, QObject
     from PyQt6.QtGui import QFont, QColor, QPalette, QPixmap, QPainter
 
+    from desktop_app.qt_worker import KeepAliveWorker
     from desktop_app.themes import JARVIS_THEME_STYLESHEET, COLORS, _ensure_icons, _ICON_STYLESHEET_TEMPLATE
     from desktop_app.mcp_catalogue import get_wizard_entries, MCPEntry
 
@@ -418,6 +419,7 @@ except ImportError:
     Qt = None
     QTimer = None
     QObject = None
+    KeepAliveWorker = object
 
     def pyqtSignal(*args, **kwargs):
         """Stub for pyqtSignal when PyQt6 is not available."""
@@ -435,33 +437,7 @@ except ImportError:
     GEOIP2_AVAILABLE = False
 
 
-class _KeepAliveWorker(QThread):
-    """QThread that keeps itself referenced until its OS thread has fully
-    finished.
-
-    Wizard pages rebind their worker attribute inside completion slots
-    (model install chains, refresh buttons, test-connection buttons). The
-    completion signal is emitted at the end of run(), so the slot can run
-    while the OS thread is still winding down; dropping the last Python
-    reference at that point destroys a running QThread and Qt aborts the
-    whole app ("Fatal Python error: Aborted" — #509, #407, #239).
-
-    Subclasses must NOT shadow the built-in ``finished`` signal — the
-    keep-alive registry relies on it to know when release is safe.
-    """
-
-    _active: ClassVar[set] = set()
-
-    def start(self, *args, **kwargs):
-        _KeepAliveWorker._active.add(self)
-        self.finished.connect(self._retire)
-        super().start(*args, **kwargs)
-
-    def _retire(self) -> None:
-        _KeepAliveWorker._active.discard(self)
-
-
-class StatusCheckWorker(_KeepAliveWorker):
+class StatusCheckWorker(KeepAliveWorker):
     """Worker thread for checking Ollama status."""
     status_ready = pyqtSignal(OllamaStatus)
 
@@ -470,7 +446,7 @@ class StatusCheckWorker(_KeepAliveWorker):
         self.status_ready.emit(status)
 
 
-class CommandWorker(_KeepAliveWorker):
+class CommandWorker(KeepAliveWorker):
     """Worker thread for running commands."""
     output = pyqtSignal(str)
     completed = pyqtSignal(bool, str)
@@ -1007,7 +983,7 @@ class ProviderChoicePage(QWizardPage):
         return wizard.welcome_page_id
 
 
-class _ModelFetchWorker(_KeepAliveWorker):
+class _ModelFetchWorker(KeepAliveWorker):
     """Fetches the model list from an OpenAI-compatible server off the UI
     thread so the wizard never freezes while connecting."""
 
@@ -1023,7 +999,7 @@ class _ModelFetchWorker(_KeepAliveWorker):
         self.done.emit(bool(models), models)
 
 
-class _DiscoveryWorker(QThread):
+class _DiscoveryWorker(KeepAliveWorker):
     """Probes well-known local ports for a running OpenAI-compatible server so
     the wizard can offer a one-click pick instead of asking for a URL."""
 
@@ -1037,7 +1013,7 @@ class _DiscoveryWorker(QThread):
         self.done.emit(OpenAICompatiblePage._discover_servers(self._candidates))
 
 
-class _CapabilityWorker(QThread):
+class _CapabilityWorker(KeepAliveWorker):
     """Probes what the chosen server+model can actually do (chat, tools,
     embeddings) off the UI thread, so the wizard catches a dud model or a
     missing embeddings endpoint before setup finishes rather than at runtime."""

--- a/src/desktop_app/setup_wizard.spec.md
+++ b/src/desktop_app/setup_wizard.spec.md
@@ -98,7 +98,8 @@ Fields suffixed `?` are written only when non-empty (minimal-config invariant).
 
 ## Threading
 
-- All wizard worker threads inherit `_KeepAliveWorker(QThread)`, which keeps
+- All wizard worker threads inherit `KeepAliveWorker(QThread)` (shared with
+  the desktop app via `desktop_app/qt_worker.py`), which keeps
   each started worker referenced in a class-level registry until its OS
   thread has fully finished (released via the built-in `finished` signal).
   Pages rebind their worker attribute inside completion slots (install

--- a/tests/test_desktop_keepalive_workers.py
+++ b/tests/test_desktop_keepalive_workers.py
@@ -1,0 +1,184 @@
+"""
+Regression tests for the desktop-app "Fatal Python error: Aborted" crash
+family (#584, #575, #576; previously #509, #407, #239).
+
+Signature: SIGABRT lands on the MAIN thread while it sits in
+``app.exec()``. Qt's ``QThread`` destructor aborts the whole process when
+the last Python reference to a QThread is dropped while its OS thread is
+still alive ("QThread: Destroyed while thread is still running"). The
+desktop app's ``DaemonThread`` and the startup check workers ran as plain
+QThreads and could hit exactly that teardown race; ``_LLMReachWorker``
+also shadowed the built-in ``finished`` signal, which breaks the
+keep-alive contract (custom completion signals must use other names).
+
+The abort kills the interpreter, so the race scenarios run in a
+subprocess: they churn rapid worker replacements exactly like the
+startup/daemon teardown paths. Pre-fix these reliably die with SIGABRT
+within the iteration budget; post-fix they complete and print CHAIN_OK.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+CHURN_SCENARIO = r"""
+import os, sys, time
+
+sys.path.insert(0, r"{src}")
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from PyQt6.QtWidgets import QApplication
+
+from desktop_app.app import DaemonThread
+from desktop_app.app import SetupCheckWorker, ServerCheckWorker
+from desktop_app.app import _LLMReachWorker
+from desktop_app.qt_worker import KeepAliveWorker
+
+app = QApplication([])
+
+N = 150
+state = {{"i": 0, "worker": None}}
+
+
+class _Sig:
+    def emit(self, *a):
+        pass
+
+
+class _Signals:
+    new_log = _Sig()
+
+
+class BusyDaemonThread(DaemonThread):
+    # DaemonThread whose run() does non-trivial work so the OS thread is
+    # still winding down when the completion slot drops the reference.
+    def __init__(self, log_signals=None):
+        super().__init__(log_signals or _Signals())
+
+    def run(self):
+        time.sleep(0.02)
+
+
+# Worker classes and the constructor arguments they need.
+WORKERS = [
+    (BusyDaemonThread, ()),
+    (SetupCheckWorker, ()),
+    (ServerCheckWorker, ()),
+    (_LLMReachWorker, (None,)),
+]
+
+
+def start_next(worker_cls, args):
+    if state["i"] >= N:
+        app.quit()
+        return
+    state["i"] += 1
+    # Mirrors app.py's teardown: the previous worker's reference is dropped
+    # from a slot connected to `finished`, while its OS thread can still be
+    # winding down after run() returned.
+    state["worker"] = worker_cls(*args)
+    if isinstance(state["worker"], DaemonThread):
+        state["worker"].finished.connect(lambda: start_next(worker_cls, args))
+    else:
+        state["worker"].check_done.connect(lambda ok: start_next(worker_cls, args))
+    state["worker"].start()
+
+
+for cls, args in WORKERS:
+    state["i"] = 0
+    start_next(cls, args)
+    app.exec()
+    assert state["i"] >= N, f"chain stopped early for {{cls.__name__}} at {{state['i']}}"
+
+assert issubclass(DaemonThread, KeepAliveWorker)
+assert issubclass(SetupCheckWorker, KeepAliveWorker)
+assert issubclass(ServerCheckWorker, KeepAliveWorker)
+assert issubclass(_LLMReachWorker, KeepAliveWorker)
+print("CHAIN_OK")
+"""
+
+
+def _run_scenario() -> str:
+    proc = subprocess.run(
+        [sys.executable, "-c", CHURN_SCENARIO.format(src=ROOT / "src")],
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+    return proc.stdout + proc.stderr
+
+
+def test_startup_and_daemon_worker_churn_survives():
+    """Rapidly replacing DaemonThread / startup workers from completion
+    slots must never destroy a running QThread (SIGABRT)."""
+    output = _run_scenario()
+    assert "CHAIN_OK" in output, (
+        "worker churn did not complete. Expected CHAIN_OK.\n" + output
+    )
+    assert "Aborted" not in output.splitlines()[-3:]
+
+
+def test_keepalive_worker_registry_holds_until_finished():
+    """KeepAliveWorker must stay referenced in the class-level registry
+    while its OS thread is running and retire once `finished` fires."""
+    import os
+
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    from PyQt6.QtWidgets import QApplication
+    from desktop_app.qt_worker import KeepAliveWorker
+
+    app = QApplication.instance() or QApplication([])
+
+    class QuickWorker(KeepAliveWorker):
+        def run(self):
+            import time
+            time.sleep(0.05)
+
+    worker = QuickWorker()
+    worker.start()
+    try:
+        assert worker in KeepAliveWorker._active, (
+            "start() must register the worker in the keep-alive registry"
+        )
+        assert worker.wait(5000), "worker did not finish in time"
+    finally:
+        # Retire is connected to `finished`; give the event loop a moment
+        # to deliver it if the connection is queued.
+        for _ in range(50):
+            if worker not in KeepAliveWorker._active:
+                break
+            app.processEvents()
+            import time
+            time.sleep(0.01)
+    assert worker not in KeepAliveWorker._active, (
+        "finished must retire the worker from the keep-alive registry"
+    )
+
+
+def test_llm_reach_worker_does_not_shadow_finished_signal():
+    """_LLMReachWorker must expose its completion via `check_done`, never
+    by shadowing QThread's built-in `finished` (the keep-alive registry
+    relies on `finished` to know when release is safe)."""
+    from desktop_app.app import _LLMReachWorker
+
+    assert "finished" not in _LLMReachWorker.__dict__, (
+        "_LLMReachWorker shadows QThread's built-in `finished` signal; "
+        "rename the custom completion signal to `check_done`."
+    )
+    assert hasattr(_LLMReachWorker, "check_done"), (
+        "_LLMReachWorker must expose its completion via `check_done`"
+    )
+
+
+def test_startup_workers_inherit_keep_alive():
+    """Every long-lived worker created during desktop startup must inherit
+    KeepAliveWorker so dropping references can never abort the app."""
+    from desktop_app.app import DaemonThread, SetupCheckWorker, ServerCheckWorker, _LLMReachWorker
+    from desktop_app.qt_worker import KeepAliveWorker
+
+    for cls in (DaemonThread, SetupCheckWorker, ServerCheckWorker, _LLMReachWorker):
+        assert issubclass(cls, KeepAliveWorker), (
+            f"{cls.__name__} must inherit KeepAliveWorker"
+        )

--- a/tests/test_macos_crash_report.py
+++ b/tests/test_macos_crash_report.py
@@ -1,0 +1,202 @@
+"""
+Tests for collecting the macOS native crash report (`.ips`) so that
+"Fatal Python error: Aborted" crashes (which faulthandler cannot explain —
+it only dumps Python frames) become diagnosable from the app's own crash
+report. See #584/#575/#576: the SIGABRT source is a C-level abort in the
+main Qt thread whose native stack is only recorded in
+`~/Library/Logs/DiagnosticReports/Jarvis-*.ips`.
+"""
+
+import json
+from pathlib import Path
+
+from unittest.mock import patch
+
+
+def _write_ips(path: Path, mtime: float, *, app_name: str = "Jarvis",
+               exc_type: str = "SIGABRT", indicator: str = "DirtyVM_FLUSH",
+               frames: list) -> None:
+    """Write a minimal but structurally valid Apple .ips crash report."""
+    body = {
+        "app_name": app_name,
+        "timestamp": "2026-08-08 13:35:39.539733",
+        "exception": {"type": exc_type, "signal": 6},
+        "termination": {"indicator": indicator},
+        "threads": [
+            {"id": 1, "frames": [{"imageOffset": 0, "symbol": f} for f in frames]},
+            {"triggered": True, "id": 2,
+             "frames": [{"imageOffset": i * 16, "symbol": s}
+                        for i, s in enumerate(frames)]},
+        ],
+    }
+    # .ips files are two-line JSON-ish: a metadata line then the payload.
+    path.write_text(
+        json.dumps({"app_name": app_name}) + "\n" + json.dumps(body),
+        encoding="utf-8",
+    )
+    import os
+    os.utime(path, (mtime, mtime))
+
+
+def _fresh_mtime() -> float:
+    """An mtime safely newer than any crash log written during the test."""
+    import time
+    return time.time() + 60
+
+
+class TestCollectMacosCrashReport:
+    def test_returns_none_when_diagnostics_dir_missing(self, tmp_path):
+        from desktop_app.app import collect_macos_crash_report
+        crash_log = tmp_path / "jarvis_desktop_crash.log"
+        crash_log.write_text("x")
+        missing = tmp_path / "nope"
+        assert collect_macos_crash_report(crash_log, diagnostics_dir=missing) is None
+
+    def test_returns_none_when_dir_empty(self, tmp_path):
+        from desktop_app.app import collect_macos_crash_report
+        crash_log = tmp_path / "jarvis_desktop_crash.log"
+        crash_log.write_text("x")
+        assert collect_macos_crash_report(crash_log, diagnostics_dir=tmp_path) is None
+
+    def test_returns_none_when_no_matching_app(self, tmp_path):
+        from desktop_app.app import collect_macos_crash_report
+        crash_log = tmp_path / "jarvis_desktop_crash.log"
+        crash_log.write_text("x")
+        other = tmp_path / "OtherApp-2026-08-08-133539.ips"
+        _write_ips(other, mtime=100.0, app_name="OtherApp", frames=["main"])
+        assert collect_macos_crash_report(crash_log, diagnostics_dir=tmp_path) is None
+
+    def test_returns_none_when_report_older_than_crash_log(self, tmp_path):
+        from desktop_app.app import collect_macos_crash_report
+        crash_log = tmp_path / "jarvis_desktop_crash.log"
+        crash_log.write_text("x")
+        # Crash report written BEFORE this session's log: stale, ignore it.
+        stale = tmp_path / "Jarvis-2026-07-01-000000.ips"
+        _write_ips(stale, mtime=50.0, frames=["main"])
+        assert collect_macos_crash_report(crash_log, diagnostics_dir=tmp_path) is None
+
+    def test_extracts_native_stack_from_fresh_report(self, tmp_path):
+        from desktop_app.app import collect_macos_crash_report
+        crash_log = tmp_path / "jarvis_desktop_crash.log"
+        crash_log.write_text("x")
+        ips = tmp_path / "Jarvis-2026-08-08-133539.ips"
+        frames = ["__pthread_kill", "abort", "qt_message_fatal",
+                  "QThread::start", "main"]
+        _write_ips(ips, mtime=_fresh_mtime(), frames=frames)
+        result = collect_macos_crash_report(crash_log, diagnostics_dir=tmp_path)
+        assert result is not None
+        assert "SIGABRT" in result
+        assert "DirtyVM_FLUSH" in result
+        assert "__pthread_kill" in result and "abort" in result
+        assert "qt_message_fatal" in result
+        assert ips.name in result
+
+    def test_handles_pretty_printed_multiline_payload(self, tmp_path):
+        """Real .ips payloads can be pretty-printed across many lines."""
+        from desktop_app.app import collect_macos_crash_report
+        crash_log = tmp_path / "jarvis_desktop_crash.log"
+        crash_log.write_text("x")
+        ips = tmp_path / "Jarvis-2026-08-08-133539.ips"
+        payload = (
+            '{\n  "app_name": "Jarvis",\n'
+            '  "exception": {"type": "SIGABRT"},\n'
+            '  "threads": [{"triggered": true, "frames": ['
+            '{"symbol": "abort"}, {"symbol": "main"}]}]\n}'
+        )
+        ips.write_text('{"app_name": "Jarvis"}\n' + payload)
+        import os as _os
+        _os.utime(ips, (_fresh_mtime(), _fresh_mtime()))
+        result = collect_macos_crash_report(crash_log, diagnostics_dir=tmp_path)
+        assert result is not None
+        assert "SIGABRT" in result and "abort" in result
+
+    def test_ignores_non_string_symbols(self, tmp_path):
+        """Frames without a demangled symbol render as '?' — never fall back
+        to the integer ``symbolLocation`` byte offset."""
+        from desktop_app.app import collect_macos_crash_report
+        crash_log = tmp_path / "jarvis_desktop_crash.log"
+        crash_log.write_text("x")
+        ips = tmp_path / "Jarvis-2026-08-08-133539.ips"
+        _write_ips(ips, mtime=_fresh_mtime(),
+                   frames=["abort", "__pthread_kill", "main"])
+        # Replace the payload with one whose frames carry only symbolLocation.
+        import os as _os
+        body = {
+            "app_name": "Jarvis",
+            "exception": {"type": "SIGABRT"},
+            "threads": [{"triggered": True, "id": 2,
+                         "frames": [{"imageOffset": 4096}]}],
+        }
+        ips.write_text('{"app_name": "Jarvis"}\n' + json.dumps(body))
+        _os.utime(ips, (_fresh_mtime(), _fresh_mtime()))
+        result = collect_macos_crash_report(crash_log, diagnostics_dir=tmp_path)
+        assert result is not None and "?" in result
+        assert "4096" not in result
+
+    def test_picks_newest_report(self, tmp_path):
+        from desktop_app.app import collect_macos_crash_report
+        crash_log = tmp_path / "jarvis_desktop_crash.log"
+        crash_log.write_text("x")
+        older = tmp_path / "Jarvis-2026-08-08-100000.ips"
+        newer = tmp_path / "Jarvis-2026-08-08-133539.ips"
+        _write_ips(older, mtime=_fresh_mtime() - 10, frames=["old_main"])
+        _write_ips(newer, mtime=_fresh_mtime(), frames=["new_main"])
+        result = collect_macos_crash_report(crash_log, diagnostics_dir=tmp_path)
+        assert result is not None and "new_main" in result and "old_main" not in result
+
+    def test_malformed_report_returns_none(self, tmp_path):
+        from desktop_app.app import collect_macos_crash_report
+        crash_log = tmp_path / "jarvis_desktop_crash.log"
+        crash_log.write_text("x")
+        bad = tmp_path / "Jarvis-2026-08-08-133539.ips"
+        bad.write_text("not json at all")
+        import os as _os
+        _os.utime(bad, (_fresh_mtime(), _fresh_mtime()))
+        assert collect_macos_crash_report(crash_log, diagnostics_dir=tmp_path) is None
+
+    def test_skipped_on_non_macos(self, tmp_path):
+        from desktop_app.app import collect_macos_crash_report
+        crash_log = tmp_path / "jarvis_desktop_crash.log"
+        crash_log.write_text("x")
+        ips = tmp_path / "Jarvis-2026-08-08-133539.ips"
+        _write_ips(ips, mtime=_fresh_mtime(), frames=["main"])
+        with patch.object(Path, "__str__", return_value="x"):
+            pass
+        with patch("desktop_app.app.sys.platform", "win32"):
+            assert collect_macos_crash_report(
+                crash_log, diagnostics_dir=tmp_path) is None
+
+
+class TestPreviousCrashIncludesNativeStack:
+    def test_previous_crash_content_includes_native_stack(self, tmp_path, monkeypatch):
+        """check_previous_crash() must surface the macOS native stack so the
+        crash dialog / report-issue body carries the C-level abort source."""
+        from desktop_app import app as desktop_app
+        crash_log, crash_marker, _ = desktop_app.get_crash_paths()
+
+        # Redirect paths to a temp dir for this test.
+        monkeypatch.setattr(desktop_app, "get_crash_paths",
+                            lambda: (tmp_path / "jarvis_desktop_crash.log",
+                                     tmp_path / ".crash_marker",
+                                     tmp_path / "previous_crash.log"))
+        crash_log, crash_marker, _ = desktop_app.get_crash_paths()
+
+        crash_log.write_text("=== Jarvis Desktop App Crash Log ===\nFatal Python error: Aborted\n")
+        crash_marker.touch()
+
+        ips = tmp_path / "Jarvis-2026-08-08-133539.ips"
+        _write_ips(ips, mtime=_fresh_mtime(), frames=["__pthread_kill", "abort", "qt_message_fatal"])
+        # Point the wiring's collector at the temp diagnostics dir so the
+        # end-to-end path (check_previous_crash -> collector -> content) is
+        # exercised without touching the real home directory.
+        _real_collect = desktop_app.collect_macos_crash_report
+        monkeypatch.setattr(
+            desktop_app, "collect_macos_crash_report",
+            lambda crash_log: _real_collect(crash_log, diagnostics_dir=tmp_path),
+        )
+        with patch.object(desktop_app.sys, "platform", "darwin"):
+            content = desktop_app.check_previous_crash()
+        assert content is not None
+        assert "Fatal Python error: Aborted" in content
+        assert "Native crash report" in content
+        assert "__pthread_kill" in content


### PR DESCRIPTION
## What

Closes #584 (and addresses the same crash class in #575, #576, #544): the macOS **"Fatal Python error: Aborted"** startup crash — SIGABRT lands on the main thread while it sits in `app.exec()`, right after "Auto-starting Jarvis listener...".

This is the same abort mechanism the repo already diagnosed and fixed for the setup wizard in #509/#407/#239: Qt aborts the whole process when the last Python reference to a `QThread` is dropped while its OS thread is still winding down. The desktop app's `DaemonThread` and startup workers were the remaining unguarded QThreads.

## Changes

- **Shared `KeepAliveWorker`** (`src/desktop_app/qt_worker.py`): the wizard's keep-alive registry pattern extracted into a shared class. `start()` registers the worker in a class-level set; the built-in `finished` signal retires it. The object therefore can never be destroyed before its OS thread has fully exited.
- **`DaemonThread`** now inherits `KeepAliveWorker` and was moved to module scope. Its `finished` slot (`_on_daemon_finished`, which clears `tray.daemon_thread` and mutates Qt UI state) is connected with `Qt.QueuedConnection` so it always runs on the main thread.
- **Startup workers** `SetupCheckWorker`, `_LLMReachWorker`, `ServerCheckWorker` inherit `KeepAliveWorker`.
- **Fixed signal shadowing**: `_LLMReachWorker.finished` shadowed `QThread`'s built-in `finished` signal, which breaks the keep-alive contract — renamed to `check_done` (matching the repo's documented convention).
- **Setup wizard** now uses the shared `KeepAliveWorker` (local private class removed); `_DiscoveryWorker`/`_CapabilityWorker` also inherit it so the "all wizard workers" invariant holds.
- **Diagnostics**: on macOS, the next launch now collects the native crash report (`~/Library/Logs/DiagnosticReports/Jarvis-*.ips`) and appends its exception type, termination indicator and crashed-thread native frames to the crash dialog / report-issue body. faulthandler only dumps Python frames, which is why the abort source was invisible — future reports will carry the C stack.

## Tests

- `tests/test_desktop_keepalive_workers.py`: subprocess churn scenario (rapid worker replacement from `finished` slots must not abort), registry retention/retirement, `finished`-shadowing guard, inheritance guard.
- `tests/test_macos_crash_report.py`: `.ips` collection behaviour (missing dir, staleness, app filtering, newest pick, single/two-line/pretty-printed payloads, non-string symbols, non-macOS) and end-to-end wiring into `check_previous_crash`.
- Full suite: 2177 passed; only 2 pre-existing environmental failures (verified identical on clean `develop`).

## Specs

`desktop_app.spec.md` and `setup_wizard.spec.md` updated to document the keep-alive threading contract and native-stack crash reporting.
