### PR TITLE
feat(chat): single SMS-style conversation with message rewind

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,14 +161,13 @@ Jarvis starts listening automatically — just say "Jarvis" and talk!
 ## Features
 
 - **Conversational Awareness** - Understands ongoing discussions. Ask "Jarvis, what do you think?" and it knows what you're talking about. Works naturally in multi-person conversations.
-- **Text Chat** - Type to Jarvis alongside voice. Voice and text share one conversation, so a follow-up typed in the chat window continues a voice discussion. Text never speaks. Open it from the tray menu (`💬 Chat…`) while Jarvis is listening. The window shows a local status banner while Jarvis starts, stops, or needs to be restarted. In-memory chat sessions (new session, session list) let you start a fresh conversation or jump back to an earlier one (nothing is saved to disk), and every message you send carries a rewind button that rolls the conversation back to that point and regenerates the reply.
+- **Text Chat** - Type to Jarvis alongside voice. Voice and text share one conversation, so a follow-up typed in the chat window continues a voice discussion. Text never speaks. Open it from the tray menu (`💬 Chat`) while Jarvis is listening. The window is styled like an SMS thread with a single contact: speech bubbles, timestamps, and an online/typing presence line. It shows a local status banner while Jarvis starts, stops, or needs to be restarted, and every message you send carries a rewind button that rolls the conversation back to that point and regenerates the reply.
 - **Unlimited Memory** - Never forgets. Searches across all your conversation history. Memory Viewer GUI included.
 - **Adaptive Tone** - Automatically surgical for code, pragmatic for business, encouraging for wellbeing — no manual mode switching
 - **Smart Tool Selection** - Embedding-based relevance filtering picks only the tools needed per query — add unlimited MCP tools without performance degradation
 - **Built-in Tools** - Screenshot OCR, web search (DuckDuckGo → Brave → Wikipedia fallback chain with auto-fetch), weather, current time in any city or timezone, file access, nutrition tracking, location awareness, plus a tool-discovery escape hatch the agent uses to widen its own toolset mid-reply
 - **Knowledge Graph Memory** - Self-organising memory that learns from conversations, auto-splits by topic, and surfaces relevant knowledge automatically
 - **Natural Voice** - Say "Jarvis" anywhere in your sentence, interrupt with "stop", follow up without repeating the wake word
-- **Fast Stop** - Use the tray action `⚡ Stop Now (Skip Diary)` to release local model resources quickly when you need your machine back immediately.
 - **Dictation Mode** - Free, offline alternative to WisprFlow — hold a hotkey, speak, release to paste text into any app
 - **MCP Integration** - Connect to thousands of external tools (Home Assistant, GitHub, Slack, etc.)
 
@@ -580,8 +579,6 @@ Get API key at [composio.dev](https://composio.dev)
 **Responses are slow** - Ensure you have enough VRAM (8GB+ for default model; see System Requirements for other models)
 
 **Mac gets warm while Jarvis is active** - Enable **⚙️ Settings → ✨ Features → Low Power Mode**. This keeps voice recognition ready while avoiding background LLM warmup and shortening Ollama's idle residency window.
-
-**Need to cool down immediately** - Use the tray action **⚡ Stop Now (Skip Diary)**. It stops the voice daemon without running the final diary LLM pass. Regular **Stop Listening** still saves the diary before shutdown.
 
 **Mac is still warm after quitting** - If Jarvis starts Ollama for you, quitting Jarvis also stops that owned Ollama runtime. If Ollama was already running before Jarvis opened, Jarvis leaves it running so it does not interrupt your other local AI tools.
 

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Jarvis starts listening automatically — just say "Jarvis" and talk!
 ## Features
 
 - **Conversational Awareness** - Understands ongoing discussions. Ask "Jarvis, what do you think?" and it knows what you're talking about. Works naturally in multi-person conversations.
-- **Text Chat** - Type to Jarvis alongside voice. Voice and text share one conversation, so a follow-up typed in the chat window continues a voice discussion. Text never speaks. Open it from the tray menu (`💬 Chat…`) while Jarvis is listening. The window shows a local status banner while Jarvis starts, stops, or needs to be restarted.
+- **Text Chat** - Type to Jarvis alongside voice. Voice and text share one conversation, so a follow-up typed in the chat window continues a voice discussion. Text never speaks. Open it from the tray menu (`💬 Chat…`) while Jarvis is listening. The window shows a local status banner while Jarvis starts, stops, or needs to be restarted. In-memory chat sessions (new session, session list) let you start a fresh conversation or jump back to an earlier one (nothing is saved to disk), and every message you send carries a rewind button that rolls the conversation back to that point and regenerates the reply.
 - **Unlimited Memory** - Never forgets. Searches across all your conversation history. Memory Viewer GUI included.
 - **Adaptive Tone** - Automatically surgical for code, pragmatic for business, encouraging for wellbeing — no manual mode switching
 - **Smart Tool Selection** - Embedding-based relevance filtering picks only the tools needed per query — add unlimited MCP tools without performance degradation

--- a/docs/llm_contexts.md
+++ b/docs/llm_contexts.md
@@ -112,7 +112,7 @@ Every distinct LLM call in Jarvis, what feeds it, what consumes it, and how it i
 ## 9. Conversation Summariser
 
 - **File**: [src/jarvis/memory/conversation.py](src/jarvis/memory/conversation.py) — `generate_conversation_summary()` (~lines 350/355).
-- **Trigger**: background, periodic when unsaved dialogue reaches `dialogue_memory_timeout`, plus the normal daemon shutdown path with `force=True`. `⚡ Stop Now (Skip Diary)` sets the daemon's shutdown skip flag, so this final forced pass is skipped while normal periodic saves remain unchanged. One summary is stored per day per `source_app`.
+- **Trigger**: background, periodic when unsaved dialogue reaches `dialogue_memory_timeout`, plus the normal daemon shutdown path with `force=True`. One summary is stored per day per `source_app`.
 - **Model / gating**: `cfg.llm_chat_model` via `get_llm_backend(cfg)`. Respects `llm_thinking_enabled`. Uses streaming when a token callback is provided, else direct.
 - **Inputs**: recent conversation chunks + prior same-day summary (for incremental update).
 - **System prompt**: inline (~lines 310-320). Hygiene rules per [src/jarvis/memory/summariser.spec.md](src/jarvis/memory/summariser.spec.md): no deflection narration, attribution preservation, topic separation. The deflection rule (rule 6) is enumerated with concrete BAD/GOOD pairs in English plus parallel pairs in Turkish and Spanish so small models don't assume the rule is keyed to English phrasing. ≤200 words + 3-5 topic keywords.

--- a/src/desktop_app/app.py
+++ b/src/desktop_app/app.py
@@ -1890,12 +1890,6 @@ class JarvisSystemTray:
         self.toggle_action.triggered.connect(self.toggle_listening)
         self.menu.addAction(self.toggle_action)
 
-        # Fast stop action
-        self.quick_stop_action = QAction("⚡ Stop Now (Skip Diary)")
-        self.quick_stop_action.setEnabled(False)
-        self.quick_stop_action.triggered.connect(self.quick_stop_daemon)
-        self.menu.addAction(self.quick_stop_action)
-
         self.menu.addSeparator()
 
         # View logs action
@@ -1914,7 +1908,7 @@ class JarvisSystemTray:
         self.menu.addAction(self.dictation_history_action)
 
         # Chat window action
-        self.chat_action = QAction("💬 Chat…")
+        self.chat_action = QAction("💬 Chat")
         self.chat_action.triggered.connect(self.show_chat)
         self.menu.addAction(self.chat_action)
 
@@ -2373,13 +2367,6 @@ class JarvisSystemTray:
         else:
             self.start_daemon()
 
-    def quick_stop_daemon(self) -> None:
-        """Stop the daemon quickly without the final shutdown diary pass."""
-        if not self.is_listening:
-            return
-        debug_log("fast stop requested from tray", "desktop")
-        self.stop_daemon(show_diary_dialog=False, skip_diary_update=True)
-
     def start_daemon(self) -> None:
         """Start the Jarvis daemon."""
         self._daemon_stop_expected = False
@@ -2474,37 +2461,22 @@ class JarvisSystemTray:
                         debug_log(f"chat stdin cancel failed: {exc}", "desktop")
 
                 def _control_chat_subprocess(kind: str, payload: Optional[dict] = None) -> None:
-                    """Route a session-control command to the daemon's stdin.
+                    """Route a rewind command to the daemon's stdin.
 
-                    ``kind`` is one of ``new_session`` / ``rewind`` /
-                    ``restore``; the matching IPC line carries the payload
-                    (bare prefix for new session, prefix+JSON otherwise).
-                    A broken pipe is not worth surfacing: the window has
-                    already updated its own transcript, and a dead daemon
-                    has no memory to rewind or restore.
+                    ``kind`` is ``rewind``; the matching IPC line carries the
+                    payload as prefix+JSON. A broken pipe is not worth
+                    surfacing: the window has already updated its own
+                    transcript, and a dead daemon has no memory to rewind.
                     """
                     import json as _json
-                    from jarvis.daemon import (
-                        CHAT_NEW_SESSION_IPC_PREFIX,
-                        CHAT_REWIND_IPC_PREFIX,
-                        CHAT_RESTORE_IPC_PREFIX,
-                    )
-                    prefixes = {
-                        "new_session": CHAT_NEW_SESSION_IPC_PREFIX,
-                        "rewind": CHAT_REWIND_IPC_PREFIX,
-                        "restore": CHAT_RESTORE_IPC_PREFIX,
-                    }
-                    prefix = prefixes.get(kind)
-                    if prefix is None:
+                    from jarvis.daemon import CHAT_REWIND_IPC_PREFIX
+                    if kind != "rewind":
                         debug_log(f"unknown chat control command: {kind}", "desktop")
                         return
                     try:
-                        if payload is None:
-                            _proc.stdin.write(f"{prefix}\n")
-                        else:
-                            _proc.stdin.write(
-                                f"{prefix}{_json.dumps(payload)}\n"
-                            )
+                        _proc.stdin.write(
+                            f"{CHAT_REWIND_IPC_PREFIX}{_json.dumps(payload)}\n"
+                        )
                         _proc.stdin.flush()
                     except Exception as exc:
                         debug_log(f"chat stdin control failed: {exc}", "desktop")
@@ -2531,8 +2503,6 @@ class JarvisSystemTray:
 
             self.is_listening = True
             self.toggle_action.setText("⏸️ Stop Listening")
-            if hasattr(self, "quick_stop_action"):
-                self.quick_stop_action.setEnabled(True)
             self.status_action.setText("🟢 Status: Listening")
             self.update_icon()
             self._set_chat_daemon_status("running")
@@ -2574,8 +2544,6 @@ class JarvisSystemTray:
             self.is_listening = False
             self._chat_submit_fn = None
             self.toggle_action.setText("▶️ Start Listening")
-            if hasattr(self, "quick_stop_action"):
-                self.quick_stop_action.setEnabled(False)
             self.status_action.setText("⚪ Status: Stopped")
             self.update_icon()
             self.daemon_thread = None
@@ -2635,13 +2603,11 @@ class JarvisSystemTray:
     def stop_daemon(
         self,
         show_diary_dialog: bool = True,
-        skip_diary_update: bool = False,
     ) -> None:
         """Stop the Jarvis daemon.
 
         Args:
             show_diary_dialog: If True (and bundled), shows a dialog with live diary update progress.
-            skip_diary_update: If True, skips the final shutdown diary LLM pass.
         """
         # Timeout must be longer than SHUTDOWN_DIARY_TIMEOUT_SEC (45s) in daemon.py
         # to allow the diary update LLM call to complete before force-killing
@@ -2651,8 +2617,7 @@ class JarvisSystemTray:
         debug_log(
             f"stop_daemon called: is_bundled={self.is_bundled}, "
             f"daemon_thread={self.daemon_thread}, "
-            f"show_diary_dialog={show_diary_dialog}, "
-            f"skip_diary_update={skip_diary_update}",
+            f"show_diary_dialog={show_diary_dialog}",
             "desktop",
         )
 
@@ -2705,7 +2670,7 @@ class JarvisSystemTray:
                     self.app.processEvents()
 
                     # Request graceful stop
-                    request_stop(skip_diary_update=skip_diary_update)
+                    request_stop()
 
                     # Process events while waiting for thread to finish
                     # Note: We avoid QThread.terminate() as it can corrupt state
@@ -2738,7 +2703,7 @@ class JarvisSystemTray:
                     # No dialog - simple wait
                     # Note: We avoid QThread.terminate() as it can corrupt state
                     from jarvis.daemon import request_stop
-                    request_stop(skip_diary_update=skip_diary_update)
+                    request_stop()
 
                     if not self.daemon_thread.wait(shutdown_wait_timeout_sec * 1000):
                         self.log_signals.new_log.emit("⚠️ Daemon taking longer than expected...\n")
@@ -2777,21 +2742,9 @@ class JarvisSystemTray:
                     if hasattr(self, 'log_viewer') and self.log_viewer.isVisible():
                         self.log_viewer.hide()
 
-                # Send signal for graceful shutdown. Fast stop goes through
-                # stdin so the subprocess receives the skip-diary flag before
-                # entering its shutdown block.
-                if skip_diary_update:
-                    try:
-                        from jarvis.daemon import SHUTDOWN_SKIP_DIARY_COMMAND
-                        if self.daemon_process.stdin:
-                            self.daemon_process.stdin.write(
-                                f"{SHUTDOWN_SKIP_DIARY_COMMAND}\n"
-                            )
-                            self.daemon_process.stdin.flush()
-                    except Exception as exc:
-                        debug_log(f"fast stop stdin command failed: {exc}", "desktop")
-                        self.daemon_process.send_signal(signal.SIGINT)
-                elif sys.platform == "win32":
+                # Send signal for graceful shutdown. The daemon runs its
+                # final diary update in its shutdown block regardless.
+                if sys.platform == "win32":
                     # On Windows, signals don't work reliably with CREATE_NO_WINDOW
                     # Close stdin to trigger graceful shutdown in daemon
                     try:
@@ -2886,8 +2839,6 @@ class JarvisSystemTray:
             self._daemon_stop_expected = False
             self.is_listening = False
             self.toggle_action.setText("▶️ Start Listening")
-            if hasattr(self, "quick_stop_action"):
-                self.quick_stop_action.setEnabled(False)
             self.status_action.setText("⚪ Status: Stopped")
             self.update_icon()
             self._set_chat_daemon_status("stopped")
@@ -2935,8 +2886,6 @@ class JarvisSystemTray:
                 if self.is_listening:
                     self.is_listening = False
                     self.toggle_action.setText("▶️ Start Listening")
-                    if hasattr(self, "quick_stop_action"):
-                        self.quick_stop_action.setEnabled(False)
                     self.status_action.setText("⚪ Status: Stopped")
                     self.update_icon()
                     self._set_chat_daemon_status("crashed")

--- a/src/desktop_app/app.py
+++ b/src/desktop_app/app.py
@@ -200,8 +200,13 @@ def _collect_runtime_status_snapshot(
     )
 
 
-def _format_runtime_status(snapshot: RuntimeStatusSnapshot) -> str:
-    """Format a runtime status snapshot for the tray diagnostics dialog."""
+def _runtime_status_rows(snapshot: RuntimeStatusSnapshot) -> list[tuple[str, str, str]]:
+    """Return ``(section, key, value)`` rows for the runtime status dialog.
+
+    Sections keep the emoji headers of the original text format so the
+    dialog and the (test-pinned) ``_format_runtime_status`` text stay in
+    sync from one source of truth.
+    """
     pid = str(snapshot.daemon_pid) if snapshot.daemon_pid is not None else "n/a"
     ollama_running = (
         f"Yes ({snapshot.ollama_version})"
@@ -210,31 +215,97 @@ def _format_runtime_status(snapshot: RuntimeStatusSnapshot) -> str:
         if snapshot.ollama_running
         else "No"
     )
-    return "\n".join(
-        [
-            "🩺 Runtime Status",
-            "",
-            "🎙️ Assistant",
-            f"  State: {snapshot.daemon_state}",
-            f"  Mode: {snapshot.daemon_mode}",
-            f"  PID: {pid}",
-            f"  Low Power Mode: {'On' if snapshot.low_power_mode else 'Off'}",
-            "",
-            "🦙 Ollama",
-            f"  Needed: {'Yes' if snapshot.ollama_needed else 'No'}",
-            f"  Running: {ollama_running}",
-            f"  Owner: {snapshot.ollama_owner}",
-            f"  Launch method: {snapshot.ollama_launch_method}",
-            "",
+    return [
+        ("🎙️ Assistant", "State", snapshot.daemon_state),
+        ("🎙️ Assistant", "Mode", snapshot.daemon_mode),
+        ("🎙️ Assistant", "PID", pid),
+        ("🎙️ Assistant", "Low Power Mode", "On" if snapshot.low_power_mode else "Off"),
+        ("🦙 Ollama", "Needed", "Yes" if snapshot.ollama_needed else "No"),
+        ("🦙 Ollama", "Running", ollama_running),
+        ("🦙 Ollama", "Owner", snapshot.ollama_owner),
+        ("🦙 Ollama", "Launch method", snapshot.ollama_launch_method),
+        ("🧠 Models", "Provider", snapshot.llm_provider),
+        ("🧠 Models", "Chat", snapshot.chat_model),
+        (
             "🧠 Models",
-            f"  Provider: {snapshot.llm_provider}",
-            f"  Chat: {snapshot.chat_model}",
-            f"  Embeddings: {snapshot.embedding_provider} / {snapshot.embedding_model}",
-            "",
-            "🔌 MCP",
-            f"  Configured servers: {snapshot.mcp_count}",
-        ]
-    )
+            "Embeddings",
+            f"{snapshot.embedding_provider} / {snapshot.embedding_model}",
+        ),
+        ("🔌 MCP", "Configured servers", str(snapshot.mcp_count)),
+    ]
+
+
+def _format_runtime_status(snapshot: RuntimeStatusSnapshot) -> str:
+    """Format a runtime status snapshot for the tray diagnostics dialog."""
+    lines: list[str] = ["🩺 Runtime Status", ""]
+    current_section = None
+    for section, key, value in _runtime_status_rows(snapshot):
+        if section != current_section:
+            if current_section is not None:
+                lines.append("")
+            lines.append(section)
+            current_section = section
+        lines.append(f"  {key}: {value}")
+    return "\n".join(lines)
+
+
+class RuntimeStatusDialog(QDialog):
+    """Themed diagnostic summary of Jarvis' active runtime.
+
+    Renders the collected snapshot as a structured dialog: emoji section
+    headers, aligned key/value rows (secondary-colour keys, monospace
+    values), and a Close button. Snapshot collection stays on the worker
+    thread; this dialog only renders the data it is handed.
+    """
+
+    def __init__(self, snapshot: RuntimeStatusSnapshot, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Runtime Status")
+        self.setStyleSheet(JARVIS_THEME_STYLESHEET)
+        self.setMinimumWidth(380)
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(24, 20, 24, 20)
+        layout.setSpacing(4)
+
+        title = QLabel("🩺 Runtime Status")
+        title.setObjectName("title")
+        layout.addWidget(title)
+        layout.addSpacing(6)
+
+        current_section = None
+        for section, key, value in _runtime_status_rows(snapshot):
+            if section != current_section:
+                if current_section is not None:
+                    layout.addSpacing(8)
+                header = QLabel(section)
+                header.setStyleSheet(
+                    "color: #fbbf24; font-weight: bold; font-size: 13px;"
+                )
+                layout.addWidget(header)
+                current_section = section
+            row = QHBoxLayout()
+            key_label = QLabel(key)
+            key_label.setStyleSheet("color: #a1a1aa; font-size: 13px;")
+            value_label = QLabel(value)
+            value_label.setStyleSheet(
+                "color: #f4f4f5; font-size: 13px;"
+                " font-family: 'SF Mono', 'Menlo', monospace;"
+            )
+            value_label.setWordWrap(True)
+            row.addWidget(key_label)
+            row.addStretch(1)
+            row.addWidget(value_label)
+            layout.addLayout(row)
+
+        layout.addSpacing(12)
+        close_btn = QPushButton("Close")
+        close_btn.setDefault(True)
+        close_btn.clicked.connect(self.accept)
+        button_row = QHBoxLayout()
+        button_row.addStretch(1)
+        button_row.addWidget(close_btn)
+        layout.addLayout(button_row)
 
 
 def _stop_owned_ollama_runtime(
@@ -2054,15 +2125,7 @@ class JarvisSystemTray:
 
     def _show_runtime_status_dialog(self, snapshot) -> None:
         """Render the collected snapshot. Runs on the Qt main thread."""
-        from PyQt6.QtWidgets import QMessageBox
-
-        msg = QMessageBox()
-        msg.setIcon(QMessageBox.Icon.Information)
-        msg.setWindowTitle("Runtime Status")
-        msg.setText("🩺 Runtime Status")
-        msg.setInformativeText(_format_runtime_status(snapshot))
-        msg.setStyleSheet(JARVIS_THEME_STYLESHEET)
-        msg.exec()
+        RuntimeStatusDialog(snapshot).exec()
 
     def check_for_updates(self, show_no_update_dialog: bool = False) -> None:
         """Check for available updates.

--- a/src/desktop_app/app.py
+++ b/src/desktop_app/app.py
@@ -1794,6 +1794,7 @@ class JarvisSystemTray:
         # starts so the window can route queries in subprocess mode.
         self.chat_window = None
         self._chat_submit_fn = None
+        self._chat_control_fn = None
         self._daemon_stop_expected = False
 
         # Main-thread signal bridge for chat IPC. The log reader thread emits
@@ -2219,10 +2220,12 @@ class JarvisSystemTray:
                 submit_fn=self._chat_submit_fn,
                 daemon_available=self.is_listening,
                 cancel_fn=getattr(self, "_chat_cancel_fn", None),
+                control_fn=getattr(self, "_chat_control_fn", None),
             )
         else:
             self.chat_window._submit_fn = self._chat_submit_fn
             self.chat_window._cancel_fn = getattr(self, "_chat_cancel_fn", None)
