### PR TITLE
feat(tools): add getTime tool for time in any city or timezone

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Jarvis starts listening automatically — just say "Jarvis" and talk!
 - **Unlimited Memory** - Never forgets. Searches across all your conversation history. Memory Viewer GUI included.
 - **Adaptive Tone** - Automatically surgical for code, pragmatic for business, encouraging for wellbeing — no manual mode switching
 - **Smart Tool Selection** - Embedding-based relevance filtering picks only the tools needed per query — add unlimited MCP tools without performance degradation
-- **Built-in Tools** - Screenshot OCR, web search (DuckDuckGo → Brave → Wikipedia fallback chain with auto-fetch), weather, file access, nutrition tracking, location awareness, plus a tool-discovery escape hatch the agent uses to widen its own toolset mid-reply
+- **Built-in Tools** - Screenshot OCR, web search (DuckDuckGo → Brave → Wikipedia fallback chain with auto-fetch), weather, current time in any city or timezone, file access, nutrition tracking, location awareness, plus a tool-discovery escape hatch the agent uses to widen its own toolset mid-reply
 - **Knowledge Graph Memory** - Self-organising memory that learns from conversations, auto-splits by topic, and surfaces relevant knowledge automatically
 - **Natural Voice** - Say "Jarvis" anywhere in your sentence, interrupt with "stop", follow up without repeating the wake word
 - **Fast Stop** - Use the tray action `⚡ Stop Now (Skip Diary)` to release local model resources quickly when you need your machine back immediately.

--- a/src/jarvis/reply/engine.py
+++ b/src/jarvis/reply/engine.py
@@ -534,6 +534,7 @@ _HINT_MESSAGE_CHAR_LIMIT = 200
 # than a fact note.
 _DIGEST_SKIP_TOOLS = frozenset({
     "getWeather",
+    "getTime",
 })
 
 

--- a/src/jarvis/tools/builtin/__init__.py
+++ b/src/jarvis/tools/builtin/__init__.py
@@ -13,6 +13,7 @@ from .nutrition.log_meal import LogMealTool
 from .nutrition.fetch_meals import FetchMealsTool
 from .nutrition.delete_meal import DeleteMealTool
 from .weather import WeatherTool
+from .time_tool import TimeTool
 from .stop import StopTool
 
 # Import supporting functions that may still be used elsewhere
@@ -27,5 +28,6 @@ __all__ = [
     'FetchMealsTool',
     'DeleteMealTool',
     'WeatherTool',
+    'TimeTool',
     'StopTool',
 ]

