### PR TITLE
feat(desktop): group listening toggle with status in tray menu

### DIFF
--- a/src/desktop_app/app.py
+++ b/src/desktop_app/app.py
@@ -1885,13 +1885,6 @@ class JarvisSystemTray:
         """Create the system tray context menu."""
         self.menu = QMenu()
 
-        # Toggle listening action
-        self.toggle_action = QAction("▶️ Start Listening")
-        self.toggle_action.triggered.connect(self.toggle_listening)
-        self.menu.addAction(self.toggle_action)
-
-        self.menu.addSeparator()
-
         # View logs action
         self.logs_action = QAction("📝 View Logs")
         self.logs_action.triggered.connect(self.show_log_viewer)
@@ -1954,6 +1947,11 @@ class JarvisSystemTray:
         self.menu.addAction(self.open_data_action)
 
         self.menu.addSeparator()
+
+        # Toggle listening action
+        self.toggle_action = QAction("▶️ Start Listening")
+        self.toggle_action.triggered.connect(self.toggle_listening)
+        self.menu.addAction(self.toggle_action)
 
         # Status action (non-clickable)
         self.status_action = QAction("⚪ Status: Stopped")

--- a/tests/test_desktop_app.py
+++ b/tests/test_desktop_app.py
@@ -1654,3 +1654,35 @@ class TestRuntimeStatusDialog:
             b for b in dialog.findChildren(QPushButton) if b.text() == "Close"
         ]
         assert close_btn, "dialog must expose a Close button"
+
+
+class TestTrayMenuLayout:
+    """The tray menu groups the listening controls together: the
+    Start/Stop Listening toggle sits directly above the listening Status
+    line in the same section of the menu."""
+
+    def _tray_menu(self, qapp):
+        from desktop_app.app import JarvisSystemTray
+        from PyQt6.QtWidgets import QSystemTrayIcon
+
+        tray = JarvisSystemTray.__new__(JarvisSystemTray)
+        tray.tray_icon = QSystemTrayIcon()
+        tray.create_menu()
+        return tray.menu
+
+    def test_listening_toggle_is_above_status_in_same_section(self, qapp):
+        menu = self._tray_menu(qapp)
+        actions = list(menu.actions())
+
+        toggle_idx = next(
+            i for i, a in enumerate(actions) if "Listening" in a.text()
+        )
+        status_idx = next(
+            i for i, a in enumerate(actions) if "Status:" in a.text()
+        )
+
+        assert toggle_idx < status_idx
+        between = actions[toggle_idx + 1 : status_idx]
+        assert not any(a.isSeparator() for a in between), (
+            "Start/Stop Listening and the Status line must share one menu section"
+        )


### PR DESCRIPTION
## What

Moves the **Start/Stop Listening** toggle out of the top of the tray context menu into the same section as the **Status** line, placing it directly above it.

Before:
```
▶️ Start Listening / ⏸️ Stop Listening
─────────────
📝 View Logs … 🔄 Check for Updates
─────────────
📁 Open Config Directory
💾 Open Data Directory
─────────────
⚪ Status: Stopped / 🟢 Status: Listening
─────────────
🚪 Quit
```

After:
```
📝 View Logs … 🔄 Check for Updates
─────────────
📁 Open Config Directory
💾 Open Data Directory
─────────────
▶️ Start Listening / ⏸️ Stop Listening
⚪ Status: Stopped / 🟢 Status: Listening
─────────────
🚪 Quit
```

The two listening controls now share one menu section, with the toggle directly above the status line.

## Why

Keeps all listening-related controls grouped together in a single section instead of having the primary toggle at the top of the menu and the status line near the bottom.

## Test plan

- Added `TestTrayMenuLayout::test_listening_toggle_is_above_status_in_same_section`: builds the real tray menu (offscreen Qt) and asserts the toggle appears before the Status line with no separator between them. Fails on the old layout, passes on the new one.
- `tests/test_desktop_app.py::TestTrayMenuLayout` and `tests/test_dictation_history.py::TestMenuIntegration` pass. The 44 failures in the broader run (`test_chat_window.py` bubble-rendering + `test_desktop_app.py` smoke tests) are pre-existing on `develop` and unchanged by this PR.