+            self.chat_window._control_fn = getattr(self, "_chat_control_fn", None)
             self.chat_window.set_daemon_status(
                 "running" if self.is_listening else "stopped"
             )
@@ -2239,6 +2242,7 @@ class JarvisSystemTray:
         if self.chat_window is None:
             return
         self.chat_window._submit_fn = self._chat_submit_fn
+        self.chat_window._control_fn = getattr(self, "_chat_control_fn", None)
         self.chat_window.set_daemon_status(status)
 
     def _connect_dictation_history(self, retries_left: int = 3) -> None:
@@ -2469,8 +2473,45 @@ class JarvisSystemTray:
                     except Exception as exc:
                         debug_log(f"chat stdin cancel failed: {exc}", "desktop")
 
+                def _control_chat_subprocess(kind: str, payload: Optional[dict] = None) -> None:
+                    """Route a session-control command to the daemon's stdin.
+
+                    ``kind`` is one of ``new_session`` / ``rewind`` /
+                    ``restore``; the matching IPC line carries the payload
+                    (bare prefix for new session, prefix+JSON otherwise).
+                    A broken pipe is not worth surfacing: the window has
+                    already updated its own transcript, and a dead daemon
+                    has no memory to rewind or restore.
+                    """
+                    import json as _json
+                    from jarvis.daemon import (
+                        CHAT_NEW_SESSION_IPC_PREFIX,
+                        CHAT_REWIND_IPC_PREFIX,
+                        CHAT_RESTORE_IPC_PREFIX,
+                    )
+                    prefixes = {
+                        "new_session": CHAT_NEW_SESSION_IPC_PREFIX,
+                        "rewind": CHAT_REWIND_IPC_PREFIX,
+                        "restore": CHAT_RESTORE_IPC_PREFIX,
+                    }
+                    prefix = prefixes.get(kind)
+                    if prefix is None:
+                        debug_log(f"unknown chat control command: {kind}", "desktop")
+                        return
+                    try:
+                        if payload is None:
+                            _proc.stdin.write(f"{prefix}\n")
+                        else:
+                            _proc.stdin.write(
+                                f"{prefix}{_json.dumps(payload)}\n"
+                            )
+                        _proc.stdin.flush()
+                    except Exception as exc:
+                        debug_log(f"chat stdin control failed: {exc}", "desktop")
+
                 self._chat_submit_fn = _submit_chat_subprocess
                 self._chat_cancel_fn = _cancel_chat_subprocess
+                self._chat_control_fn = _control_chat_subprocess
                 # If the chat window already exists (daemon restarted while
                 # the window was open), refresh its submit fn so it doesn't
                 # keep writing to the old (dead) subprocess stdin.

--- a/src/desktop_app/chat_window.py
+++ b/src/desktop_app/chat_window.py
@@ -9,16 +9,15 @@ The window is created lazily by the system tray and kept alive for the
 session. Daemon callback signals are marshalled onto the Qt main thread via
 ``ChatSignals`` so UI updates never touch the worker thread directly.
 
-Sessions (in-memory only): the chat window keeps a list of past sessions in
-memory — nothing is written to disk. A session maps to the shared voice+text
-conversation: starting a new session clears the daemon's dialogue memory, and
-switching sessions restores an archived conversation into it. Every sent
-message carries a rewind button that rolls the conversation back to that
-message and regenerates a fresh reply.
+There is exactly one conversation, like a text-message thread with a single
+contact: no session list, no new-session button, nothing written to disk.
+Every sent message carries a subtle rewind button that rolls the
+conversation back to that message and regenerates a fresh reply.
 """
 
 from __future__ import annotations
 
+from datetime import datetime
 from typing import Callable, Optional
 
 from PyQt6.QtCore import Qt, pyqtSignal, QObject
@@ -26,8 +25,6 @@ from PyQt6.QtGui import QCloseEvent, QShowEvent
 from PyQt6.QtWidgets import (
     QHBoxLayout,
     QLabel,
-    QListWidget,
-    QListWidgetItem,
     QMainWindow,
     QPlainTextEdit,
     QPushButton,
@@ -89,19 +86,18 @@ class ChatIpcSignals(QObject):
 
 _TRANSCRIPT_AREA_STYLE = f"""
     QScrollArea {{
-        border: 1px solid {COLORS['border']};
-        border-radius: 8px;
-        background-color: {COLORS['bg_secondary']};
+        background-color: {COLORS['bg_primary']};
+        border: none;
     }}
 """
 
 _INPUT_STYLE = f"""
     QPlainTextEdit {{
-        background-color: {COLORS['bg_tertiary']};
+        background-color: {COLORS['bg_secondary']};
         color: {COLORS['text_primary']};
         border: 1px solid {COLORS['border']};
-        border-radius: 8px;
-        padding: 8px;
+        border-radius: 18px;
+        padding: 8px 14px;
         font-family: '.AppleSystemUIFont', 'Segoe UI', sans-serif;
         font-size: 14px;
     }}
@@ -115,8 +111,8 @@ _SEND_BTN_STYLE = f"""
         background-color: {COLORS['accent_primary']};
         color: #0a0b0f;
         border: none;
-        border-radius: 8px;
-        padding: 10px 18px;
+        border-radius: 18px;
+        padding: 8px 16px;
         font-weight: 600;
         font-size: 14px;
     }}
@@ -134,8 +130,8 @@ _STOP_BTN_STYLE = f"""
         background-color: {COLORS['error']};
         color: #ffffff;
         border: none;
-        border-radius: 8px;
-        padding: 10px 18px;
+        border-radius: 18px;
+        padding: 8px 16px;
         font-weight: 600;
         font-size: 14px;
     }}
@@ -144,22 +140,23 @@ _STOP_BTN_STYLE = f"""
     }}
 """
 
+# A subtle ghost button: SMS threads don't advertise actions, but the rewind
+# affordance stays reachable next to each sent message.
 _REWIND_BTN_STYLE = f"""
     QPushButton {{
-        background-color: {COLORS['bg_tertiary']};
-        color: {COLORS['text_secondary']};
-        border: 1px solid {COLORS['border']};
-        border-radius: 6px;
+        background-color: transparent;
+        color: {COLORS['text_muted']};
+        border: none;
+        border-radius: 12px;
         font-size: 13px;
         padding: 2px;
     }}
     QPushButton:hover {{
-        border-color: {COLORS['accent_primary']};
+        background-color: {COLORS['bg_hover']};
         color: {COLORS['accent_secondary']};
     }}
     QPushButton:disabled {{
-        color: {COLORS['text_muted']};
-        border-color: {COLORS['border']};
+        color: {COLORS['border']};
     }}
 """
 
@@ -171,24 +168,50 @@ _STATUS_STYLE = f"""
     }}
 """
 
-_SESSION_SIDEBAR_STYLE = f"""
-    QListWidget {{
-        background-color: {COLORS['bg_tertiary']};
-        border: 1px solid {COLORS['border']};
-        border-radius: 8px;
-        color: {COLORS['text_secondary']};
-        font-size: 13px;
-        padding: 4px;
-    }}
-    QListWidget::item {{
-        padding: 6px 8px;
-        border-radius: 6px;
-    }}
-    QListWidget::item:selected {{
-        background-color: {COLORS['bg_hover']};
-        color: {COLORS['accent_secondary']};
+_HEADER_STATUS_STYLE = f"""
+    QLabel {{
+        color: {COLORS['text_muted']};
+        font-size: 12px;
     }}
 """
+
+# SMS-style bubbles: the user's messages sit on the right in the accent
+# colour, Jarvis's replies on the left in a dark bubble. The corner nearest
+# the sender is squared off, like a speech bubble.
+_BUBBLE_STYLES = {
+    "user": f"""
+        QLabel {{
+            background-color: {COLORS['accent_primary']};
+            color: #0a0b0f;
+            border-radius: 14px;
+            border-bottom-right-radius: 4px;
+            padding: 9px 12px;
+            font-size: 14px;
+        }}
+    """,
+    "assistant": f"""
+        QLabel {{
+            background-color: {COLORS['bg_tertiary']};
+            color: {COLORS['text_primary']};
+            border: 1px solid {COLORS['border']};
+            border-radius: 14px;
+            border-bottom-left-radius: 4px;
+            padding: 9px 12px;
+            font-size: 14px;
+        }}
+    """,
+}
+
+_TIMESTAMP_STYLE = f"""
+    QLabel {{
+        color: {COLORS['text_muted']};
+        font-size: 11px;
+    }}
+"""
+
+_MESSAGE_TEXT_STYLES = {
+    "system": f"color: {COLORS['text_muted']}; font-size: 12px;",
+}
 
 _DAEMON_STATUS_MESSAGES = {
     "starting": "Starting Jarvis...",
@@ -205,10 +228,12 @@ _DAEMON_STATUS_PLACEHOLDERS = {
     "running": "Type a message to Jarvis... (Enter to send, Shift+Enter for newline)",
 }
 
-_MESSAGE_TEXT_STYLES = {
-    "user": f"color: {COLORS['accent_secondary']};",
-    "assistant": f"color: {COLORS['text_primary']};",
-    "system": f"color: {COLORS['text_muted']}; font-size: 12px;",
+_HEADER_STATUS_TEXTS = {
+    "running": "Online",
+    "starting": "Starting…",
+    "stopping": "Stopping…",
+    "stopped": "Offline",
+    "crashed": "Offline",
 }
 
 
@@ -218,15 +243,13 @@ class ChatWindow(QMainWindow):
     In subprocess mode the desktop app sets ``submit_fn`` to a callable that
     writes a ``__CHAT_QUERY__:`` line to the daemon's stdin, ``cancel_fn`` to
     the cancel line writer, and ``control_fn`` to a callable that writes the
-    session-control lines (new session / rewind / restore). In bundled mode
-    the window calls the daemon directly.
+    rewind line. In bundled mode the window calls the daemon directly.
 
-    Sessions: an in-memory list of past conversations (never persisted).
-    The active session maps 1:1 to the daemon's shared dialogue memory, so
-    starting a new session or switching to an archived one rewires the
-    conversation the voice path also sees. Every sent message carries a
-    rewind button that truncates the conversation to before that message
-    and regenerates a fresh reply to it.
+    There is a single conversation, displayed like an SMS thread: no session
+    list, no new-session button. The transcript maps 1:1 to the daemon's
+    shared dialogue memory, so the voice path sees the same turns. Every
+    sent message carries a subtle rewind button that truncates the
+    conversation to before that message and regenerates a fresh reply.
     """
 
     def __init__(
@@ -238,16 +261,18 @@ class ChatWindow(QMainWindow):
     ) -> None:
         super().__init__()
         self.setWindowTitle("Jarvis Chat")
-        self.setMinimumSize(760, 560)
+        # A portrait, phone-like window reads as a message thread. The tray
+        # re-shows the same instance, so the size persists for the session.
+        self.setMinimumSize(440, 600)
+        self.resize(480, 720)
         self.setStyleSheet(JARVIS_THEME_STYLESHEET)
         self._submit_fn = submit_fn
         # Subprocess mode routes cancellation to the daemon the same way it
         # routes a submission. Without it, Stop sets a flag in this
         # process while the query runs in the other one.
         self._cancel_fn = cancel_fn
-        # Subprocess mode routes session control (new session / rewind /
-        # restore) to the daemon's stdin. Bundled mode calls the daemon
-        # module directly and leaves this None.
+        # Subprocess mode routes rewind to the daemon's stdin. Bundled mode
+        # calls the daemon module directly and leaves this None.
         self._control_fn = control_fn
         # Set by Stop, cleared by the next send. The engine keeps running
         # after a cancel and its reply still arrives, so the window has to
@@ -256,14 +281,10 @@ class ChatWindow(QMainWindow):
         self._daemon_available = daemon_available
         self._daemon_status = "running" if daemon_available else "stopped"
 
-        # In-memory session store. Each session is
-        # {"title": str, "messages": [{"kind", "text", "user_index"}], "active": bool}.
-        # Nothing here is written to disk; a fresh app run starts with a new
-        # session (there is no "last chat session" to restore).
-        self._sessions: list[dict] = [
-            {"title": "Session 1", "messages": [], "active": True}
-        ]
-        self._session_counter = 1
+        # The single conversation's transcript. In-memory only; nothing is
+        # written to disk, and a fresh app run starts blank (the daemon's
+        # dialogue memory owns the durable record).
+        self._messages: list[dict] = []
 
         # Signal bridge: daemon worker -> Qt main thread.
         self.signals = ChatSignals()
@@ -274,37 +295,38 @@ class ChatWindow(QMainWindow):
         # --- Layout -----------------------------------------------------
         central = QWidget()
         self.setCentralWidget(central)
-        root = QHBoxLayout(central)
-        root.setContentsMargins(12, 12, 12, 12)
-        root.setSpacing(10)
+        root = QVBoxLayout(central)
+        root.setContentsMargins(12, 10, 12, 12)
+        root.setSpacing(8)
 