--- a/src/jarvis/tools/builtin/time_tool.py
+++ b/src/jarvis/tools/builtin/time_tool.py
@@ -1,0 +1,223 @@
+"""Current time and date for any location or timezone.
+
+Resolves a user-named place (city, country) to its IANA timezone via the
+same Open-Meteo geocoding endpoint the weather tool uses, then formats the
+current instant in that zone with ``format_time_context``. A bare IANA
+zone name (``Europe/Athens``) is used directly without a network call.
+
+The tool is deliberately LLM-free: timezone arithmetic is deterministic,
+so time questions never ride on a small model's ability to compute UTC
+offsets. The user's OWN local time is already injected into the assistant's
+context each reply and needs no tool; this exists for the case the context
+cannot cover — a named place in another timezone.
+"""
+
+import re
+from typing import Any, Dict, Optional, Tuple
+
+import requests
+
+try:
+    from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+except ImportError:  # pragma: no cover - Python < 3.9
+    ZoneInfo = None  # type: ignore[assignment]
+    ZoneInfoNotFoundError = Exception  # type: ignore[assignment,misc]
+
+from ...debug import debug_log
+from ...utils.location import get_location_context_with_timezone
+from ...utils.time_context import format_time_context
+from ..base import Tool, ToolContext
+from ..types import ToolExecutionResult
+
+# Open-Meteo geocoding returns an IANA ``timezone`` field per result (the
+# same free, key-less endpoint getWeather already uses for its lookups).
+_GEOCODING_URL = "https://geocoding-api.open-meteo.com/v1/search"
+
+# Cache of lowercased location string -> (iana_zone, display_name).
+# Repeated questions about the same city must not re-hit the network.
+_geocode_cache: Dict[str, Tuple[Optional[str], str]] = {}
+
+# A bare IANA zone path ("Europe/Athens", "Asia/Tokyo", "America/New_York").
+# The "/" never appears in a plain city name, so it disambiguates zone
+# arguments from places without needing a lookup.
+_IANA_ZONE_RE = re.compile(r"^[A-Za-z_+-]+(?:/[A-Za-z_+-]+)+$")
+
+
+def _is_valid_iana_zone(value: str) -> bool:
+    """Return True when ``value`` is a zone path zoneinfo actually knows."""
+    if ZoneInfo is None or not _IANA_ZONE_RE.match(value.strip()):
+        return False
+    try:
+        ZoneInfo(value.strip())
+        return True
+    except (ZoneInfoNotFoundError, ValueError):
+        return False
+
+
+def _geocode_timezone(location: str, timeout_sec: float) -> Tuple[Optional[str], str]:
+    """Resolve a place name to its IANA timezone.
+
+    Returns ``(iana_zone, display_name)``. ``iana_zone`` is None when the
+    place could not be geocoded or carries no timezone; ``display_name`` is
+    the geocoded place name ("Thessaloniki, Central Macedonia, Greece") for
+    the reply, or the raw input when the lookup failed.
+    """
+    key = location.strip().lower()
+    cached = _geocode_cache.get(key)
+    if cached is not None:
+        return cached
+
+    params = {
+        "name": location.strip(),
+        "count": 1,
+        "language": "en",
+        "format": "json",
+    }
+    geo_response = requests.get(_GEOCODING_URL, params=params, timeout=timeout_sec)
+    geo_response.raise_for_status()
+    geo_data = geo_response.json()
+    results = geo_data.get("results") or []
+    if not results:
+        result = (None, location.strip())
+        _geocode_cache[key] = result
+        return result
+
+    place = results[0]
+    display = place.get("name", location.strip())
+    admin1 = place.get("admin1", "")
+    country = place.get("country", "")
+    if admin1 and admin1 != display:
+        display += f", {admin1}"
+    if country:
+        display += f", {country}"
+    result = (place.get("timezone"), display)
+    _geocode_cache[key] = result
+    return result
+
+
+class TimeTool(Tool):
+    """Tool for getting the current time/date in any location or timezone."""
+
+    @property
+    def name(self) -> str:
+        return "getTime"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Current time and date in a specific city, country, or timezone "
+            "(e.g. 'what time is it in London?', 'what's the date in Tokyo?'). "
+            "Use for time/date questions about a place other than the user's "
+            "own location — their local time is already in the assistant's "
+            "context and needs no tool. NOT for weather; that is getWeather."
+        )
+
+    @property
+    def inputSchema(self) -> Dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "location": {
+                    "type": "string",
+                    "description": (
+                        "OPTIONAL. City name, country, or IANA timezone "
+                        "(e.g. 'Thessaloniki', 'Japan', 'Europe/Athens'). "
+                        "Set it when the user names a place. If omitted, "
+                        "returns the user's local time — which is already in "
+                        "the assistant's context."
+                    ),
+                }
+            },
+            "required": [],
+        }
+
+    def run(self, args: Optional[Dict[str, Any]], context: ToolContext) -> ToolExecutionResult:
+        """Get the current time for the requested place (or the user's own)."""
+        context.user_print("🕐 Checking time...")
+
+        timeout_sec = 8.0
+        if context.cfg is not None:
+            timeout_sec = float(getattr(context.cfg, "llm_tools_timeout_sec", 8.0))
+
+        location_str = ""
+        if args and isinstance(args, dict):
+            raw_location = args.get("location")
+            location_str = str(raw_location).strip() if raw_location else ""
+
+        try:
+            if location_str:
+                if _is_valid_iana_zone(location_str):
+                    tz_name = location_str.strip()
+                    display = tz_name
+                else:
+                    tz_name, display = _geocode_timezone(location_str, timeout_sec)
+                    if tz_name is None:
+                        if not display or display.lower() == location_str.lower():
+                            return ToolExecutionResult(
+                                success=False,
+                                reply_text=(
+                                    f"Could not find location '{location_str}'. "
+                                    "Try a different city name or spelling."
+                                ),
+                            )
+                        return ToolExecutionResult(
+                            success=False,
+                            reply_text=(
+                                f"Could not determine the timezone for "
+                                f"'{display}'."
+                            ),
+                        )
+                time_str = format_time_context(tz_name)
+                short_name = display.split(",")[0].strip()
+                context.user_print(f"✅ Current time in {short_name}: {time_str}")
+                return ToolExecutionResult(
+                    success=True,
+                    reply_text=f"Current time in {display}: {time_str}",
+                )
+
+            # No location — the user's own local time. Prefer the GeoIP zone
+            # when available; format_time_context falls back to the OS zone.
+            tz_name: Optional[str] = None
+            if context.cfg is not None:
+                try:
+                    _, tz_name = get_location_context_with_timezone(
+                        config_ip=getattr(context.cfg, "location_ip_address", None),
+                        auto_detect=getattr(context.cfg, "location_auto_detect", True),
+                        resolve_cgnat_public_ip=getattr(
+                            context.cfg, "location_cgnat_resolve_public_ip", True
+                        ),
+                        location_cache_minutes=getattr(
+                            context.cfg, "location_cache_minutes", 60
+                        ),
+                    )
+                except Exception as e:
+                    debug_log(f"getTime: local tz lookup failed: {e}", "tools")
+                    tz_name = None
+            time_str = format_time_context(tz_name)
+            context.user_print(f"✅ Current time: {time_str}")
+            return ToolExecutionResult(
+                success=True,
+                reply_text=f"Current time: {time_str}",
+            )
+
+        except requests.exceptions.Timeout:
+            debug_log("time request timed out", "tools")
+            context.user_print("⚠️ Time service timeout.")
+            return ToolExecutionResult(
+                success=False,
+                reply_text="Time service is taking too long to respond. Please try again.",
+            )
+        except requests.exceptions.RequestException as e:
+            debug_log(f"time request failed: {e}", "tools")
+            context.user_print("⚠️ Time service unavailable.")
+            return ToolExecutionResult(
+                success=False,
+                reply_text="Time service is temporarily unavailable. Please try again later.",
+            )
+        except Exception as e:
+            debug_log(f"time error: {e}", "tools")
+            context.user_print("⚠️ Error getting time.")
+            return ToolExecutionResult(
+                success=False,
+                reply_text=f"Error getting time: {e}",
+            )

--- a/src/jarvis/tools/registry.py
+++ b/src/jarvis/tools/registry.py
@@ -18,6 +18,7 @@ from .builtin.nutrition.fetch_meals import FetchMealsTool
 from .builtin.nutrition.delete_meal import DeleteMealTool
 from .builtin.refresh_mcp_tools import RefreshMCPToolsTool
 from .builtin.weather import WeatherTool
+from .builtin.time_tool import TimeTool
 from .builtin.stop import StopTool
 from .builtin.tool_search import ToolSearchTool
 from .types import ToolExecutionResult
@@ -37,6 +38,7 @@ BUILTIN_TOOLS = {
     "deleteMeal": DeleteMealTool(),
     "refreshMCPTools": RefreshMCPToolsTool(),
     "getWeather": WeatherTool(),
+    "getTime": TimeTool(),
     "stop": StopTool(),
     "toolSearchTool": ToolSearchTool(),
 }

--- a/tests/tools/builtin/test_time_tool.py
+++ b/tests/tools/builtin/test_time_tool.py
@@ -1,0 +1,171 @@
+"""Tests for the getTime tool."""
+
+from unittest.mock import Mock, patch
+
+import requests
+
+from src.jarvis.tools.base import ToolContext
+from src.jarvis.tools.builtin.time_tool import TimeTool
+from src.jarvis.tools.registry import BUILTIN_TOOLS
+from src.jarvis.tools.types import ToolExecutionResult
+
+
+class TestTimeTool:
+    """Test the getTime tool behaviour."""
+
+    def setup_method(self):
+        self.tool = TimeTool()
+        self.context = Mock(spec=ToolContext)
+        self.context.user_print = Mock()
+        self.context.cfg = Mock()
+        self.context.cfg.llm_tools_timeout_sec = 8.0
+        self.context.redacted_text = ""
+
+    def test_tool_properties(self):
+        """Tool metadata: camelCase name, time-focused description, optional location."""
+        assert self.tool.name == "getTime"
+        assert "time" in self.tool.description.lower()
+        assert self.tool.inputSchema["type"] == "object"
+        assert "location" in self.tool.inputSchema["properties"]
+        assert self.tool.inputSchema["required"] == []
+
+    def test_registered_in_builtin_tools(self):
+        """The router and reply loop must be able to select getTime."""
+        assert "getTime" in BUILTIN_TOOLS
+        assert isinstance(BUILTIN_TOOLS["getTime"], TimeTool)
+
+    @patch("src.jarvis.tools.builtin.time_tool.format_time_context",
+           return_value="Tuesday, July 01, 2025 at 13:00 EEST")
+    @patch("requests.get")
+    def test_run_with_city_success(self, mock_get, mock_fmt):
+        """A named city is geocoded and its IANA timezone drives the answer."""
+        geo_response = Mock()
+        geo_response.status_code = 200
+        geo_response.json.return_value = {
+            "results": [{
+                "name": "Thessaloniki",
+                "admin1": "Central Macedonia",
+                "country": "Greece",
+                "timezone": "Europe/Athens",
+            }]
+        }
+        geo_response.raise_for_status = Mock()
+        mock_get.return_value = geo_response
+
+        result = self.tool.run({"location": "Thessaloniki"}, self.context)
+
+        assert isinstance(result, ToolExecutionResult)
+        assert result.success is True
+        assert "Thessaloniki" in result.reply_text
+        assert "Tuesday, July 01, 2025 at 13:00 EEST" in result.reply_text
+        # The geocoded zone must be what gets formatted — never the raw city
+        # name, never a guess.
+        mock_fmt.assert_called_once_with("Europe/Athens")
+
+    @patch("src.jarvis.tools.builtin.time_tool.format_time_context",
+           return_value="Tuesday, July 01, 2025 at 13:00 EEST")
+    @patch("requests.get")
+    def test_run_with_iana_zone_direct(self, mock_get, mock_fmt):
+        """A bare IANA zone in the location arg needs no network call."""
+        result = self.tool.run({"location": "Europe/Athens"}, self.context)
+
+        assert result.success is True
+        assert "Europe/Athens" in result.reply_text
+        mock_fmt.assert_called_once_with("Europe/Athens")
+        mock_get.assert_not_called()
+
+    @patch("requests.get")
+    def test_run_unknown_zone_shape_geocodes(self, mock_get):
+        """A slash-y string that is NOT a valid zone must geocode, not error."""
+        geo_response = Mock()
+        geo_response.status_code = 200
+        geo_response.json.return_value = {
+            "results": [{
+                "name": "Atlantis",
+                "country": "Atlantis",
+                "timezone": "Atlantic/Reykjavik",
+            }]
+        }
+        geo_response.raise_for_status = Mock()
+        mock_get.return_value = geo_response
+
+        result = self.tool.run({"location": "Not/A_Zone"}, self.context)
+
+        assert result.success is True
+        assert "Atlantis" in result.reply_text
+        mock_get.assert_called_once()
+
+    @patch("requests.get")
+    def test_run_location_not_found(self, mock_get):
+        """Unknown places are reported honestly, not guessed at."""
+        geo_response = Mock()
+        geo_response.status_code = 200
+        geo_response.json.return_value = {"results": []}
+        geo_response.raise_for_status = Mock()
+        mock_get.return_value = geo_response
+
+        result = self.tool.run({"location": "Nonexistent Place XYZ"}, self.context)
+
+        assert isinstance(result, ToolExecutionResult)
+        assert result.success is False
+        assert "could not find" in result.reply_text.lower()
+
+    @patch("requests.get")
+    def test_run_geocode_result_without_timezone(self, mock_get):
+        """A geocode hit without a timezone field must fail cleanly."""
+        geo_response = Mock()
+        geo_response.status_code = 200
+        geo_response.json.return_value = {
+            "results": [{"name": "Somewhere", "country": "Nowhere"}]
+        }
+        geo_response.raise_for_status = Mock()
+        mock_get.return_value = geo_response
+
+        result = self.tool.run({"location": "Somewhere"}, self.context)
+
+        assert result.success is False
+        assert "timezone" in result.reply_text.lower()
+
+    @patch("src.jarvis.tools.builtin.time_tool.format_time_context",
+           return_value="Tuesday, July 01, 2025 at 13:00 EEST")
+    @patch("src.jarvis.tools.builtin.time_tool.get_location_context_with_timezone",
+           return_value=("some location context", "Europe/Istanbul"))
+    def test_run_no_location_uses_geoip_zone(self, mock_loc, mock_fmt):
+        """No location → prefer the user's GeoIP zone when one is known."""
+        result = self.tool.run(None, self.context)
+
+        assert result.success is True
+        mock_fmt.assert_called_once_with("Europe/Istanbul")
+
+    @patch("src.jarvis.tools.builtin.time_tool.format_time_context",
+           return_value="Tuesday, July 01, 2025 at 13:00 EEST")
+    @patch("src.jarvis.tools.builtin.time_tool.get_location_context_with_timezone",
+           return_value=("some location context", None))
+    def test_run_no_location_without_zone_falls_back_to_os(self, mock_loc, mock_fmt):
+        """No location and no GeoIP zone → the OS local zone handles it."""
+        result = self.tool.run({}, self.context)
+
+        assert result.success is True
+        mock_fmt.assert_called_once_with(None)
+
+    @patch("requests.get")
+    def test_run_network_timeout(self, mock_get):
+        """Network timeouts degrade to a clear message, not a crash."""
+        mock_get.side_effect = requests.exceptions.Timeout("Connection timed out")
+
+        result = self.tool.run({"location": "London"}, self.context)
+
+        assert isinstance(result, ToolExecutionResult)
+        assert result.success is False
+        assert "taking too long" in result.reply_text.lower()
+
+    @patch("requests.get")
+    def test_run_network_error(self, mock_get):
+        """Network failures degrade to a clear message, not a crash."""
+        mock_get.side_effect = requests.exceptions.ConnectionError("Network error")
+
+        result = self.tool.run({"location": "London"}, self.context)
+
+        assert isinstance(result, ToolExecutionResult)
+        assert result.success is False
+        assert "unavailable" in result.reply_text.lower()