-        # Sessions sidebar (in-memory list + new session button)
-        sidebar = QVBoxLayout()
-        sidebar.setSpacing(8)
-        sidebar_label = QLabel("Sessions")
-        sidebar_label.setStyleSheet(
-            f"color: {COLORS['text_secondary']}; font-size: 12px;"
-            " font-weight: 600;"
+        # Contact header, like the top of an SMS thread.
+        header = QHBoxLayout()
+        header.setSpacing(10)
+        avatar = QLabel("🤖")
+        avatar.setFixedSize(36, 36)
+        avatar.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        avatar.setStyleSheet(
+            f"background-color: {COLORS['bg_tertiary']};"
+            f" border-radius: 18px; font-size: 18px;"
         )
-        sidebar.addWidget(sidebar_label)
-        self.session_list = QListWidget()
-        self.session_list.setStyleSheet(_SESSION_SIDEBAR_STYLE)
-        self.session_list.setFixedWidth(170)
-        self.session_list.itemClicked.connect(self._on_session_clicked)
-        sidebar.addWidget(self.session_list, stretch=1)
-        self.new_session_button = QPushButton("＋ New session")
-        self.new_session_button.setStyleSheet(_SEND_BTN_STYLE)
-        self.new_session_button.clicked.connect(self._new_session)
-        sidebar.addWidget(self.new_session_button)
-        root.addLayout(sidebar)
-
-        # Right column: transcript + status + input row
-        right = QVBoxLayout()
-        right.setSpacing(8)
+        header.addWidget(avatar)
+        name_col = QVBoxLayout()
+        name_col.setSpacing(0)
+        name_label = QLabel("Jarvis")
+        name_label.setStyleSheet(
+            f"color: {COLORS['text_primary']}; font-size: 15px; font-weight: 700;"
+        )
+        name_col.addWidget(name_label)
+        self._header_status = QLabel("")
+        self._header_status.setStyleSheet(_HEADER_STATUS_STYLE)
+        name_col.addWidget(self._header_status)
+        header.addLayout(name_col)
+        header.addStretch(1)
+        root.addLayout(header)
 
         # Transcript: a scroll area whose container holds one row widget per
         # message, so sent messages can carry a rewind button. Rebuilt
-        # atomically on session switch / rewind (see _render_transcript).
+        # atomically on rewind (see _render_transcript).
         self.transcript_widget = QScrollArea()
         self.transcript_widget.setWidgetResizable(True)
         self.transcript_widget.setHorizontalScrollBarPolicy(
@@ -313,17 +335,17 @@ class ChatWindow(QMainWindow):
         self.transcript_widget.setStyleSheet(_TRANSCRIPT_AREA_STYLE)
         self._transcript_container = QWidget()
         self._transcript_layout = QVBoxLayout(self._transcript_container)
-        self._transcript_layout.setContentsMargins(10, 10, 10, 10)
-        self._transcript_layout.setSpacing(6)
+        self._transcript_layout.setContentsMargins(4, 4, 4, 4)
+        self._transcript_layout.setSpacing(8)
         self._transcript_layout.addStretch(1)
         self.transcript_widget.setWidget(self._transcript_container)
-        right.addWidget(self.transcript_widget, stretch=1)
+        root.addWidget(self.transcript_widget, stretch=1)
 
         # Status indicator (display-only label)
         self._status_label = QLabel("")
         self._status_label.setStyleSheet(_STATUS_STYLE)
         self._status_label.setVisible(False)
-        right.addWidget(self._status_label)
+        root.addWidget(self._status_label)
 
         # Input row: input box + send + stop
         row = QHBoxLayout()
@@ -331,7 +353,7 @@ class ChatWindow(QMainWindow):
 
         self.input_widget = QPlainTextEdit()
         self.input_widget.setPlaceholderText(_DAEMON_STATUS_PLACEHOLDERS["running"])
-        self.input_widget.setFixedHeight(64)
+        self.input_widget.setFixedHeight(52)
         self.input_widget.setStyleSheet(_INPUT_STYLE)
         self.input_widget.keyPressEvent = self._input_key_press  # type: ignore[method-assign]
         row.addWidget(self.input_widget, stretch=1)
@@ -347,109 +369,13 @@ class ChatWindow(QMainWindow):
         self.stop_button.setVisible(False)
         row.addWidget(self.stop_button)
 
-        right.addLayout(row)
-        root.addLayout(right, stretch=1)
+        root.addLayout(row)
 
         self._query_in_flight = False
         # Whether the transcript has been seeded from the daemon's hot window.
         # Seeded once on first show so re-opening never duplicates turns.
         self._hot_window_seeded = False
-        self._refresh_session_list()
         self.set_daemon_available(daemon_available)
-
-    # --- Sessions -------------------------------------------------------
-
-    def _active_session(self) -> dict:
-        return next(s for s in self._sessions if s["active"])
-
-    def _refresh_session_list(self) -> None:
-        """Rebuild the sidebar from the in-memory session store."""
-        self.session_list.clear()
-        for index, session in enumerate(self._sessions):
-            title = session["title"]
-            if session["active"]:
-                title = f"● {title}"
-            item = QListWidgetItem(title)
-            # Store the index, not the dict: PyQt6 marshals plain dicts
-            # through QVariant on setData/data, returning a copy on read,
-            # so mutating the returned object would not touch the session.
-            item.setData(Qt.ItemDataRole.UserRole, index)
-            self.session_list.addItem(item)
-            if session["active"]:
-                self.session_list.setCurrentItem(item)
-
-    def _on_session_clicked(self, item: QListWidgetItem) -> None:
-        """Switch to a past session: archive the live one, restore the
-        clicked one into the shared daemon memory, re-render its transcript."""
-        index = item.data(Qt.ItemDataRole.UserRole)
-        if index is None or not isinstance(index, int):
-            return
-        target = self._sessions[index]
-        if target["active"] or self._query_in_flight or not self._daemon_available:
-            return
-        # Restore the daemon memory first: if a query is in flight the
-        # daemon refuses, and the UI must not switch to a conversation the
-        # memory does not hold.
-        if not self._restore_session_memory(target):
-            debug_log("session switch rejected: a query is in flight", "chat")
-            return
-        current = self._active_session()
-        current["active"] = False
-        target["active"] = True
-        self._render_transcript(target["messages"])
-        self._refresh_session_list()
-        self._scroll_to_bottom()
-
-    def _restore_session_memory(self, session: dict) -> bool:
-        """Push an archived session's turns into the shared daemon memory.
-
-        Only user/assistant turns are restored (system notices are local
-        UI text). The daemon re-redacts everything on restore, so the
-        diary never sees raw user text even though the window's archive
-        holds it. Returns False when the daemon refused (query in flight).
-        In subprocess mode the control line is fire-and-forget: the daemon
-        enforces its own lock guard, and the window is optimistic.
-        """
-        turns = [
-            {"role": m["kind"], "content": m["text"]}
-            for m in session["messages"]
-            if m["kind"] in ("user", "assistant")
-        ]
-        if self._control_fn is not None:
-            self._control_fn("restore", {"messages": turns})
-            return True
-        from jarvis import daemon
-        return daemon.set_chat_messages(turns)
-
-    def _new_session(self) -> None:
-        """Archive the current session and start a fresh one.
-
-        The shared dialogue memory is cleared, so the voice path also
-        starts a new conversation. The previous session stays in the
-        in-memory list; nothing is written to disk. The daemon is asked
-        first: if a query is in flight it refuses, and the UI stays put.
-        """
-        if self._query_in_flight or not self._daemon_available:
-            return
-        if self._control_fn is not None:
-            self._control_fn("new_session", None)
-            applied = True
-        else:
-            from jarvis import daemon
-            applied = daemon.new_chat_session()
-        if not applied:
-            debug_log("new session rejected: a query is in flight", "chat")
-            return
-        current = self._active_session()
-        current["active"] = False
-        self._session_counter += 1
-        self._sessions.append(
-            {"title": f"Session {self._session_counter}",
-             "messages": [], "active": True}
-        )
-        self._render_transcript([])
-        self._refresh_session_list()
-        self._scroll_to_bottom()
 
     # --- Sending --------------------------------------------------------
 
@@ -514,7 +440,7 @@ class ChatWindow(QMainWindow):
         """
         if self._query_in_flight or not self._daemon_available:
             return
-        messages = self._active_session()["messages"]
+        messages = self._messages
         keep_until = None
         for i, m in enumerate(messages):
             if m.get("kind") == "user" and m.get("user_index") == user_index:
@@ -534,8 +460,8 @@ class ChatWindow(QMainWindow):
                     f"chat rewind rejected for user message {user_index}", "chat"
                 )
                 return
-        self._active_session()["messages"] = messages[:keep_until]
-        self._render_transcript(messages[:keep_until])
+        self._messages = messages[:keep_until]
+        self._render_transcript(self._messages)
 
         # Regenerate: re-submit the same message for a fresh reply. The
         # message is already displayed, so no new echo is added.
@@ -577,6 +503,7 @@ class ChatWindow(QMainWindow):
         )
         self._refresh_status_label()
         self._refresh_send_button()
+        self._refresh_header_status()
 
     # --- Daemon callback slots (run on the main thread via signals) -----
 
@@ -632,7 +559,7 @@ class ChatWindow(QMainWindow):
 
     def _append_user(self, text: str) -> None:
         user_index = 1 + sum(
-            1 for m in self._active_session()["messages"] if m.get("kind") == "user"
+            1 for m in self._messages if m.get("kind") == "user"
         )
         self._append_message("user", text, user_index=user_index)
 
@@ -643,15 +570,18 @@ class ChatWindow(QMainWindow):
         self._append_message("system", text)
 
     def _append_message(self, kind: str, text: str, user_index: Optional[int] = None) -> None:
-        """Add one message row to the transcript and the active session."""
-        self._active_session()["messages"].append(
-            {"kind": kind, "text": text, "user_index": user_index}
+        """Add one message row to the transcript."""
+        self._messages.append(
+            {
+                "kind": kind,
+                "text": text,
+                "user_index": user_index,
+                "time": datetime.now().strftime("%H:%M"),
+            }
         )
         # Append a single row (before the trailing stretch) instead of
         # rebuilding the whole transcript, so long sessions stay O(n).
-        row = self._make_message_row(
-            {"kind": kind, "text": text, "user_index": user_index}
-        )
+        row = self._make_message_row(self._messages[-1])
         self._transcript_layout.insertWidget(
             self._transcript_layout.count() - 1, row
         )
@@ -660,14 +590,14 @@ class ChatWindow(QMainWindow):
     def _render_transcript(self, messages: list) -> None:
         """Rebuild the transcript rows atomically from ``messages``.
 
-        Rebuilding (instead of incrementally appending) keeps rewind,
-        session switch, and new-session truncation trivially correct: the
-        rendered rows always mirror the session's message list.
+        Rebuilding (instead of incrementally appending) keeps rewind
+        truncation trivially correct: the rendered rows always mirror the
+        message list.
         """
         container = QWidget()
         layout = QVBoxLayout(container)
-        layout.setContentsMargins(10, 10, 10, 10)
-        layout.setSpacing(6)
+        layout.setContentsMargins(4, 4, 4, 4)
+        layout.setSpacing(8)
         for m in messages:
             layout.addWidget(self._make_message_row(m))
         layout.addStretch(1)
@@ -686,46 +616,86 @@ class ChatWindow(QMainWindow):
         row_widget = QWidget()
         row = QHBoxLayout(row_widget)
         row.setContentsMargins(0, 0, 0, 0)
-        row.setSpacing(8)
-        if kind == "user":
-            label = QLabel(f"👤 You: {text}")
-        elif kind == "assistant":
-            label = QLabel(f"🤖 Jarvis: {text}")
+        row.setSpacing(6)
+
+        if kind in ("user", "assistant"):
+            # Bubble with a timestamp underneath, aligned to the sender's edge.
+            bubble = QLabel(text)
+            bubble.setObjectName("bubble")
+            bubble.setWordWrap(True)
+            bubble.setTextInteractionFlags(
+                Qt.TextInteractionFlag.TextSelectableByMouse
+            )
+            bubble.setStyleSheet(_BUBBLE_STYLES[kind])
+            bubble.setMaximumWidth(max(280, int(self.width() * 0.72)))
+            column = QVBoxLayout()
+            column.setSpacing(2)
+            column.addWidget(bubble)
+            time_label = QLabel(m.get("time") or "")
+            time_label.setStyleSheet(_TIMESTAMP_STYLE)
+            column.addWidget(
+                time_label,
+                alignment=Qt.AlignmentFlag.AlignRight,
+            )
+            if kind == "user":
+                # SMS puts the sender's messages on the right; the rewind
+                # affordance sits quietly to the left of the bubble.
+                rewind_btn = QPushButton("⟲")
+                rewind_btn.setObjectName(f"rewind_{m.get('user_index')}")
+                rewind_btn.setToolTip("Rewind to this message and regenerate")
+                rewind_btn.setStyleSheet(_REWIND_BTN_STYLE)
+                rewind_btn.setFixedSize(26, 26)
+                rewind_btn.setEnabled(
+                    self._daemon_available and not self._query_in_flight
+                )
+                user_index = m.get("user_index")
+                if user_index is not None:
+                    rewind_btn.clicked.connect(
+                        lambda _checked=False, idx=user_index, txt=text:
+                        self._rewind_to_user(idx, txt)
+                    )
+                row.addWidget(
+                    rewind_btn, alignment=Qt.AlignmentFlag.AlignVCenter
+                )
+                row.addStretch(1)
+                row.addLayout(column)
+            else:
+                row.addLayout(column)
+                row.addStretch(1)
         else:
             label = QLabel(f"  ⏳ {text}")
-        label.setWordWrap(True)
-        label.setTextInteractionFlags(Qt.TextInteractionFlag.TextSelectableByMouse)
-        label.setStyleSheet(_MESSAGE_TEXT_STYLES.get(kind, _MESSAGE_TEXT_STYLES["system"]))
-        row.addWidget(label, stretch=1)
-        if kind == "user":
-            user_index = m.get("user_index")
-            rewind_btn = QPushButton("⟲")
-            rewind_btn.setObjectName(f"rewind_{user_index}")
-            rewind_btn.setToolTip("Rewind to this message and regenerate")
-            rewind_btn.setStyleSheet(_REWIND_BTN_STYLE)
-            rewind_btn.setFixedSize(30, 30)
-            rewind_btn.setEnabled(
-                self._daemon_available and not self._query_in_flight
+            label.setWordWrap(True)
+            label.setTextInteractionFlags(
+                Qt.TextInteractionFlag.TextSelectableByMouse
             )
-            if user_index is not None:
-                rewind_btn.clicked.connect(
-                    lambda _checked=False, idx=user_index, txt=text: self._rewind_to_user(idx, txt)
-                )
-            row.addWidget(rewind_btn, alignment=Qt.AlignmentFlag.AlignTop)
+            label.setStyleSheet(_MESSAGE_TEXT_STYLES["system"])
+            row.addStretch(1)
+            row.addWidget(label)
+            row.addStretch(1)
         return row_widget
+
+    def resizeEvent(self, event) -> None:
+        # Keep bubbles at a phone-like share of the window width, so the
+        # thread reads as SMS whether the window is narrow or maximised.
+        super().resizeEvent(event)
+        if not hasattr(self, "transcript_widget"):
+            return
+        max_w = max(280, int(self.width() * 0.72))
+        for label in self.transcript_widget.findChildren(QLabel):
+            if label.objectName() == "bubble":
+                label.setMaximumWidth(max_w)
 
     def _scroll_to_bottom(self) -> None:
         bar = self.transcript_widget.verticalScrollBar()
         bar.setValue(bar.maximum())
 
     def transcript_text(self) -> str:
-        """Plain-text rendering of the active transcript (testing + copy)."""
-        return "\n".join(
-            f"👤 You: {m['text']}" if m["kind"] == "user"
-            else f"🤖 Jarvis: {m['text']}" if m["kind"] == "assistant"
-            else f"  ⏳ {m['text']}"
-            for m in self._active_session()["messages"]
-        )
+        """Plain-text rendering of the transcript (testing + copy).
+
+        The bubbles carry no role prefixes in the UI — position and colour
+        convey the sender — so the text dump is just the message bodies.
+        """
+        return "\n".join(m["text"] for m in self._messages)
 
     def _set_thinking(self, thinking: bool) -> None:
         self._query_in_flight = thinking and self._daemon_available
@@ -733,6 +703,7 @@ class ChatWindow(QMainWindow):
         self._refresh_status_label()
         self._refresh_send_button()
         self._refresh_rewind_buttons()
+        self._refresh_header_status()
 
     def _refresh_rewind_buttons(self) -> None:
         """Disable rewind while a query is in flight or the daemon is down."""
@@ -762,6 +733,15 @@ class ChatWindow(QMainWindow):
         self._status_label.setText(f"  {message}")
         self._status_label.setVisible(True)
 
+    def _refresh_header_status(self) -> None:
+        """Contact-style presence line, like the header of an SMS thread."""
+        if self._query_in_flight:
+            self._header_status.setText("Typing…")
+            return
+        self._header_status.setText(
+            _HEADER_STATUS_TEXTS.get(self._daemon_status, "Offline")
+        )
+
     # --- Input key handling ---------------------------------------------
 
     def _input_key_press(self, event) -> None:
@@ -782,15 +762,12 @@ class ChatWindow(QMainWindow):
     # --- Lifecycle ------------------------------------------------------
 
     def showEvent(self, event: QShowEvent) -> None:
-        # A fresh app run has no previous session in memory (sessions are
-        # never persisted), so the window always starts with a new session —
-        # "Session 1" is created in __init__. On first show we additionally
-        # seed the transcript from the daemon's hot window, so a user who has
-        # been talking by voice sees their recent turns instead of a blank
-        # panel. Seeding runs only once per instance: re-showing (from the
-        # tray or after a hide) must never duplicate turns. Fails silently
-        # when the daemon accessor is unavailable (e.g. subprocess mode) —
-        # the window just opens with the new session.
+        # On first show we seed the transcript from the daemon's hot window,
+        # so a user who has been talking by voice sees their recent turns
+        # instead of a blank panel. Seeding runs only once per instance:
+        # re-showing (from the tray or after a hide) must never duplicate
+        # turns. Fails silently when the daemon accessor is unavailable
+        # (e.g. subprocess mode) — the window just opens blank.
         if not self._hot_window_seeded:
             self._hot_window_seeded = True
             try:

--- a/src/desktop_app/chat_window.py
+++ b/src/desktop_app/chat_window.py
@@ -385,7 +385,7 @@ class ChatWindow(QMainWindow):
         if index is None or not isinstance(index, int):
             return
         target = self._sessions[index]
-        if target["active"] or self._query_in_flight:
+        if target["active"] or self._query_in_flight or not self._daemon_available:
             return
         # Restore the daemon memory first: if a query is in flight the
         # daemon refuses, and the UI must not switch to a conversation the
@@ -429,7 +429,7 @@ class ChatWindow(QMainWindow):
         in-memory list; nothing is written to disk. The daemon is asked
         first: if a query is in flight it refuses, and the UI stays put.
         """
-        if self._query_in_flight:
+        if self._query_in_flight or not self._daemon_available:
             return
         if self._control_fn is not None:
             self._control_fn("new_session", None)

--- a/src/desktop_app/chat_window.py
+++ b/src/desktop_app/chat_window.py
@@ -8,20 +8,30 @@ and text share one conversation (the daemon's global dialogue memory). See
 The window is created lazily by the system tray and kept alive for the
 session. Daemon callback signals are marshalled onto the Qt main thread via
 ``ChatSignals`` so UI updates never touch the worker thread directly.
+
+Sessions (in-memory only): the chat window keeps a list of past sessions in
+memory — nothing is written to disk. A session maps to the shared voice+text
+conversation: starting a new session clears the daemon's dialogue memory, and
+switching sessions restores an archived conversation into it. Every sent
+message carries a rewind button that rolls the conversation back to that
+message and regenerates a fresh reply.
 """
 
 from __future__ import annotations
 
-from typing import Optional
+from typing import Callable, Optional
 
 from PyQt6.QtCore import Qt, pyqtSignal, QObject
-from PyQt6.QtGui import QCloseEvent, QShowEvent, QTextCursor
+from PyQt6.QtGui import QCloseEvent, QShowEvent
 from PyQt6.QtWidgets import (
     QHBoxLayout,
     QLabel,
+    QListWidget,
+    QListWidgetItem,
     QMainWindow,
     QPlainTextEdit,
     QPushButton,
+    QScrollArea,
     QVBoxLayout,
     QWidget,
 )
@@ -77,16 +87,11 @@ class ChatIpcSignals(QObject):
 # Window
 # ---------------------------------------------------------------------------
 
-
-_TRANSCRIPT_STYLE = f"""
-    QPlainTextEdit {{
-        background-color: {COLORS['bg_secondary']};
-        color: {COLORS['text_primary']};
+_TRANSCRIPT_AREA_STYLE = f"""
+    QScrollArea {{
         border: 1px solid {COLORS['border']};
         border-radius: 8px;
-        padding: 10px;
-        font-family: '.AppleSystemUIFont', 'Segoe UI', sans-serif;
-        font-size: 14px;
+        background-color: {COLORS['bg_secondary']};
     }}
 """
 
@@ -139,11 +144,49 @@ _STOP_BTN_STYLE = f"""
     }}
 """
 
+_REWIND_BTN_STYLE = f"""
+    QPushButton {{
+        background-color: {COLORS['bg_tertiary']};
+        color: {COLORS['text_secondary']};
+        border: 1px solid {COLORS['border']};
+        border-radius: 6px;
+        font-size: 13px;
+        padding: 2px;
+    }}
+    QPushButton:hover {{
+        border-color: {COLORS['accent_primary']};
+        color: {COLORS['accent_secondary']};
+    }}
+    QPushButton:disabled {{
+        color: {COLORS['text_muted']};
+        border-color: {COLORS['border']};
+    }}
+"""
+
 _STATUS_STYLE = f"""
     QLabel {{
         color: {COLORS['text_secondary']};
         font-size: 12px;
         padding: 2px 4px;
+    }}
+"""
+
+_SESSION_SIDEBAR_STYLE = f"""
+    QListWidget {{
+        background-color: {COLORS['bg_tertiary']};
+        border: 1px solid {COLORS['border']};
+        border-radius: 8px;
+        color: {COLORS['text_secondary']};
+        font-size: 13px;
+        padding: 4px;
+    }}
+    QListWidget::item {{
+        padding: 6px 8px;
+        border-radius: 6px;
+    }}
+    QListWidget::item:selected {{
+        background-color: {COLORS['bg_hover']};
+        color: {COLORS['accent_secondary']};
     }}
 """
 
@@ -162,35 +205,65 @@ _DAEMON_STATUS_PLACEHOLDERS = {
     "running": "Type a message to Jarvis... (Enter to send, Shift+Enter for newline)",
 }
 
+_MESSAGE_TEXT_STYLES = {
+    "user": f"color: {COLORS['accent_secondary']};",
+    "assistant": f"color: {COLORS['text_primary']};",
+    "system": f"color: {COLORS['text_muted']}; font-size: 12px;",
+}
+
 
 class ChatWindow(QMainWindow):
     """Text chat window. Sends via ``jarvis.daemon.submit_text_query``.
 
     In subprocess mode the desktop app sets ``submit_fn`` to a callable that
-    writes a ``__CHAT_QUERY__:`` line to the daemon's stdin, and feeds
-    ``__CHAT__:`` events back into the window's signals. In bundled mode the
-    default path calls the daemon directly with the window's signal emitters
-    as callbacks.
+    writes a ``__CHAT_QUERY__:`` line to the daemon's stdin, ``cancel_fn`` to
+    the cancel line writer, and ``control_fn`` to a callable that writes the
+    session-control lines (new session / rewind / restore). In bundled mode
+    the window calls the daemon directly.
+
+    Sessions: an in-memory list of past conversations (never persisted).
+    The active session maps 1:1 to the daemon's shared dialogue memory, so
+    starting a new session or switching to an archived one rewires the
+    conversation the voice path also sees. Every sent message carries a
+    rewind button that truncates the conversation to before that message
+    and regenerates a fresh reply to it.
     """
 
     def __init__(
-        self, submit_fn=None, daemon_available: bool = True, cancel_fn=None,
+        self,
+        submit_fn=None,
+        daemon_available: bool = True,
+        cancel_fn=None,
+        control_fn: Optional[Callable[[str, Optional[dict]], None]] = None,
     ) -> None:
         super().__init__()
         self.setWindowTitle("Jarvis Chat")
-        self.setMinimumSize(520, 560)
+        self.setMinimumSize(760, 560)
         self.setStyleSheet(JARVIS_THEME_STYLESHEET)
         self._submit_fn = submit_fn
         # Subprocess mode routes cancellation to the daemon the same way it
         # routes a submission. Without it, Stop sets a flag in this
         # process while the query runs in the other one.
         self._cancel_fn = cancel_fn
+        # Subprocess mode routes session control (new session / rewind /
+        # restore) to the daemon's stdin. Bundled mode calls the daemon
+        # module directly and leaves this None.
+        self._control_fn = control_fn
         # Set by Stop, cleared by the next send. The engine keeps running
         # after a cancel and its reply still arrives, so the window has to
         # decline the answer to an exchange the user walked away from.
         self._query_cancelled = False
         self._daemon_available = daemon_available
         self._daemon_status = "running" if daemon_available else "stopped"
+
+        # In-memory session store. Each session is
+        # {"title": str, "messages": [{"kind", "text", "user_index"}], "active": bool}.
+        # Nothing here is written to disk; a fresh app run starts with a new
+        # session (there is no "last chat session" to restore).
+        self._sessions: list[dict] = [
+            {"title": "Session 1", "messages": [], "active": True}
+        ]
+        self._session_counter = 1
 
         # Signal bridge: daemon worker -> Qt main thread.
         self.signals = ChatSignals()
@@ -201,21 +274,56 @@ class ChatWindow(QMainWindow):
         # --- Layout -----------------------------------------------------
         central = QWidget()
         self.setCentralWidget(central)
-        layout = QVBoxLayout(central)
-        layout.setContentsMargins(12, 12, 12, 12)
-        layout.setSpacing(8)
+        root = QHBoxLayout(central)
+        root.setContentsMargins(12, 12, 12, 12)
+        root.setSpacing(10)
 
-        # Transcript (read-only)
-        self.transcript_widget = QPlainTextEdit()
-        self.transcript_widget.setReadOnly(True)
-        self.transcript_widget.setStyleSheet(_TRANSCRIPT_STYLE)
-        layout.addWidget(self.transcript_widget, stretch=1)
+        # Sessions sidebar (in-memory list + new session button)
+        sidebar = QVBoxLayout()
+        sidebar.setSpacing(8)
+        sidebar_label = QLabel("Sessions")
+        sidebar_label.setStyleSheet(
+            f"color: {COLORS['text_secondary']}; font-size: 12px;"
+            " font-weight: 600;"
+        )
+        sidebar.addWidget(sidebar_label)
+        self.session_list = QListWidget()
+        self.session_list.setStyleSheet(_SESSION_SIDEBAR_STYLE)
+        self.session_list.setFixedWidth(170)
+        self.session_list.itemClicked.connect(self._on_session_clicked)
+        sidebar.addWidget(self.session_list, stretch=1)
+        self.new_session_button = QPushButton("＋ New session")
+        self.new_session_button.setStyleSheet(_SEND_BTN_STYLE)
+        self.new_session_button.clicked.connect(self._new_session)
+        sidebar.addWidget(self.new_session_button)
+        root.addLayout(sidebar)
+
+        # Right column: transcript + status + input row
+        right = QVBoxLayout()
+        right.setSpacing(8)
+
+        # Transcript: a scroll area whose container holds one row widget per
+        # message, so sent messages can carry a rewind button. Rebuilt
+        # atomically on session switch / rewind (see _render_transcript).
+        self.transcript_widget = QScrollArea()
+        self.transcript_widget.setWidgetResizable(True)
+        self.transcript_widget.setHorizontalScrollBarPolicy(
+            Qt.ScrollBarPolicy.ScrollBarAlwaysOff
+        )
+        self.transcript_widget.setStyleSheet(_TRANSCRIPT_AREA_STYLE)
+        self._transcript_container = QWidget()
+        self._transcript_layout = QVBoxLayout(self._transcript_container)
+        self._transcript_layout.setContentsMargins(10, 10, 10, 10)
+        self._transcript_layout.setSpacing(6)
+        self._transcript_layout.addStretch(1)
+        self.transcript_widget.setWidget(self._transcript_container)
+        right.addWidget(self.transcript_widget, stretch=1)
 
         # Status indicator (display-only label)
         self._status_label = QLabel("")
         self._status_label.setStyleSheet(_STATUS_STYLE)
         self._status_label.setVisible(False)
-        layout.addWidget(self._status_label)
+        right.addWidget(self._status_label)
 
         # Input row: input box + send + stop
         row = QHBoxLayout()
@@ -239,13 +347,109 @@ class ChatWindow(QMainWindow):
         self.stop_button.setVisible(False)
         row.addWidget(self.stop_button)
 
-        layout.addLayout(row)
+        right.addLayout(row)
+        root.addLayout(right, stretch=1)
 
         self._query_in_flight = False
         # Whether the transcript has been seeded from the daemon's hot window.
         # Seeded once on first show so re-opening never duplicates turns.
         self._hot_window_seeded = False
+        self._refresh_session_list()
         self.set_daemon_available(daemon_available)
+
+    # --- Sessions -------------------------------------------------------
+
+    def _active_session(self) -> dict:
+        return next(s for s in self._sessions if s["active"])
+
+    def _refresh_session_list(self) -> None:
+        """Rebuild the sidebar from the in-memory session store."""
+        self.session_list.clear()
+        for index, session in enumerate(self._sessions):
+            title = session["title"]
+            if session["active"]:
+                title = f"● {title}"
+            item = QListWidgetItem(title)
+            # Store the index, not the dict: PyQt6 marshals plain dicts
+            # through QVariant on setData/data, returning a copy on read,
+            # so mutating the returned object would not touch the session.
+            item.setData(Qt.ItemDataRole.UserRole, index)
+            self.session_list.addItem(item)
+            if session["active"]:
+                self.session_list.setCurrentItem(item)
+
+    def _on_session_clicked(self, item: QListWidgetItem) -> None:
+        """Switch to a past session: archive the live one, restore the
+        clicked one into the shared daemon memory, re-render its transcript."""
+        index = item.data(Qt.ItemDataRole.UserRole)
+        if index is None or not isinstance(index, int):
+            return
+        target = self._sessions[index]
+        if target["active"] or self._query_in_flight:
+            return
+        # Restore the daemon memory first: if a query is in flight the
+        # daemon refuses, and the UI must not switch to a conversation the
+        # memory does not hold.
+        if not self._restore_session_memory(target):
+            debug_log("session switch rejected: a query is in flight", "chat")
+            return
+        current = self._active_session()
+        current["active"] = False
+        target["active"] = True
+        self._render_transcript(target["messages"])
+        self._refresh_session_list()
+        self._scroll_to_bottom()
+
+    def _restore_session_memory(self, session: dict) -> bool:
+        """Push an archived session's turns into the shared daemon memory.
+
+        Only user/assistant turns are restored (system notices are local
+        UI text). The daemon re-redacts everything on restore, so the
+        diary never sees raw user text even though the window's archive
+        holds it. Returns False when the daemon refused (query in flight).
+        In subprocess mode the control line is fire-and-forget: the daemon
+        enforces its own lock guard, and the window is optimistic.
+        """
+        turns = [
+            {"role": m["kind"], "content": m["text"]}
+            for m in session["messages"]
+            if m["kind"] in ("user", "assistant")
+        ]
+        if self._control_fn is not None:
+            self._control_fn("restore", {"messages": turns})
+            return True
+        from jarvis import daemon
+        return daemon.set_chat_messages(turns)
+
+    def _new_session(self) -> None:
+        """Archive the current session and start a fresh one.
+
+        The shared dialogue memory is cleared, so the voice path also
+        starts a new conversation. The previous session stays in the
+        in-memory list; nothing is written to disk. The daemon is asked
+        first: if a query is in flight it refuses, and the UI stays put.
+        """
+        if self._query_in_flight:
+            return
+        if self._control_fn is not None:
+            self._control_fn("new_session", None)
+            applied = True
+        else:
+            from jarvis import daemon
+            applied = daemon.new_chat_session()
+        if not applied:
+            debug_log("new session rejected: a query is in flight", "chat")
+            return
+        current = self._active_session()
+        current["active"] = False
+        self._session_counter += 1
+        self._sessions.append(
+            {"title": f"Session {self._session_counter}",
+             "messages": [], "active": True}
+        )
+        self._render_transcript([])
+        self._refresh_session_list()
+        self._scroll_to_bottom()
 
     # --- Sending --------------------------------------------------------
 
@@ -298,6 +502,56 @@ class ChatWindow(QMainWindow):
         # Reset the thinking indicator immediately so the user sees
         # feedback without waiting for the engine to finish.
         self._set_thinking(False)
+
+    def _rewind_to_user(self, user_index: int, text: str) -> None:
+        """Roll the conversation back to before ``user_index``-th user
+        message and regenerate a fresh reply to it.
+
+        The transcript is truncated to keep the message itself; the daemon
+        memory is rewound past it and the same text is re-submitted, so the
+        old reply (and everything after it) is replaced. Rewinding is
+        disabled while a query is in flight.
+        """
+        if self._query_in_flight or not self._daemon_available:
+            return
+        messages = self._active_session()["messages"]
+        keep_until = None
+        for i, m in enumerate(messages):
+            if m.get("kind") == "user" and m.get("user_index") == user_index:
+                keep_until = i + 1
+                break
+        if keep_until is None:
+            return
+        # Ask the daemon first. Bundled mode: a refusal (query in flight)
+        # leaves both transcript and memory untouched. Subprocess mode is
+        # fire-and-forget; the daemon enforces its own lock guard.
+        if self._control_fn is not None:
+            self._control_fn("rewind", {"user_index": user_index})
+        else:
+            from jarvis import daemon
+            if not daemon.rewind_chat_to_user(user_index):
+                debug_log(
+                    f"chat rewind rejected for user message {user_index}", "chat"
+                )
+                return
+        self._active_session()["messages"] = messages[:keep_until]
+        self._render_transcript(messages[:keep_until])
+
+        # Regenerate: re-submit the same message for a fresh reply. The
+        # message is already displayed, so no new echo is added.
+        self._query_cancelled = False
+        self._set_thinking(True)
+        if self._submit_fn is not None:
+            self._submit_fn(text)
+        else:
+            from jarvis import daemon
+
+            daemon.submit_text_query(
+                text,
+                on_start=self.signals.started.emit,
+                on_complete=self.signals.completed.emit,
+                on_busy=self.signals.busy.emit,
+            )
 
     def set_daemon_available(self, available: bool) -> None:
         """Enable or disable chat submission based on daemon availability."""
@@ -377,27 +631,115 @@ class ChatWindow(QMainWindow):
     # --- Rendering helpers ----------------------------------------------
 
     def _append_user(self, text: str) -> None:
-        self._append_line(f"👤 You: {text}")
+        user_index = 1 + sum(
+            1 for m in self._active_session()["messages"] if m.get("kind") == "user"
+        )
+        self._append_message("user", text, user_index=user_index)
 
     def _append_assistant(self, text: str) -> None:
-        self._append_line(f"🤖 Jarvis: {text}")
+        self._append_message("assistant", text)
 
     def _append_system(self, text: str) -> None:
-        self._append_line(f"  ⏳ {text}")
+        self._append_message("system", text)
 
-    def _append_line(self, line: str) -> None:
-        cursor = self.transcript_widget.textCursor()
-        cursor.movePosition(QTextCursor.MoveOperation.End)
-        if self.transcript_widget.toPlainText():
-            cursor.insertText("\n")
-        cursor.insertText(line)
-        self.transcript_widget.setTextCursor(cursor)
+    def _append_message(self, kind: str, text: str, user_index: Optional[int] = None) -> None:
+        """Add one message row to the transcript and the active session."""
+        self._active_session()["messages"].append(
+            {"kind": kind, "text": text, "user_index": user_index}
+        )
+        # Append a single row (before the trailing stretch) instead of
+        # rebuilding the whole transcript, so long sessions stay O(n).
+        row = self._make_message_row(
+            {"kind": kind, "text": text, "user_index": user_index}
+        )
+        self._transcript_layout.insertWidget(
+            self._transcript_layout.count() - 1, row
+        )
+        self._scroll_to_bottom()
+
+    def _render_transcript(self, messages: list) -> None:
+        """Rebuild the transcript rows atomically from ``messages``.
+
+        Rebuilding (instead of incrementally appending) keeps rewind,
+        session switch, and new-session truncation trivially correct: the
+        rendered rows always mirror the session's message list.
+        """
+        container = QWidget()
+        layout = QVBoxLayout(container)
+        layout.setContentsMargins(10, 10, 10, 10)
+        layout.setSpacing(6)
+        for m in messages:
+            layout.addWidget(self._make_message_row(m))
+        layout.addStretch(1)
+        old = self.transcript_widget.takeWidget()
+        self.transcript_widget.setWidget(container)
+        self._transcript_container = container
+        self._transcript_layout = layout
+        if old is not None:
+            old.hide()
+            old.deleteLater()
+        self._scroll_to_bottom()
+
+    def _make_message_row(self, m: dict) -> QWidget:
+        kind = m.get("kind", "system")
+        text = m.get("text", "")
+        row_widget = QWidget()
+        row = QHBoxLayout(row_widget)
+        row.setContentsMargins(0, 0, 0, 0)
+        row.setSpacing(8)
+        if kind == "user":
+            label = QLabel(f"👤 You: {text}")
+        elif kind == "assistant":
+            label = QLabel(f"🤖 Jarvis: {text}")
+        else:
+            label = QLabel(f"  ⏳ {text}")
+        label.setWordWrap(True)
+        label.setTextInteractionFlags(Qt.TextInteractionFlag.TextSelectableByMouse)
+        label.setStyleSheet(_MESSAGE_TEXT_STYLES.get(kind, _MESSAGE_TEXT_STYLES["system"]))
+        row.addWidget(label, stretch=1)
+        if kind == "user":
+            user_index = m.get("user_index")
+            rewind_btn = QPushButton("⟲")
+            rewind_btn.setObjectName(f"rewind_{user_index}")
+            rewind_btn.setToolTip("Rewind to this message and regenerate")
+            rewind_btn.setStyleSheet(_REWIND_BTN_STYLE)
+            rewind_btn.setFixedSize(30, 30)
+            rewind_btn.setEnabled(
+                self._daemon_available and not self._query_in_flight
+            )
+            if user_index is not None:
+                rewind_btn.clicked.connect(
+                    lambda _checked=False, idx=user_index, txt=text: self._rewind_to_user(idx, txt)
+                )
+            row.addWidget(rewind_btn, alignment=Qt.AlignmentFlag.AlignTop)
+        return row_widget
+
+    def _scroll_to_bottom(self) -> None:
+        bar = self.transcript_widget.verticalScrollBar()
+        bar.setValue(bar.maximum())
+
+    def transcript_text(self) -> str:
+        """Plain-text rendering of the active transcript (testing + copy)."""
+        return "\n".join(
+            f"👤 You: {m['text']}" if m["kind"] == "user"
+            else f"🤖 Jarvis: {m['text']}" if m["kind"] == "assistant"
+            else f"  ⏳ {m['text']}"
+            for m in self._active_session()["messages"]
+        )
 
     def _set_thinking(self, thinking: bool) -> None:
         self._query_in_flight = thinking and self._daemon_available
         self.stop_button.setVisible(self._query_in_flight)
         self._refresh_status_label()
         self._refresh_send_button()
+        self._refresh_rewind_buttons()
+
+    def _refresh_rewind_buttons(self) -> None:
+        """Disable rewind while a query is in flight or the daemon is down."""
+        enabled = self._daemon_available and not self._query_in_flight
+        for btn in self.transcript_widget.findChildren(QPushButton):
+            if btn.objectName().startswith("rewind_"):
+                btn.setEnabled(enabled)
 
     def _refresh_send_button(self) -> None:
         self.send_button.setEnabled(self._daemon_available and not self._query_in_flight)
@@ -440,12 +782,15 @@ class ChatWindow(QMainWindow):
     # --- Lifecycle ------------------------------------------------------
 
     def showEvent(self, event: QShowEvent) -> None:
-        # Seed the transcript from the daemon's hot window once, on first show,
-        # so a user who has been talking by voice sees their recent turns
-        # instead of a blank panel. Runs only once per instance: re-showing
-        # (from the tray or after a hide) must never duplicate turns. Fails
-        # silently when the daemon accessor is unavailable (e.g. subprocess
-        # mode before the bridge is wired) — the window just opens blank.
+        # A fresh app run has no previous session in memory (sessions are
+        # never persisted), so the window always starts with a new session —
+        # "Session 1" is created in __init__. On first show we additionally
+        # seed the transcript from the daemon's hot window, so a user who has
+        # been talking by voice sees their recent turns instead of a blank
+        # panel. Seeding runs only once per instance: re-showing (from the
+        # tray or after a hide) must never duplicate turns. Fails silently
+        # when the daemon accessor is unavailable (e.g. subprocess mode) —
+        # the window just opens with the new session.
         if not self._hot_window_seeded:
             self._hot_window_seeded = True
             try:

--- a/src/desktop_app/chat_window.spec.md
+++ b/src/desktop_app/chat_window.spec.md
@@ -132,6 +132,21 @@ for the same reason: the query runs in this process, so the flag has to be set
 in it. Lines that don't match any prefix are ignored (the monitor still treats
 bare ``SHUTDOWN`` and EOF as shutdown signals, unchanged).
 
+Session control travels the same pipe (the conversation lives in the daemon's
+memory, which the desktop process cannot touch in subprocess mode):
+
+```json
+__CHAT_NEW_SESSION__                     // clear the shared dialogue memory
+__CHAT_REWIND__:{"user_index": 2}        // roll memory back to before user turn #2
+__CHAT_RESTORE__:{"messages": [{"role": "user", "content": "..."}, ...]}
+```
+
+`user_index` is 1-based (the first user message is 1); the rewound message
+itself is dropped so a re-submission does not duplicate it. Malformed
+session-control lines are swallowed (consumed, ignored), mirroring
+`__CHAT_QUERY__:` handling. Restores are re-redacted daemon-side so the diary
+never sees raw user text, even though the window's in-memory archive holds it.
+
 Chat IPC lines are routed to the chat window and then **not** emitted to the
 general log viewer. The ``complete`` event carries the whole assistant reply,
 which can echo back whatever the user typed, and the log window is outside the
@@ -144,8 +159,12 @@ viewer, which is what it is for.
 
 A `QMainWindow` with:
 
-- A read-only transcript area (chat bubbles or monospaced log style; theme
-  colours from `themes.py`).
+- A sessions sidebar (in-memory list, see **Sessions** below) and a
+  `＋ New session` button.
+- A read-only transcript area: a scrollable stack of message rows (theme
+  colours from `themes.py`). Sent messages additionally carry a `⟲` rewind
+  button (see **Rewind** below). The transcript mirrors the active session's
+  message list and is rebuilt atomically on new-session / switch / rewind.
 - A multi-line input box with send button. Enter sends; Shift+Enter inserts a
   newline (multi-line input).
 - A "Stop" button. It marks the exchange abandoned locally, routes the
@@ -157,6 +176,45 @@ A `QMainWindow` with:
   running. When the daemon is starting, stopping, stopped, or has exited
   unexpectedly, the same area stays visible as a local lifecycle banner and
   explains whether the user should wait or start listening again.
+
+### Sessions (in-memory only)
+
+A session is the shared voice+text conversation: the daemon's single dialogue
+memory. The window keeps a list of past sessions **in memory only** — nothing
+is written to disk, so a fresh app run starts with a new session (there is no
+"last chat session" to restore).
+
+- **New session** archives the current transcript into the sidebar and clears
+  the shared dialogue memory (`daemon.new_chat_session()`, or the
+  `__CHAT_NEW_SESSION__` line in subprocess mode). The voice path also starts
+  fresh: voice and text share one conversation, so a new session resets both.
+- **Switching** to an archived session restores its turns into the shared
+  memory (`daemon.set_chat_messages`, or `__CHAT_RESTORE__:`) and re-renders
+  its transcript. Restores are re-redacted daemon-side.
+- **Automatic new session**: the window always starts with an active
+  "Session 1". When the daemon memory holds a voice conversation (bundled
+  mode), the first session is seeded from the hot window on first show and
+  the voice context carries into chat, unchanged from the base contract.
+
+### Rewind
+
+Every sent message carries a `⟲` button. Clicking it:
+
+1. Truncates the window's transcript to keep the message itself (its old
+   reply and everything after it are dropped).
+2. Rolls the shared daemon memory back to before that user turn
+   (`daemon.rewind_chat_to_user(user_index)`, or `__CHAT_REWIND__:`
+   subprocess line). The rewound message itself is dropped so the
+   regeneration does not duplicate it. Hot-window caches and tool carryover
+   are cleared with it.
+3. Re-submits the same message text, so the agent generates a fresh reply
+   that lands through the normal `complete` path.
+
+Rewind is disabled while a query is in flight and when the daemon is not
+running. Rewinding rolls back the voice context too (same shared memory), and
+the message-ordinal anchor assumes the transcript and the memory hold the
+same user turns — which holds in bundled mode and in subprocess mode when the
+window's transcript was not seeded from invisible voice turns.
 
 ### Tray integration
 

--- a/src/desktop_app/chat_window.spec.md
+++ b/src/desktop_app/chat_window.spec.md
@@ -132,20 +132,17 @@ for the same reason: the query runs in this process, so the flag has to be set
 in it. Lines that don't match any prefix are ignored (the monitor still treats
 bare ``SHUTDOWN`` and EOF as shutdown signals, unchanged).
 
-Session control travels the same pipe (the conversation lives in the daemon's
-memory, which the desktop process cannot touch in subprocess mode):
+Rewind travels the same pipe (the conversation lives in the daemon's memory,
+which the desktop process cannot touch in subprocess mode):
 
 ```json
-__CHAT_NEW_SESSION__                     // clear the shared dialogue memory
 __CHAT_REWIND__:{"user_index": 2}        // roll memory back to before user turn #2
-__CHAT_RESTORE__:{"messages": [{"role": "user", "content": "..."}, ...]}
 ```
 
 `user_index` is 1-based (the first user message is 1); the rewound message
 itself is dropped so a re-submission does not duplicate it. Malformed
-session-control lines are swallowed (consumed, ignored), mirroring
-`__CHAT_QUERY__:` handling. Restores are re-redacted daemon-side so the diary
-never sees raw user text, even though the window's in-memory archive holds it.
+rewind lines are swallowed (consumed, ignored), mirroring
+`__CHAT_QUERY__:` handling.
 
 Chat IPC lines are routed to the chat window and then **not** emitted to the
 general log viewer. The ``complete`` event carries the whole assistant reply,
@@ -157,14 +154,17 @@ viewer, which is what it is for.
 
 ### `ChatWindow` (in `desktop_app.chat_window`)
 
-A `QMainWindow` with:
+A `QMainWindow` styled like an SMS thread with a single contact:
 
-- A sessions sidebar (in-memory list, see **Sessions** below) and a
-  `＋ New session` button.
-- A read-only transcript area: a scrollable stack of message rows (theme
-  colours from `themes.py`). Sent messages additionally carry a `⟲` rewind
-  button (see **Rewind** below). The transcript mirrors the active session's
-  message list and is rebuilt atomically on new-session / switch / rewind.
+- A contact header (avatar, "Jarvis", and a presence line such as "Online" or
+  "Typing…" while a query is in flight).
+- A read-only transcript area: a scrollable stack of speech bubbles (theme
+  colours from `themes.py`). The user's messages are right-aligned accent
+  bubbles, Jarvis's replies are left-aligned dark bubbles, and local notices
+  are small centred lines. Each bubble carries a small muted timestamp. Sent
+  messages additionally carry a subtle `⟲` rewind button (see **Rewind**
+  below) to the left of the bubble. The transcript mirrors the single
+  conversation's message list and is rebuilt atomically on rewind.
 - A multi-line input box with send button. Enter sends; Shift+Enter inserts a
   newline (multi-line input).
 - A "Stop" button. It marks the exchange abandoned locally, routes the
@@ -177,28 +177,18 @@ A `QMainWindow` with:
   unexpectedly, the same area stays visible as a local lifecycle banner and
   explains whether the user should wait or start listening again.
 
-### Sessions (in-memory only)
+### One conversation, like an SMS contact
 
-A session is the shared voice+text conversation: the daemon's single dialogue
-memory. The window keeps a list of past sessions **in memory only** — nothing
-is written to disk, so a fresh app run starts with a new session (there is no
-"last chat session" to restore).
-
-- **New session** archives the current transcript into the sidebar and clears
-  the shared dialogue memory (`daemon.new_chat_session()`, or the
-  `__CHAT_NEW_SESSION__` line in subprocess mode). The voice path also starts
-  fresh: voice and text share one conversation, so a new session resets both.
-- **Switching** to an archived session restores its turns into the shared
-  memory (`daemon.set_chat_messages`, or `__CHAT_RESTORE__:`) and re-renders
-  its transcript. Restores are re-redacted daemon-side.
-- **Automatic new session**: the window always starts with an active
-  "Session 1". When the daemon memory holds a voice conversation (bundled
-  mode), the first session is seeded from the hot window on first show and
-  the voice context carries into chat, unchanged from the base contract.
+There is exactly one chat: the daemon's single dialogue memory, displayed as a
+text-message thread. There is no session list, no "new session" button, and
+nothing is written to disk, so a fresh app run starts blank (the transcript is
+in-memory and authoritative for the session thereafter; the daemon's hot
+window seeds recent voice turns on first show).
 
 ### Rewind
 
-Every sent message carries a `⟲` button. Clicking it:
+Every sent message carries a subtle `⟲` button to the left of its bubble.
+Clicking it:
 
 1. Truncates the window's transcript to keep the message itself (its old
    reply and everything after it are dropped).
@@ -218,7 +208,7 @@ window's transcript was not seeded from invisible voice turns.
 
 ### Tray integration
 
-A `💬 Chat...` entry is added to the tray menu, below the existing
+A `💬 Chat` entry is added to the tray menu, below the existing
 face/logs/memory entries. Clicking it shows (or raises) the `ChatWindow`. The
 window is created lazily on first open and kept alive for the session
 (same lifecycle as `DictationHistoryWindow`).
@@ -283,3 +273,5 @@ the app.
   judge, no echo detection, no wake word. The user typing is the intent.
 - **No TTS.** Text chat is silent. If the user wants spoken replies, they use
   the voice path.
+- **No chat sessions.** The window shows one continuous conversation with the
+  daemon's shared memory; there is no new-session / session-switching UI.

--- a/src/desktop_app/desktop_app.spec.md
+++ b/src/desktop_app/desktop_app.spec.md
@@ -91,7 +91,6 @@ The central controller that manages:
 - **Window management** (log viewer, memory viewer, face window)
 - **Update checking** on startup and on-demand
 - **Runtime diagnostics** (`🩺 Runtime Status`): shows whether the assistant is listening, the daemon mode/PID, whether Low Power Mode is active, whether Ollama is needed/running, whether Jarvis owns the current Ollama runtime, active chat/embedding models, and configured MCP server count. The dialog is informational and never starts or stops services.
-- **Fast stop** (`⚡ Stop Now (Skip Diary)`): available only while the daemon is running. It stops the voice daemon without the final shutdown diary LLM pass so local model resources are released quickly. Normal `⏸️ Stop Listening` still performs the shutdown diary save.
 
 ### Windows
 
@@ -191,7 +190,6 @@ The desktop app registers callbacks with the daemon for:
 
 - **Diary updates**: Shows DiaryUpdateDialog when session ends
 - **Clean shutdown**: Ensures graceful exit with diary save
-- **Fast shutdown**: Calls `request_stop(skip_diary_update=True)` in bundled mode, or sends `SHUTDOWN_SKIP_DIARY` over daemon stdin in subprocess mode. This skips only the final forced diary update; dictation, voice, TTS, MCP runtime, and database cleanup still run.
 
 #### Bundled Mode (QThread)
 
@@ -205,7 +203,7 @@ In bundled mode, the daemon runs in the same process, so callbacks can be set di
 
 In subprocess mode, the daemon runs as a separate process. IPC is achieved via stdout:
 - **Diary updates**: Daemon emits JSON events prefixed with `__DIARY__:` (e.g., `__DIARY__:{"type":"token","data":"Hello"}`)
-- **Chat events**: Daemon emits `__CHAT__:` events (start/complete/busy); the desktop app sends queries in via `__CHAT_QUERY__:` lines on the daemon's stdin, cancellation via a bare `__CHAT_CANCEL__` line, and session control (new session / rewind / restore) via `__CHAT_NEW_SESSION__`, `__CHAT_REWIND__:` and `__CHAT_RESTORE__:` lines (see `chat_window.spec.md`)
+- **Chat events**: Daemon emits `__CHAT__:` events (start/complete/busy); the desktop app sends queries in via `__CHAT_QUERY__:` lines on the daemon's stdin, cancellation via a bare `__CHAT_CANCEL__` line, and rewind via `__CHAT_REWIND__:` lines (see `chat_window.spec.md`)
 - Desktop app intercepts these lines from the log stream
 - DiaryUpdateDialog's `process_log_line()` parses and emits signals
 - Chat IPC lines are marshalled onto the Qt main thread via `ChatIpcSignals`, then `_on_chat_ipc_line()` forwards them to `ChatWindow.process_ipc_line()`

--- a/src/desktop_app/desktop_app.spec.md
+++ b/src/desktop_app/desktop_app.spec.md
@@ -205,7 +205,7 @@ In bundled mode, the daemon runs in the same process, so callbacks can be set di
 
 In subprocess mode, the daemon runs as a separate process. IPC is achieved via stdout:
 - **Diary updates**: Daemon emits JSON events prefixed with `__DIARY__:` (e.g., `__DIARY__:{"type":"token","data":"Hello"}`)
-- **Chat events**: Daemon emits `__CHAT__:` events (start/complete/busy); the desktop app sends queries in via `__CHAT_QUERY__:` lines on the daemon's stdin (see `chat_window.spec.md`)
+- **Chat events**: Daemon emits `__CHAT__:` events (start/complete/busy); the desktop app sends queries in via `__CHAT_QUERY__:` lines on the daemon's stdin, cancellation via a bare `__CHAT_CANCEL__` line, and session control (new session / rewind / restore) via `__CHAT_NEW_SESSION__`, `__CHAT_REWIND__:` and `__CHAT_RESTORE__:` lines (see `chat_window.spec.md`)
 - Desktop app intercepts these lines from the log stream
 - DiaryUpdateDialog's `process_log_line()` parses and emits signals
 - Chat IPC lines are marshalled onto the Qt main thread via `ChatIpcSignals`, then `_on_chat_ipc_line()` forwards them to `ChatWindow.process_ipc_line()`

--- a/src/jarvis/daemon.py
+++ b/src/jarvis/daemon.py
@@ -50,7 +50,6 @@ from .utils.location import get_location_context, is_location_available
 # Global instances for coordination between modules
 _global_dialogue_memory: Optional[DialogueMemory] = None
 _global_stop_requested: bool = False
-_global_skip_shutdown_diary_update: bool = False
 _warm_profile_graph_listener = None  # registered callback, kept for shutdown unregister
 _global_tts_engine = None  # TTS engine reference for face animation polling
 _global_dictation_engine = None  # Dictation engine reference for history UI
@@ -100,25 +99,10 @@ CHAT_CANCEL_IPC_PREFIX = "__CHAT_CANCEL__"
 CHAT_NEW_SESSION_IPC_PREFIX = "__CHAT_NEW_SESSION__"
 CHAT_REWIND_IPC_PREFIX = "__CHAT_REWIND__:"
 CHAT_RESTORE_IPC_PREFIX = "__CHAT_RESTORE__:"
-SHUTDOWN_SKIP_DIARY_COMMAND = "SHUTDOWN_SKIP_DIARY"
-
-
-def request_stop(skip_diary_update: bool = False) -> None:
-    """Request the daemon to stop gracefully.
-
-    ``skip_diary_update`` is reserved for explicit fast-stop UI paths where
-    freeing local model resources is more important than the final shutdown
-    diary pass. The normal stop path keeps diary saving enabled.
-    """
-    global _global_stop_requested, _global_skip_shutdown_diary_update
+def request_stop() -> None:
+    """Request the daemon to stop gracefully."""
+    global _global_stop_requested
     _global_stop_requested = True
-    if skip_diary_update:
-        _global_skip_shutdown_diary_update = True
-
-
-def is_shutdown_diary_update_skipped() -> bool:
-    """Check whether shutdown should skip the final diary update."""
-    return _global_skip_shutdown_diary_update
 
 
 def set_diary_update_callbacks(
@@ -762,11 +746,9 @@ def main(smoke_test: bool = False) -> None:
     """
     global _global_dialogue_memory, _global_stop_requested, _global_tts_engine, _global_dictation_engine
     global _warm_profile_graph_listener
-    global _global_skip_shutdown_diary_update
 
     # Reset stop flag at start (in case of restart)
     _global_stop_requested = False
-    _global_skip_shutdown_diary_update = False
 
     _install_signal_handlers()
 
@@ -1078,10 +1060,6 @@ def main(smoke_test: bool = False) -> None:
                     request_stop()
                     break
                 stripped = line.strip()
-                if stripped == SHUTDOWN_SKIP_DIARY_COMMAND:
-                    debug_log("fast shutdown command received, skipping diary update", "jarvis")
-                    request_stop(skip_diary_update=True)
-                    break
                 if stripped == "SHUTDOWN":
                     debug_log("SHUTDOWN command received, requesting stop", "jarvis")
                     request_stop()
@@ -1163,29 +1141,25 @@ def main(smoke_test: bool = False) -> None:
         # closed-handle raise or a diary pass racing its writes.
         wait_for_chat_worker(timeout_sec=5.0)
 
-        if _global_skip_shutdown_diary_update:
-            debug_log("shutdown diary update skipped by fast stop request", "jarvis")
-            print("⏭️ Skipping diary update before shutdown", flush=True)
+        # Final diary update before shutdown
+        debug_log("performing final diary update (force=True)...", "jarvis")
+        print("📝 Updating diary before shutdown...", flush=True)
+
+        # Check dialogue memory status
+        if _global_dialogue_memory is None:
+            print("⚠️ Dialogue memory is None - nothing to save", flush=True)
         else:
-            # Final diary update before shutdown
-            debug_log("performing final diary update (force=True)...", "jarvis")
-            print("📝 Updating diary before shutdown...", flush=True)
+            # Display-only count; actual save uses the atomic snapshot path.
+            pending = _global_dialogue_memory.get_pending_chunks()
+            print(f"💬 Found {len(pending)} pending conversation chunks", flush=True)
 
-            # Check dialogue memory status
-            if _global_dialogue_memory is None:
-                print("⚠️ Dialogue memory is None - nothing to save", flush=True)
-            else:
-                # Display-only count; actual save uses the atomic snapshot path.
-                pending = _global_dialogue_memory.get_pending_chunks()
-                print(f"💬 Found {len(pending)} pending conversation chunks", flush=True)
-
-            # Use callbacks if they were set by desktop app (for live UI updates in bundled mode)
-            # Use IPC (stdout events) if callbacks not set (subprocess mode)
-            use_callbacks = any(_diary_update_callbacks.values())
-            use_ipc = not use_callbacks  # Subprocess mode - emit events to stdout
-            _check_and_update_diary(db, cfg, verbose=True, force=True, timeout_sec=SHUTDOWN_DIARY_TIMEOUT_SEC, use_callbacks=use_callbacks, use_ipc=use_ipc)
-            print("✅ Diary update complete", flush=True)
-            debug_log("diary update complete", "jarvis")
+        # Use callbacks if they were set by desktop app (for live UI updates in bundled mode)
+        # Use IPC (stdout events) if callbacks not set (subprocess mode)
+        use_callbacks = any(_diary_update_callbacks.values())
+        use_ipc = not use_callbacks  # Subprocess mode - emit events to stdout
+        _check_and_update_diary(db, cfg, verbose=True, force=True, timeout_sec=SHUTDOWN_DIARY_TIMEOUT_SEC, use_callbacks=use_callbacks, use_ipc=use_ipc)
+        print("✅ Diary update complete", flush=True)
+        debug_log("diary update complete", "jarvis")
 
         if tts is not None:
             tts.stop()

--- a/src/jarvis/daemon.py
+++ b/src/jarvis/daemon.py
@@ -94,6 +94,12 @@ CHAT_QUERY_IPC_PREFIX = "__CHAT_QUERY__:"
 # different instance from the desktop app's: calling the cancel
 # function over there sets a flag nobody in this process reads.
 CHAT_CANCEL_IPC_PREFIX = "__CHAT_CANCEL__"
+# Session control (subprocess mode): new session (bare line), rewind to a
+# user turn, and restore an archived session. All operate on the daemon's
+# shared dialogue memory, which is where the conversation actually lives.
+CHAT_NEW_SESSION_IPC_PREFIX = "__CHAT_NEW_SESSION__"
+CHAT_REWIND_IPC_PREFIX = "__CHAT_REWIND__:"
+CHAT_RESTORE_IPC_PREFIX = "__CHAT_RESTORE__:"
 SHUTDOWN_SKIP_DIARY_COMMAND = "SHUTDOWN_SKIP_DIARY"
 
 
@@ -166,6 +172,83 @@ def get_hot_window_messages() -> list:
     if _global_dialogue_memory is None:
         return []
     return _global_dialogue_memory.get_recent_messages()
+
+
+def new_chat_session() -> bool:
+    """Start a fresh conversation: clear the shared dialogue memory.
+
+    Voice and text share this memory, so a new session resets both. The
+    previous conversation is not lost anywhere else — the chat window
+    keeps an in-memory archive of its transcript for the session list.
+    Nothing is written to disk. Returns False when a query is currently
+    running (the engine appends its turns after we clear, resurrecting
+    the conversation); the caller should retry after the query finishes.
+    """
+    global _global_dialogue_memory
+    if _global_dialogue_memory is None:
+        return False
+    if not _chat_query_lock.acquire(blocking=False):
+        debug_log("new chat session rejected: a query is in flight", "chat")
+        return False
+    try:
+        _global_dialogue_memory.clear()
+        return True
+    finally:
+        _chat_query_lock.release()
+
+
+def rewind_chat_to_user(user_index: int) -> bool:
+    """Roll the shared dialogue memory back to before a given user turn.
+
+    ``user_index`` is 1-based (the first user message is 1). Every turn
+    from that user message on is dropped — including the message itself,
+    so the caller can re-submit it and get a fresh reply. Returns True
+    when a rewind happened, False when the turn is not in memory or a
+    query is currently running (the engine's late turn-append would
+    resurrect turns past the rewind point).
+    """
+    global _global_dialogue_memory
+    if _global_dialogue_memory is None:
+        return False
+    if not _chat_query_lock.acquire(blocking=False):
+        debug_log("chat rewind rejected: a query is in flight", "chat")
+        return False
+    try:
+        return _global_dialogue_memory.rewind_before_user_message(user_index)
+    finally:
+        _chat_query_lock.release()
+
+
+def set_chat_messages(messages: list) -> bool:
+    """Restore an archived session into the shared dialogue memory.
+
+    Used when the chat window switches back to a session from its
+    in-memory list. Redaction is applied here, on the daemon side, so the
+    diary (written at session end from this memory) never sees raw user
+    text even if the window's archive holds it. Returns False when a
+    query is currently running (see ``rewind_chat_to_user``).
+    """
+    global _global_dialogue_memory
+    if _global_dialogue_memory is None:
+        return False
+    if not _chat_query_lock.acquire(blocking=False):
+        debug_log("chat restore rejected: a query is in flight", "chat")
+        return False
+    try:
+        from .utils.redact import redact
+
+        scrubbed = []
+        for m in messages:
+            if not isinstance(m, dict):
+                continue
+            role = m.get("role")
+            content = m.get("content")
+            if isinstance(role, str) and isinstance(content, str) and role in ("user", "assistant"):
+                scrubbed.append({"role": role, "content": redact(content)})
+        _global_dialogue_memory.set_messages(scrubbed)
+        return True
+    finally:
+        _chat_query_lock.release()
 
 
 # Diary IPC protocol prefix - desktop app intercepts lines starting with this
@@ -416,6 +499,66 @@ def handle_chat_cancel_stdin_line(line: str) -> bool:
     if line.strip() != CHAT_CANCEL_IPC_PREFIX:
         return False
     cancel_active_chat_query()
+    return True
+
+
+def handle_chat_new_session_stdin_line(line: str) -> bool:
+    """Parse a stdin line as a chat new-session instruction (subprocess mode).
+
+    Returns True when the line was the new-session instruction and was
+    handled, False otherwise so the caller can apply its own semantics.
+    """
+    if line.strip() != CHAT_NEW_SESSION_IPC_PREFIX:
+        return False
+    new_chat_session()
+    return True
+
+
+def handle_chat_rewind_stdin_line(line: str) -> bool:
+    """Parse a stdin line as a chat rewind instruction (subprocess mode).
+
+    Payload is ``{"user_index": N}`` with N 1-based. Returns True when
+    the line was a rewind instruction and was handled (whether or not a
+    rewind actually happened), False for anything else.
+    """
+    line = line.strip()
+    if not line.startswith(CHAT_REWIND_IPC_PREFIX):
+        return False
+    import json
+    try:
+        payload = json.loads(line[len(CHAT_REWIND_IPC_PREFIX):])
+        user_index = int(payload.get("user_index"))
+    except Exception:
+        debug_log("malformed __CHAT_REWIND__ line ignored", "chat_ipc")
+        return True
+    if user_index < 1:
+        debug_log("__CHAT_REWIND__ user_index out of range, ignored", "chat_ipc")
+        return True
+    rewind_chat_to_user(user_index)
+    return True
+
+
+def handle_chat_restore_stdin_line(line: str) -> bool:
+    """Parse a stdin line as a session-restore instruction (subprocess mode).
+
+    Payload is ``{"messages": [{"role", "content"}, ...]}``. Returns True
+    when the line was a restore instruction and was handled (even if the
+    payload was malformed), False for anything else.
+    """
+    line = line.strip()
+    if not line.startswith(CHAT_RESTORE_IPC_PREFIX):
+        return False
+    import json
+    try:
+        payload = json.loads(line[len(CHAT_RESTORE_IPC_PREFIX):])
+        messages = payload.get("messages", [])
+    except Exception:
+        debug_log("malformed __CHAT_RESTORE__ line ignored", "chat_ipc")
+        return True
+    if not isinstance(messages, list):
+        debug_log("__CHAT_RESTORE__ messages not a list, ignored", "chat_ipc")
+        return True
+    set_chat_messages(messages)
     return True
 
 
@@ -946,6 +1089,12 @@ def main(smoke_test: bool = False) -> None:
                 # Chat query-in (subprocess mode). Returns False for any other
                 # line, which we silently ignore.
                 if handle_chat_cancel_stdin_line(stripped):
+                    continue
+                if handle_chat_new_session_stdin_line(stripped):
+                    continue
+                if handle_chat_rewind_stdin_line(stripped):
+                    continue
+                if handle_chat_restore_stdin_line(stripped):
                     continue
                 if stripped.startswith(CHAT_QUERY_IPC_PREFIX):
                     handle_chat_query_stdin_line(stripped)

--- a/src/jarvis/daemon.py
+++ b/src/jarvis/daemon.py
@@ -99,6 +99,8 @@ CHAT_CANCEL_IPC_PREFIX = "__CHAT_CANCEL__"
 CHAT_NEW_SESSION_IPC_PREFIX = "__CHAT_NEW_SESSION__"
 CHAT_REWIND_IPC_PREFIX = "__CHAT_REWIND__:"
 CHAT_RESTORE_IPC_PREFIX = "__CHAT_RESTORE__:"
+
+
 def request_stop() -> None:
     """Request the daemon to stop gracefully."""
     global _global_stop_requested

--- a/src/jarvis/memory/conversation.py
+++ b/src/jarvis/memory/conversation.py
@@ -810,6 +810,87 @@ class DialogueMemory:
 
             return [{"role": role, "content": content} for _, role, content in recent_messages]
 
+    # ------------------------------------------------------------------
+    # Session / rewind support (text-chat sessions)
+    # ------------------------------------------------------------------
+    # These operate on the FULL in-memory conversation, not the recent
+    # window: the chat window archives and restores whole sessions, and a
+    # rewind rolls the conversation back to a chosen turn. Everything is
+    # in-memory only — nothing here touches the diary or the disk.
+
+    def all_messages(self) -> List[dict]:
+        """Return every stored turn as ``[{"role", "content"}, ...]``.
+
+        Unlike ``get_recent_messages`` this is not bounded by the hot
+        window: it is the full in-memory conversation, used to archive a
+        session before switching or starting a new one. Content is
+        already redacted (redaction runs before a turn is stored).
+        """
+        with self._lock:
+            return [
+                {"role": role, "content": content}
+                for _ts, role, content in self._messages
+            ]
+
+    def set_messages(self, messages: List[dict]) -> None:
+        """Replace the stored conversation with ``messages`` (session restore).
+
+        ``messages`` must be ``{"role", "content"}`` dicts as produced by
+        ``all_messages``. Caches and tool carryover are cleared: the
+        restored conversation starts fresh. Timestamps are regenerated
+        with a monotonic epsilon so the restored turns count as recent
+        and keep their order.
+        """
+        with self._lock:
+            now = time.time()
+            fresh: List[Tuple[float, str, str]] = []
+            for i, msg in enumerate(messages):
+                role = str(msg.get("role", "")).strip()
+                content = str(msg.get("content", "")).strip()
+                if role and content:
+                    fresh.append((now + i * 0.001, role, content))
+            self._messages = fresh
+            self._last_ts = now + len(fresh) * 0.001
+            self._last_activity_time = self._last_ts
+            self._tool_turns = []
+            self._hot_cache = OrderedDict()
+
+    def clear(self) -> None:
+        """Drop the entire conversation and its caches (new session)."""
+        with self._lock:
+            self._messages = []
+            self._tool_turns = []
+            self._hot_cache = OrderedDict()
+            self._last_activity_time = time.time()
+
+    def rewind_before_user_message(self, user_index: int) -> bool:
+        """Drop every message from the ``user_index``-th user message on.
+
+        ``user_index`` is 1-based: 1 rewinds to before the first user
+        message (dropping the whole conversation), 2 keeps everything up
+        to but excluding the second user message, and so on. The chosen
+        user message itself is dropped so a regenerate can re-add it
+        without duplicating. Conversation-scoped caches and tool
+        carryover are cleared: they describe state after the rewind
+        point. Returns True when a rewind happened, False when the given
+        user message is not in memory (nothing to rewind).
+        """
+        with self._lock:
+            seen = 0
+            keep_until: Optional[int] = None
+            for i, (_ts, role, _content) in enumerate(self._messages):
+                if role == "user":
+                    seen += 1
+                    if seen == user_index:
+                        keep_until = i
+                        break
+            if keep_until is None:
+                return False
+            self._messages = self._messages[:keep_until]
+            self._tool_turns = []
+            self._hot_cache = OrderedDict()
+            return True
+
     def record_tool_turn(self, tool_msgs: List[dict]) -> None:
         """Store in-loop tool-call/tool-role messages from a just-finished reply.
 

--- a/tests/test_chat_submission.py
+++ b/tests/test_chat_submission.py
@@ -623,3 +623,148 @@ class TestGetHotWindowMessages:
         _time.sleep(1.2)
 
         assert daemon.get_hot_window_messages() == []
+
+
+@pytest.mark.unit
+class TestChatSessionControls:
+    """Session lifecycle on the daemon side: new session, rewind, restore.
+    The chat window drives these in bundled mode (direct calls) and
+    subprocess mode (stdin lines)."""
+
+    def setup_method(self, _method):
+        _reset_daemon_globals()
+
+    def teardown_method(self, _method):
+        _reset_daemon_globals()
+
+    def _seeded_memory(self):
+        dm = _install_dialogue_memory(cfg=object(), db=object())
+        dm.add_message("user", "remind me to buy oat milk")
+        dm.add_message("assistant", "Noted.")
+        dm.add_message("user", "what about eggs?")
+        dm.add_message("assistant", "Eggs too.")
+        return dm
+
+    # ── bundled-mode functions ─────────────────────────────────────────
+
+    def test_new_chat_session_clears_shared_memory(self):
+        dm = self._seeded_memory()
+        daemon.new_chat_session()
+        assert dm.all_messages() == []
+        assert daemon.get_hot_window_messages() == []
+
+    def test_new_chat_session_noops_when_daemon_not_booted(self):
+        # Globals are None; must not raise.
+        daemon.new_chat_session()
+
+    def test_rewind_chat_to_user_truncates_shared_memory(self):
+        dm = self._seeded_memory()
+        assert daemon.rewind_chat_to_user(2) is True
+        assert dm.all_messages() == [
+            {"role": "user", "content": "remind me to buy oat milk"},
+            {"role": "assistant", "content": "Noted."},
+        ]
+
+    def test_rewind_chat_to_unknown_user_returns_false(self):
+        dm = self._seeded_memory()
+        assert daemon.rewind_chat_to_user(9) is False
+        assert len(dm.all_messages()) == 4
+
+    def test_set_chat_messages_restores_and_redacts(self):
+        _install_dialogue_memory(cfg=object(), db=object())
+        daemon.set_chat_messages([
+            {"role": "user", "content": "my email is test@example.com"},
+            {"role": "assistant", "content": "Got it."},
+        ])
+        restored = daemon.get_hot_window_messages()
+        # Redaction runs on the daemon side so the diary never sees raw text.
+        assert "test@example.com" not in restored[0]["content"]
+        assert restored[1]["content"] == "Got it."
+
+    # ── subprocess stdin handlers ──────────────────────────────────────
+
+    def test_new_session_stdin_line(self):
+        dm = self._seeded_memory()
+        assert daemon.handle_chat_new_session_stdin_line(
+            daemon.CHAT_NEW_SESSION_IPC_PREFIX
+        ) is True
+        assert dm.all_messages() == []
+        assert daemon.handle_chat_new_session_stdin_line("SHUTDOWN") is False
+        assert daemon.handle_chat_new_session_stdin_line("") is False
+
+    def test_rewind_stdin_line_valid(self):
+        dm = self._seeded_memory()
+        line = f'{daemon.CHAT_REWIND_IPC_PREFIX}{{"user_index": 2}}'
+        assert daemon.handle_chat_rewind_stdin_line(line) is True
+        assert len(dm.all_messages()) == 2
+
+    def test_rewind_stdin_line_malformed_is_swallowed(self):
+        dm = self._seeded_memory()
+        assert daemon.handle_chat_rewind_stdin_line(
+            f"{daemon.CHAT_REWIND_IPC_PREFIX}not json"
+        ) is True
+        assert len(dm.all_messages()) == 4
+        assert daemon.handle_chat_rewind_stdin_line(
+            f'{daemon.CHAT_REWIND_IPC_PREFIX}{{"user_index": 0}}'
+        ) is True
+        assert len(dm.all_messages()) == 4
+        assert daemon.handle_chat_rewind_stdin_line("SHUTDOWN") is False
+
+    def test_restore_stdin_line_valid(self):
+        _install_dialogue_memory(cfg=object(), db=object())
+        line = (
+            f'{daemon.CHAT_RESTORE_IPC_PREFIX}{{"messages": ['
+            '{"role": "user", "content": "hi"}, '
+            '{"role": "assistant", "content": "hello"}]}'
+        )
+        assert daemon.handle_chat_restore_stdin_line(line) is True
+        assert daemon.get_hot_window_messages() == [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"},
+        ]
+
+    def test_restore_stdin_line_malformed_is_swallowed(self):
+        _install_dialogue_memory(cfg=object(), db=object())
+        assert daemon.handle_chat_restore_stdin_line(
+            f"{daemon.CHAT_RESTORE_IPC_PREFIX}not json"
+        ) is True
+        assert daemon.handle_chat_restore_stdin_line(
+            f'{daemon.CHAT_RESTORE_IPC_PREFIX}{{"messages": "nope"}}'
+        ) is True
+        assert daemon.get_hot_window_messages() == []
+        assert daemon.handle_chat_restore_stdin_line("SHUTDOWN") is False
+
+
+@pytest.mark.unit
+class TestChatSessionControlsLockGuard:
+    """Session controls must not run while a query is in flight: the engine
+    appends its turns after the truncation, which would resurrect the
+    conversation the rewind/new-session/restore just dropped."""
+
+    def setup_method(self, _method):
+        _reset_daemon_globals()
+
+    def teardown_method(self, _method):
+        _reset_daemon_globals()
+
+    def test_controls_are_rejected_while_the_query_lock_is_held(self):
+        dm = _install_dialogue_memory(cfg=object(), db=object())
+        dm.add_message("user", "q1")
+        dm.add_message("assistant", "a1")
+        dm.add_message("user", "q2")
+        dm.add_message("assistant", "a2")
+
+        # Simulate an in-flight query (voice or text) holding the lock.
+        assert daemon._chat_query_lock.acquire(blocking=False)
+
+        try:
+            assert daemon.rewind_chat_to_user(2) is False
+            assert daemon.new_chat_session() is False
+            assert daemon.set_chat_messages([{"role": "user", "content": "x"}]) is False
+            assert len(dm.all_messages()) == 4, "memory must be untouched"
+        finally:
+            daemon._chat_query_lock.release()
+
+        # Once the lock is free the same calls apply.
+        assert daemon.rewind_chat_to_user(2) is True
+        assert len(dm.all_messages()) == 2

--- a/tests/test_chat_submission.py
+++ b/tests/test_chat_submission.py
@@ -38,7 +38,6 @@ def _reset_daemon_globals():
     daemon._global_cfg = None
     daemon._global_db = None
     daemon._global_stop_requested = False
-    daemon._global_skip_shutdown_diary_update = False
     daemon._chat_query_lock = threading.Lock()
 
 
@@ -565,7 +564,7 @@ class TestChatQueryStdinHandler:
 
 @pytest.mark.unit
 class TestDaemonShutdownMode:
-    """Shutdown requests can skip the final diary LLM pass when explicitly asked."""
+    """``request_stop`` flags a graceful stop; the final diary save always runs."""
 
     def setup_method(self, _method):
         _reset_daemon_globals()
@@ -573,20 +572,10 @@ class TestDaemonShutdownMode:
     def teardown_method(self, _method):
         _reset_daemon_globals()
 
-    def test_normal_stop_keeps_shutdown_diary_update_enabled(self):
+    def test_request_stop_requests_graceful_stop(self):
         daemon.request_stop()
 
         assert daemon.is_stop_requested() is True
-        assert daemon.is_shutdown_diary_update_skipped() is False
-
-    def test_fast_stop_marks_shutdown_diary_update_skipped(self):
-        daemon.request_stop(skip_diary_update=True)
-
-        assert daemon.is_stop_requested() is True
-        assert daemon.is_shutdown_diary_update_skipped() is True
-
-    def test_shutdown_skip_diary_command_is_not_a_chat_query(self):
-        assert daemon.handle_chat_query_stdin_line(daemon.SHUTDOWN_SKIP_DIARY_COMMAND) is False
 
 
 @pytest.mark.unit

--- a/tests/test_chat_window.py
+++ b/tests/test_chat_window.py
@@ -73,7 +73,7 @@ class TestChatWindowSend:
         win = ChatWindow()
         win.input_widget.setPlainText("hello there")
         win._send()
-        text = win.transcript_widget.toPlainText()
+        text = win.transcript_text()
         assert "hello there" in text
 
     def test_send_clears_input(self, qapp, monkeypatch):
@@ -113,7 +113,7 @@ class TestChatWindowSend:
         win._send()
 
         assert calls == []
-        text = win.transcript_widget.toPlainText().lower()
+        text = win.transcript_text().lower()
         assert "start listening" in text
         assert win.input_widget.toPlainText() == "are you there"
 
@@ -133,7 +133,7 @@ class TestChatWindowCallbacks:
         win._send()
         # Simulate the daemon completing with a reply.
         win._on_complete("It is sunny today.")
-        text = win.transcript_widget.toPlainText()
+        text = win.transcript_text()
         assert "It is sunny today." in text
 
     def test_on_complete_hides_stop_button(self, qapp, monkeypatch):
@@ -165,7 +165,7 @@ class TestChatWindowCallbacks:
         win._send()
         # Simulate the daemon rejecting because a query is already running.
         win._on_busy()
-        text = win.transcript_widget.toPlainText()
+        text = win.transcript_text()
         # The notice is language-neutral in shape but must mention the query
         # was not accepted.
         assert "second query" in text  # user echo stays
@@ -301,7 +301,7 @@ class TestDesktopAppChatDispatch:
         tray._on_chat_ipc_line(f'{CHAT_IPC_PREFIX}{{"type":"complete","data":"hello back"}}')
         tray.chat_window.show()
         qapp.processEvents()
-        assert "hello back" in tray.chat_window.transcript_widget.toPlainText()
+        assert "hello back" in tray.chat_window.transcript_text()
 
     def test_dispatch_start_sets_thinking(self, qapp):
         from jarvis.daemon import CHAT_IPC_PREFIX
@@ -317,7 +317,7 @@ class TestDesktopAppChatDispatch:
         tray._on_chat_ipc_line(f'{CHAT_IPC_PREFIX}{{"type":"busy","data":null}}')
         tray.chat_window.show()
         qapp.processEvents()
-        text = tray.chat_window.transcript_widget.toPlainText().lower()
+        text = tray.chat_window.transcript_text().lower()
         assert "busy" in text
 
     def test_dispatch_malformed_line_is_swallowed(self, qapp):
@@ -374,6 +374,52 @@ class TestDesktopAppChatDispatch:
         assert written.startswith(CHAT_QUERY_IPC_PREFIX)
         payload = json.loads(written[len(CHAT_QUERY_IPC_PREFIX):].strip())
         assert payload["text"] == "hello over stdin"
+
+    def test_subprocess_control_fn_writes_session_lines(self, qapp, monkeypatch):
+        """The session-control closure writes the new-session / rewind /
+        restore IPC lines (bare prefix or prefix+JSON as appropriate)."""
+        import io
+        import json
+        from jarvis.daemon import (
+            CHAT_NEW_SESSION_IPC_PREFIX,
+            CHAT_REWIND_IPC_PREFIX,
+            CHAT_RESTORE_IPC_PREFIX,
+        )
+        import desktop_app.app as app_mod
+
+        tray = app_mod.JarvisSystemTray.__new__(app_mod.JarvisSystemTray)
+        sink = io.StringIO()
+        fake_proc = type("P", (), {"stdin": sink})()
+        tray.daemon_process = fake_proc
+
+        def _control(kind: str, payload=None) -> None:
+            import json as _json
+            prefixes = {
+                "new_session": CHAT_NEW_SESSION_IPC_PREFIX,
+                "rewind": CHAT_REWIND_IPC_PREFIX,
+                "restore": CHAT_RESTORE_IPC_PREFIX,
+            }
+            prefix = prefixes[kind]
+            if payload is None:
+                tray.daemon_process.stdin.write(f"{prefix}\n")
+            else:
+                tray.daemon_process.stdin.write(
+                    f"{prefix}{_json.dumps(payload)}\n"
+                )
+            tray.daemon_process.stdin.flush()
+
+        _control("new_session")
+        _control("rewind", {"user_index": 2})
+        _control("restore", {"messages": [{"role": "user", "content": "hi"}]})
+        lines = sink.getvalue().splitlines()
+
+        assert lines[0] == CHAT_NEW_SESSION_IPC_PREFIX
+        assert json.loads(lines[1][len(CHAT_REWIND_IPC_PREFIX):]) == {
+            "user_index": 2
+        }
+        assert json.loads(lines[2][len(CHAT_RESTORE_IPC_PREFIX):])["messages"] == [
+            {"role": "user", "content": "hi"}
+        ]
 
     def test_show_chat_marks_window_unavailable_when_daemon_stopped(self, qapp):
         import desktop_app.app as app_mod
@@ -644,7 +690,7 @@ class TestChatWindowHotWindowReplay:
         win.show()
         qapp.processEvents()
 
-        text = win.transcript_widget.toPlainText()
+        text = win.transcript_text()
         assert "what is the weather" in text
         assert "It is sunny." in text
 
@@ -666,7 +712,7 @@ class TestChatWindowHotWindowReplay:
         win.show()
         qapp.processEvents()
 
-        text = win.transcript_widget.toPlainText()
+        text = win.transcript_text()
         assert text.count("hi") == 1
 
     def test_empty_hot_window_leaves_transcript_blank(self, qapp, monkeypatch):
@@ -682,4 +728,203 @@ class TestChatWindowHotWindowReplay:
         win.show()
         qapp.processEvents()
 
-        assert win.transcript_widget.toPlainText() == ""
+        assert win.transcript_text() == ""
+
+
+@pytest.mark.unit
+class TestChatSessions:
+    """In-memory chat sessions: new session clears the shared conversation,
+    the sidebar lists past sessions, switching restores one."""
+
+    def _window(self, qapp, **kwargs):
+        from desktop_app.chat_window import ChatWindow
+        return ChatWindow(**kwargs)
+
+    def test_starts_with_an_active_session(self, qapp):
+        """A fresh window always has a new session (nothing is kept on
+        disk, so there is no previous session to restore)."""
+        win = self._window(qapp)
+        assert win.session_list.count() == 1
+        assert "Session 1" in win.session_list.item(0).text()
+        assert win._active_session()["active"] is True
+
+    def test_new_session_clears_transcript_and_shared_memory(self, qapp, monkeypatch):
+        cleared = []
+        monkeypatch.setattr(
+            "jarvis.daemon.new_chat_session", lambda: cleared.append(True) or True
+        )
+        win = self._window(qapp)
+        win.input_widget.setPlainText("hello")
+        win._send()
+        assert "hello" in win.transcript_text()
+
+        win._new_session()
+
+        assert cleared == [True], "the shared daemon memory must be cleared"
+        assert win.transcript_text() == ""
+        assert win.session_list.count() == 2
+        assert "● Session 2" in win.session_list.item(1).text()
+
+    def test_new_session_sends_ipc_line_in_subprocess_mode(self, qapp):
+        commands = []
+        win = self._window(
+            qapp, submit_fn=lambda _t: None,
+            control_fn=lambda kind, payload: commands.append((kind, payload)),
+        )
+        win._new_session()
+        assert ("new_session", None) in commands
+
+    def test_switch_restores_session_into_shared_memory(self, qapp, monkeypatch):
+        restored = []
+        monkeypatch.setattr(
+            "jarvis.daemon.set_chat_messages",
+            lambda msgs: restored.append(msgs) or True,
+        )
+        monkeypatch.setattr("jarvis.daemon.new_chat_session", lambda: True)
+        win = self._window(qapp)
+        win.input_widget.setPlainText("first question")
+        win._send()
+        win._new_session()
+        win.input_widget.setPlainText("second question")
+        win._send()
+
+        # Switch back to session 1.
+        win._on_session_clicked(win.session_list.item(0))
+
+        assert restored, "switching must restore the archived turns"
+        assert restored[-1] == [
+            {"role": "user", "content": "first question"},
+        ]
+        assert "first question" in win.transcript_text()
+        assert "second question" not in win.transcript_text()
+        assert win._active_session()["title"] == "Session 1"
+
+    def test_switch_sends_restore_ipc_line_in_subprocess_mode(self, qapp):
+        commands = []
+        win = self._window(
+            qapp, submit_fn=lambda _t: None,
+            control_fn=lambda kind, payload: commands.append((kind, payload)),
+        )
+        win.input_widget.setPlainText("archived question")
+        win._send()
+        win._on_complete(None)  # the daemon's reply arrives; query no longer in flight
+        win._new_session()
+        win._on_session_clicked(win.session_list.item(0))
+
+        restore = [c for c in commands if c[0] == "restore"]
+        assert restore and restore[-1][1] == {
+            "messages": [{"role": "user", "content": "archived question"}]
+        }
+
+
+@pytest.mark.unit
+class TestChatRewind:
+    """The rewind button under a sent message rolls the conversation back
+    to that message and regenerates a fresh reply."""
+
+    def _window(self, qapp, **kwargs):
+        from desktop_app.chat_window import ChatWindow
+        return ChatWindow(**kwargs)
+
+    def _send(self, win, text):
+        win.input_widget.setPlainText(text)
+        win._send()
+
+    def test_every_sent_message_carries_a_rewind_button(self, qapp):
+        from PyQt6.QtWidgets import QPushButton
+
+        win = self._window(qapp)
+        self._send(win, "one")
+        self._send(win, "two")
+
+        buttons = [
+            b.objectName() for b in win.transcript_widget.findChildren(QPushButton)
+            if b.objectName().startswith("rewind_")
+        ]
+        assert buttons == ["rewind_1", "rewind_2"]
+
+    def test_rewind_truncates_transcript_and_regenerates(self, qapp, monkeypatch):
+        rewinds = []
+        submits = []
+        monkeypatch.setattr(
+            "jarvis.daemon.rewind_chat_to_user",
+            lambda idx: rewinds.append(idx) or True,
+        )
+        monkeypatch.setattr(
+            "jarvis.daemon.submit_text_query",
+            lambda text, **kw: submits.append(text),
+        )
+        win = self._window(qapp)
+        self._send(win, "first")
+        win._on_complete("first reply")
+        self._send(win, "second")
+        win._on_complete("second reply")
+
+        win._rewind_to_user(1, "first")
+
+        assert rewinds == [1], "the daemon memory must be rewound to message 1"
+        assert submits[-1] == "first", "the rewound message must be re-submitted"
+        assert "first" in win.transcript_text()
+        assert "second" not in win.transcript_text()
+        assert "first reply" not in win.transcript_text()
+
+        # The fresh reply lands through the normal complete path.
+        win._on_complete("fresh reply")
+        assert "fresh reply" in win.transcript_text()
+
+    def test_rewind_keeps_later_user_messages_after_regenerate(self, qapp, monkeypatch):
+        """After a rewind + regenerate, the message ordinal stays stable so
+        a subsequent send continues the conversation correctly."""
+        monkeypatch.setattr(
+            "jarvis.daemon.rewind_chat_to_user", lambda idx: True
+        )
+        monkeypatch.setattr(
+            "jarvis.daemon.submit_text_query", lambda text, **kw: None
+        )
+        win = self._window(qapp)
+        self._send(win, "one")
+        win._on_complete(None)
+        self._send(win, "two")
+        win._on_complete(None)
+        win._rewind_to_user(2, "two")
+        win._on_complete(None)
+        self._send(win, "three")
+
+        buttons = [
+            b.objectName() for b in win.transcript_widget.findChildren(
+                __import__("PyQt6.QtWidgets", fromlist=["QPushButton"]).QPushButton
+            )
+            if b.objectName().startswith("rewind_")
+        ]
+        assert buttons == ["rewind_1", "rewind_2", "rewind_3"]
+
+    def test_rewind_sends_ipc_line_in_subprocess_mode(self, qapp):
+        commands = []
+        submits = []
+        win = self._window(
+            qapp,
+            submit_fn=lambda t: submits.append(t),
+            control_fn=lambda kind, payload: commands.append((kind, payload)),
+        )
+        self._send(win, "question")
+        win._on_complete(None)  # query finished; rewind is now allowed
+        win._rewind_to_user(1, "question")
+
+        assert ("rewind", {"user_index": 1}) in commands
+        assert submits == ["question", "question"]
+
+    def test_rewind_noops_while_query_in_flight(self, qapp, monkeypatch):
+        rewinds = []
+        monkeypatch.setattr(
+            "jarvis.daemon.rewind_chat_to_user",
+            lambda idx: rewinds.append(idx) or True,
+        )
+        monkeypatch.setattr(
+            "jarvis.daemon.submit_text_query", lambda text, **kw: None
+        )
+        win = self._window(qapp)
+        self._send(win, "question")  # leaves _query_in_flight True
+
+        win._rewind_to_user(1, "question")
+
+        assert rewinds == [], "rewind must be disabled while a query is in flight"

--- a/tests/test_chat_window.py
+++ b/tests/test_chat_window.py
@@ -375,16 +375,12 @@ class TestDesktopAppChatDispatch:
         payload = json.loads(written[len(CHAT_QUERY_IPC_PREFIX):].strip())
         assert payload["text"] == "hello over stdin"
 
-    def test_subprocess_control_fn_writes_session_lines(self, qapp, monkeypatch):
-        """The session-control closure writes the new-session / rewind /
-        restore IPC lines (bare prefix or prefix+JSON as appropriate)."""
+    def test_subprocess_control_fn_writes_rewind_line(self, qapp, monkeypatch):
+        """The rewind control closure writes the ``__CHAT_REWIND__:`` IPC
+        line (prefix + JSON payload)."""
         import io
         import json
-        from jarvis.daemon import (
-            CHAT_NEW_SESSION_IPC_PREFIX,
-            CHAT_REWIND_IPC_PREFIX,
-            CHAT_RESTORE_IPC_PREFIX,
-        )
+        from jarvis.daemon import CHAT_REWIND_IPC_PREFIX
         import desktop_app.app as app_mod
 
         tray = app_mod.JarvisSystemTray.__new__(app_mod.JarvisSystemTray)
@@ -394,32 +390,18 @@ class TestDesktopAppChatDispatch:
 
         def _control(kind: str, payload=None) -> None:
             import json as _json
-            prefixes = {
-                "new_session": CHAT_NEW_SESSION_IPC_PREFIX,
-                "rewind": CHAT_REWIND_IPC_PREFIX,
-                "restore": CHAT_RESTORE_IPC_PREFIX,
-            }
-            prefix = prefixes[kind]
-            if payload is None:
-                tray.daemon_process.stdin.write(f"{prefix}\n")
-            else:
-                tray.daemon_process.stdin.write(
-                    f"{prefix}{_json.dumps(payload)}\n"
-                )
+            assert kind == "rewind"
+            tray.daemon_process.stdin.write(
+                f"{CHAT_REWIND_IPC_PREFIX}{_json.dumps(payload)}\n"
+            )
             tray.daemon_process.stdin.flush()
 
-        _control("new_session")
         _control("rewind", {"user_index": 2})
-        _control("restore", {"messages": [{"role": "user", "content": "hi"}]})
         lines = sink.getvalue().splitlines()
 
-        assert lines[0] == CHAT_NEW_SESSION_IPC_PREFIX
-        assert json.loads(lines[1][len(CHAT_REWIND_IPC_PREFIX):]) == {
+        assert json.loads(lines[0][len(CHAT_REWIND_IPC_PREFIX):]) == {
             "user_index": 2
         }
-        assert json.loads(lines[2][len(CHAT_RESTORE_IPC_PREFIX):])["messages"] == [
-            {"role": "user", "content": "hi"}
-        ]
 
     def test_show_chat_marks_window_unavailable_when_daemon_stopped(self, qapp):
         import desktop_app.app as app_mod
@@ -732,89 +714,132 @@ class TestChatWindowHotWindowReplay:
 
 
 @pytest.mark.unit
-class TestChatSessions:
-    """In-memory chat sessions: new session clears the shared conversation,
-    the sidebar lists past sessions, switching restores one."""
+class TestChatWindowSmsLook:
+    """The window reads as an SMS thread with a single contact: no session
+    sidebar, one continuous conversation, speech bubbles aligned by sender,
+    and a contact header."""
 
     def _window(self, qapp, **kwargs):
         from desktop_app.chat_window import ChatWindow
         return ChatWindow(**kwargs)
 
-    def test_starts_with_an_active_session(self, qapp):
-        """A fresh window always has a new session (nothing is kept on
-        disk, so there is no previous session to restore)."""
+    def test_no_session_sidebar(self, qapp):
+        """There is no session list and no new-session button: the window is
+        a single conversation, like an SMS thread with one contact."""
         win = self._window(qapp)
-        assert win.session_list.count() == 1
-        assert "Session 1" in win.session_list.item(0).text()
-        assert win._active_session()["active"] is True
+        assert not hasattr(win, "session_list")
+        assert not hasattr(win, "new_session_button")
+        assert win._messages == []
 
-    def test_new_session_clears_transcript_and_shared_memory(self, qapp, monkeypatch):
-        cleared = []
+    def test_header_shows_contact_and_presence(self, qapp):
+        from PyQt6.QtWidgets import QLabel
+        win = self._window(qapp)
+        win.show()
+        qapp.processEvents()
+        texts = [label.text() for label in win.findChildren(QLabel)]
+        assert "Jarvis" in texts
+        assert "Online" in texts
+
+    def test_header_shows_typing_while_query_in_flight(self, qapp, monkeypatch):
         monkeypatch.setattr(
-            "jarvis.daemon.new_chat_session", lambda: cleared.append(True) or True
+            "jarvis.daemon.submit_text_query", lambda text, **kw: None
         )
         win = self._window(qapp)
-        win.input_widget.setPlainText("hello")
+        win.show()
+        qapp.processEvents()
+        win.input_widget.setPlainText("hi")
         win._send()
-        assert "hello" in win.transcript_text()
+        qapp.processEvents()
+        assert win._header_status.text() == "Typing…"
 
-        win._new_session()
-
-        assert cleared == [True], "the shared daemon memory must be cleared"
-        assert win.transcript_text() == ""
-        assert win.session_list.count() == 2
-        assert "● Session 2" in win.session_list.item(1).text()
-
-    def test_new_session_sends_ipc_line_in_subprocess_mode(self, qapp):
-        commands = []
-        win = self._window(
-            qapp, submit_fn=lambda _t: None,
-            control_fn=lambda kind, payload: commands.append((kind, payload)),
-        )
-        win._new_session()
-        assert ("new_session", None) in commands
-
-    def test_switch_restores_session_into_shared_memory(self, qapp, monkeypatch):
-        restored = []
+    def test_single_conversation_accumulates_all_turns(self, qapp, monkeypatch):
+        """Voice-seeded turns and typed turns live in one transcript; there
+        is no way to split the conversation into separate sessions."""
         monkeypatch.setattr(
-            "jarvis.daemon.set_chat_messages",
-            lambda msgs: restored.append(msgs) or True,
+            "desktop_app.chat_window.get_hot_window_messages",
+            lambda: [
+                {"role": "user", "content": "voice question"},
+                {"role": "assistant", "content": "voice answer"},
+            ],
         )
-        monkeypatch.setattr("jarvis.daemon.new_chat_session", lambda: True)
+        monkeypatch.setattr(
+            "jarvis.daemon.submit_text_query", lambda text, **kw: None
+        )
         win = self._window(qapp)
-        win.input_widget.setPlainText("first question")
+        win.show()
+        qapp.processEvents()
+        win.input_widget.setPlainText("typed question")
         win._send()
-        win._new_session()
-        win.input_widget.setPlainText("second question")
+        win._on_complete("typed answer")
+
+        text = win.transcript_text()
+        assert "voice question" in text
+        assert "voice answer" in text
+        assert "typed question" in text
+        assert "typed answer" in text
+
+    def test_user_bubble_right_assistant_left(self, qapp, monkeypatch):
+        """SMS layout: the user's bubble sits on the right half of the
+        window, Jarvis's reply on the left half."""
+        from PyQt6.QtWidgets import QLabel
+        monkeypatch.setattr(
+            "jarvis.daemon.submit_text_query", lambda text, **kw: None
+        )
+        win = self._window(qapp)
+        win.show()
+        qapp.processEvents()
+        win.input_widget.setPlainText("hi there")
         win._send()
+        win._on_complete("hello back")
+        qapp.processEvents()
 
-        # Switch back to session 1.
-        win._on_session_clicked(win.session_list.item(0))
-
-        assert restored, "switching must restore the archived turns"
-        assert restored[-1] == [
-            {"role": "user", "content": "first question"},
+        bubbles = [
+            label
+            for label in win.transcript_widget.findChildren(QLabel)
+            if label.objectName() == "bubble"
         ]
-        assert "first question" in win.transcript_text()
-        assert "second question" not in win.transcript_text()
-        assert win._active_session()["title"] == "Session 1"
+        assert len(bubbles) == 2
+        user_bubble, assistant_bubble = bubbles
+        mid = win.width() // 2
+        assert user_bubble.mapTo(win, user_bubble.rect().topLeft()).x() > mid
+        assert assistant_bubble.mapTo(win, assistant_bubble.rect().topLeft()).x() < mid
 
-    def test_switch_sends_restore_ipc_line_in_subprocess_mode(self, qapp):
-        commands = []
-        win = self._window(
-            qapp, submit_fn=lambda _t: None,
-            control_fn=lambda kind, payload: commands.append((kind, payload)),
+    def test_bubbles_show_plain_text_without_role_prefixes(self, qapp, monkeypatch):
+        """The bubbles carry the message bodies only; position and colour
+        convey the sender, so there is no 'You:' / 'Jarvis:' prefix."""
+        from PyQt6.QtWidgets import QLabel
+        monkeypatch.setattr(
+            "jarvis.daemon.submit_text_query", lambda text, **kw: None
         )
-        win.input_widget.setPlainText("archived question")
+        win = self._window(qapp)
+        win.input_widget.setPlainText("no prefix")
         win._send()
-        win._on_complete(None)  # the daemon's reply arrives; query no longer in flight
-        win._new_session()
-        win._on_session_clicked(win.session_list.item(0))
+        win._on_complete("plain reply")
 
-        restore = [c for c in commands if c[0] == "restore"]
-        assert restore and restore[-1][1] == {
-            "messages": [{"role": "user", "content": "archived question"}]
-        }
+        texts = [
+            label.text()
+            for label in win.transcript_widget.findChildren(QLabel)
+            if label.objectName() == "bubble"
+        ]
+        assert texts == ["no prefix", "plain reply"]
+        assert all("You:" not in t and "Jarvis:" not in t for t in texts)
+
+    def test_bubbles_carry_timestamps(self, qapp, monkeypatch):
+        from PyQt6.QtWidgets import QLabel
+        monkeypatch.setattr(
+            "jarvis.daemon.submit_text_query", lambda text, **kw: None
+        )
+        win = self._window(qapp)
+        win.input_widget.setPlainText("timed")
+        win._send()
+
+        time_labels = [
+            label
+            for label in win.transcript_widget.findChildren(QLabel)
+            if label.styleSheet() and "font-size: 11px" in label.styleSheet()
+        ]
+        assert time_labels, "each bubble should show a muted timestamp"
+        assert all(":" in label.text() for label in time_labels)
 
 
 @pytest.mark.unit

--- a/tests/test_desktop_app.py
+++ b/tests/test_desktop_app.py
@@ -1605,3 +1605,81 @@ class TestDesktopSmokeTest:
 
             mock_smoke.assert_called_once()
             assert result == 42  # return value propagated from _smoke_test_main
+
+
+@pytest.mark.unit
+class TestRuntimeStatusDialog:
+    """The runtime-status dialog renders the snapshot as a structured,
+    themed dialog rather than a plain text blob."""
+
+    def _snapshot(self):
+        from desktop_app.app import RuntimeStatusSnapshot
+
+        return RuntimeStatusSnapshot(
+            daemon_state="Listening",
+            daemon_mode="subprocess",
+            daemon_pid=12345,
+            ollama_needed=True,
+            ollama_running=True,
+            ollama_version="0.9.1",
+            ollama_owner="Jarvis",
+            ollama_launch_method="serve",
+            low_power_mode=True,
+            llm_provider="ollama",
+            chat_model="gemma4:e2b",
+            embedding_provider="ollama",
+            embedding_model="nomic-embed-text",
+            mcp_count=2,
+        )
+
+    def test_rows_cover_every_snapshot_field(self):
+        from desktop_app.app import _runtime_status_rows
+
+        snapshot = self._snapshot()
+        rows = _runtime_status_rows(snapshot)
+
+        by_key = {key: value for _section, key, value in rows}
+        assert by_key["State"] == "Listening"
+        assert by_key["Mode"] == "subprocess"
+        assert by_key["PID"] == "12345"
+        assert by_key["Low Power Mode"] == "On"
+        assert by_key["Running"] == "Yes (0.9.1)"
+        assert by_key["Owner"] == "Jarvis"
+        assert by_key["Chat"] == "gemma4:e2b"
+        assert by_key["Embeddings"] == "ollama / nomic-embed-text"
+        assert by_key["Configured servers"] == "2"
+        sections = [section for section, _key, _value in rows]
+        assert sections == ["🎙️ Assistant"] * 4 + ["🦙 Ollama"] * 4 + ["🧠 Models"] * 3 + ["🔌 MCP"] * 1
+
+    def test_format_still_matches_legacy_text_layout(self):
+        """The text formatter (used by tests and any terminal path) must
+        keep producing the exact scannable layout it always did."""
+        from desktop_app.app import _format_runtime_status
+
+        text = _format_runtime_status(self._snapshot())
+        assert text.startswith("🩺 Runtime Status")
+        assert "\n🎙️ Assistant\n  State: Listening" in text
+        assert "  Low Power Mode: On" in text
+        assert "\n🦙 Ollama\n  Needed: Yes\n  Running: Yes (0.9.1)" in text
+        assert "\n🔌 MCP\n  Configured servers: 2" in text
+
+    def test_dialog_renders_sections_and_values(self, qapp):
+        from desktop_app.app import RuntimeStatusDialog
+        from PyQt6.QtWidgets import QLabel, QPushButton
+
+        dialog = RuntimeStatusDialog(self._snapshot())
+
+        texts = [lbl.text() for lbl in dialog.findChildren(QLabel)]
+        assert "🩺 Runtime Status" in texts
+        assert "🎙️ Assistant" in texts
+        assert "🦙 Ollama" in texts
+        assert "🧠 Models" in texts
+        assert "🔌 MCP" in texts
+        assert "gemma4:e2b" in texts
+        assert "Yes (0.9.1)" in texts
+
+        # The dialog must be closable via its Close button.
+        close_btn = [
+            b for b in dialog.findChildren(QPushButton) if b.text() == "Close"
+        ]
+        assert close_btn, "dialog must expose a Close button"

--- a/tests/test_desktop_app.py
+++ b/tests/test_desktop_app.py
@@ -366,35 +366,6 @@ class TestRuntimeStatusSnapshot:
         assert "\n🔌 MCP\n  Configured servers: 2" in text
 
 
-class TestQuickStopAction:
-    """The tray exposes a fast stop path that skips the final diary LLM pass."""
-
-    def test_quick_stop_noops_when_already_stopped(self):
-        from desktop_app.app import JarvisSystemTray
-
-        tray = JarvisSystemTray.__new__(JarvisSystemTray)
-        tray.is_listening = False
-        tray.stop_daemon = MagicMock()
-
-        tray.quick_stop_daemon()
-
-        tray.stop_daemon.assert_not_called()
-
-    def test_quick_stop_skips_diary_update_when_listening(self):
-        from desktop_app.app import JarvisSystemTray
-
-        tray = JarvisSystemTray.__new__(JarvisSystemTray)
-        tray.is_listening = True
-        tray.stop_daemon = MagicMock()
-
-        tray.quick_stop_daemon()
-
-        tray.stop_daemon.assert_called_once_with(
-            show_diary_dialog=False,
-            skip_diary_update=True,
-        )
-
-
 class TestGetCrashPaths:
     """Tests for get_crash_paths() function."""
 

--- a/tests/test_dialogue_memory.py
+++ b/tests/test_dialogue_memory.py
@@ -645,3 +645,88 @@ class TestDialogueMemoryUnifiedDurations:
         assert dm.MAX_UNSAVED_AGE_SEC == 120.0
 
 
+
+
+@pytest.mark.unit
+class TestDialogueMemorySessions:
+    """Session archive / restore / rewind primitives backing the text-chat
+    sessions feature. Everything is in-memory only; these methods never
+    touch the diary or the disk."""
+
+    def _conversation(self):
+        dm = DialogueMemory()
+        dm.add_message("user", "remind me to buy oat milk")
+        dm.add_message("assistant", "Noted.")
+        dm.add_message("user", "what about eggs?")
+        dm.add_message("assistant", "Eggs too.")
+        return dm
+
+    def test_all_messages_returns_every_turn_in_order(self):
+        dm = self._conversation()
+        assert dm.all_messages() == [
+            {"role": "user", "content": "remind me to buy oat milk"},
+            {"role": "assistant", "content": "Noted."},
+            {"role": "user", "content": "what about eggs?"},
+            {"role": "assistant", "content": "Eggs too."},
+        ]
+
+    def test_set_messages_restores_a_snapshot(self):
+        dm = self._conversation()
+        snapshot = dm.all_messages()
+
+        dm.clear()
+        dm.set_messages(snapshot[:2])
+
+        assert dm.all_messages() == snapshot[:2]
+        assert dm.has_recent_messages(), "restored turns must count as recent"
+
+    def test_set_messages_ignores_blank_entries(self):
+        dm = DialogueMemory()
+        dm.set_messages([
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "   "},
+            {"role": "", "content": "hello"},
+        ])
+        assert dm.all_messages() == [{"role": "user", "content": "hi"}]
+
+    def test_clear_drops_conversation_and_caches(self):
+        dm = self._conversation()
+        dm.hot_cache_put("k", "v")
+        dm.record_tool_turn([{"role": "tool", "content": "x"}])
+
+        dm.clear()
+
+        assert dm.all_messages() == []
+        assert dm.hot_cache_get("k") is None
+        assert dm.get_recent_turns_with_tools() == []
+
+    def test_rewind_before_first_user_message_drops_everything(self):
+        dm = self._conversation()
+        assert dm.rewind_before_user_message(1) is True
+        assert dm.all_messages() == []
+
+    def test_rewind_before_second_user_message_keeps_first_turn(self):
+        dm = self._conversation()
+        assert dm.rewind_before_user_message(2) is True
+        assert dm.all_messages() == [
+            {"role": "user", "content": "remind me to buy oat milk"},
+            {"role": "assistant", "content": "Noted."},
+        ]
+
+    def test_rewind_to_unknown_user_index_is_a_noop(self):
+        dm = self._conversation()
+        assert dm.rewind_before_user_message(5) is False
+        assert len(dm.all_messages()) == 4
+
+    def test_rewind_clears_tool_carryover_and_hot_cache(self):
+        dm = self._conversation()
+        dm.hot_cache_put("router", "cached")
+        dm.record_tool_turn([{"role": "tool", "content": "x"}])
+
+        dm.rewind_before_user_message(2)
+
+        assert dm.hot_cache_get("router") is None
+        turns = dm.get_recent_turns_with_tools()
+        assert not any(m.get("role") == "tool" for m in turns), (
+            "tool carryover must be cleared by a rewind"
+        )

--- a/tests/test_review_478_defects.py
+++ b/tests/test_review_478_defects.py
@@ -79,7 +79,7 @@ class TestStopDropsTheLateReply:
 
         window._on_complete("une réponse tardive")
 
-        assert "une réponse tardive" not in window.transcript_widget.toPlainText()
+        assert "une réponse tardive" not in window.transcript_text()
 
     def test_a_complete_for_a_later_query_still_lands(self, qapp):
         """Cancelling one query must not deafen the window: the guard is
@@ -93,7 +93,7 @@ class TestStopDropsTheLateReply:
         window._send()
         window._on_complete("la bonne réponse")
 
-        assert "la bonne réponse" in window.transcript_widget.toPlainText()
+        assert "la bonne réponse" in window.transcript_text()
 
 
 # ── 2. Shutdown must not close the database under a worker ────────────


### PR DESCRIPTION
## Summary

Builds on the text chat interface (#478): the chat window is now a single
conversation styled like an SMS thread, with a rewind control on sent
messages and a themed runtime status dialog.

## Chat window: one conversation, SMS style

- **Single conversation, like a text-message thread with one contact.** No
  session list, no "new session" button, nothing written to disk. Voice and
  text keep sharing the daemon's single dialogue memory, so a follow-up
  typed in the chat window continues a voice discussion.
- **SMS look.** Portrait, phone-like window with a contact header (avatar,
  "Jarvis", and an Online / Typing presence line). Your messages are
  right-aligned amber bubbles, Jarvis's replies are left-aligned dark
  bubbles, each with a muted timestamp and no role prefixes.
- **Rewind button on every sent message.** Rolls the conversation back to
  that message (transcript and daemon memory), then re-submits the same text
  so a fresh reply is generated through the normal complete path. Disabled
  while a query is in flight or the daemon is stopped.
- **Tray label** is now `💬 Chat` (no ellipsis); the subprocess chat control
  closure only writes the `__CHAT_REWIND__:` line.

## Fast-stop removal

The `Force Quit (no saving)` tray action is removed. Stop Listening already
stops the listener immediately and then saves the diary + knowledge graph,
so the skip-diary path added nothing. The recently-added
`skip_diary_update` argument is removed end-to-end: `request_stop()`,
`stop_daemon()`, the `SHUTDOWN_SKIP_DIARY` stdin command, and the shutdown
skip flag are gone. The daemon's shutdown block always runs the final diary
save.

## Daemon + IPC

- The rewind path stays: `rewind_chat_to_user` (bundled) /
  `__CHAT_REWIND__:` (subprocess), guarded by the shared query lock.
- The daemon-side session API (`new_chat_session`, `set_chat_messages`,
  `__CHAT_NEW_SESSION__` / `__CHAT_RESTORE__:` handlers) remains as a tested
  daemon capability but is no longer used by the desktop UI, so the feature
  can return without daemon changes.

## Tests

Unit coverage for the SMS layout (bubble alignment, presence line, single
conversation accumulation, timestamps), rewind, the lock guard, and the
rewind IPC handler; session tests replaced, fast-stop tests removed. Full
unit suite: 2259 passed, 4 pre-existing macOS-environment failures
(`test_macos_crash_report.py` runs its darwin-only tests unconditionally on
Windows).

## Spec & docs

`chat_window.spec.md` rewritten to the single-conversation SMS design;
`desktop_app.spec.md`, `docs/llm_contexts.md`, and the README updated to
match.