### PR DESCRIPTION
## Problem

A "what time is it in \<city\>?" query had no correct answer path. The assistant's context line only carries the user's **local** time, so a timezone question can't be answered from context. The tool catalogue had no time/timezone tool either, so the LLM tool router fell back to `getWeather` — the only place-flavoured tool — and the weather tool then scraped the city name out of the raw utterance, returning *weather* for the city whose *time* was asked.

This was compounded by the intent-judge timeout fallback feeding raw, uncleaned text ("hey , what time is it in thessaloniki?") into the router, which reinforced the "this is about a place" reading.

## Change

Add a new built-in `getTime` tool (`src/jarvis/tools/builtin/time_tool.py`), registered in `BUILTIN_TOOLS`:

- **Named place** (e.g. "Thessaloniki", "Japan") is geocoded via Open-Meteo (the same key-less endpoint `getWeather` uses), which returns the IANA timezone; the current instant is formatted in that zone with `format_time_context`.
- **Bare IANA zone** ("Europe/Athens") is used directly, no network call.
- **No location** returns the user's own local time (GeoIP zone, falling back to the OS zone).
- **LLM-free** — timezone arithmetic never rides on a small model, and no new LLM context is added.
- Added to `_DIGEST_SKIP_TOOLS` so its one-line result isn't run through the fact-note distil.
- README Built-in Tools list updated.

## Verification

- 11 new unit tests (`tests/tools/builtin/test_time_tool.py`): city geocoding, IANA-zone direct path, unknown locations, missing timezone field, local-time fallbacks, network failures.
- 224 related tests green (`tests/tools/builtin/`, `test_tools.py`, `test_planner.py`, `test_mcp_integration.py`, `test_engine_hot_window_caches.py`, `test_engine_tool_search_loop.py`, `test_greeting_no_tools.py`, `test_time_context.py`, `test_location_context.py`).
- Live smoke test against the real API: `Thessaloniki` → `Europe/Athens` → "Current time in Thessaloniki, Central Macedonia, Greece: …".