### PR TITLE
fix(config): keep a Hugging Face model ID out of path normalisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,8 @@ is ready. The first LLM-backed request after startup or idle may be slower.
 
 Speed is relative to the original large model. [Source](https://github.com/openai/whisper)
 
+`whisper_model` also accepts a Hugging Face repo ID (`"deepdml/faster-whisper-large-v3-turbo-ct2"`) or a directory holding a converted model, which is how you run a model this table does not name.
+
 #### GPU Acceleration (Windows)
 If you have an NVIDIA GPU, Jarvis can use CUDA for much faster speech recognition. The Windows installer offers an optional CUDA download during setup. For development:
 ```bash

--- a/src/jarvis/config.py
+++ b/src/jarvis/config.py
@@ -449,6 +449,25 @@ def _expand_path(value: Any) -> Optional[str]:
         return str(value)
 
 
+def _expand_model_reference(value: Any) -> Optional[str]:
+    """Normalise a model setting that may name a model rather than a file.
+
+    A Whisper model is given as a size ("medium"), a Hugging Face repo ID
+    ("owner/model"), or a directory on disk. Only the last is a path, and
+    path normalisation would rewrite the repo ID's separator to a backslash
+    on Windows, leaving an identifier the loader cannot resolve. Expansion
+    therefore applies to what is recognisably a path and nothing else.
+    """
+    if value in (None, "", "null"):
+        return None
+    raw = str(value)
+    try:
+        is_a_path = raw.startswith("~") or Path(raw).is_absolute() or Path(raw).exists()
+    except Exception:
+        is_a_path = False
+    return _expand_path(raw) if is_a_path else raw
+
+
 def _ensure_dict(value: Any) -> Dict[str, Any]:
     if isinstance(value, dict):
         return value
@@ -768,9 +787,7 @@ def load_settings() -> Settings:
     wake_word = str(merged.get("wake_word", "jarvis")).strip().lower()
     wake_aliases = [a.strip().lower() for a in _ensure_list(merged.get("wake_aliases")) if a.strip()]
     wake_fuzzy_ratio = float(merged.get("wake_fuzzy_ratio", 0.78))
-    # whisper_model accepts a size name ("medium") or a local model
-    # directory; _expand_path is a no-op for plain names.
-    whisper_model = _expand_path(merged.get("whisper_model")) or "medium"
+    whisper_model = _expand_model_reference(merged.get("whisper_model")) or "medium"
     whisper_backend = os.environ.get("JARVIS_WHISPER_BACKEND", "").lower() or str(merged.get("whisper_backend", "auto")).lower()
     if whisper_backend not in ("auto", "mlx", "faster-whisper"):
         whisper_backend = "auto"

--- a/tests/test_config_path_expansion.py
+++ b/tests/test_config_path_expansion.py
@@ -69,6 +69,28 @@ def test_tilde_whisper_model_path_is_expanded(tmp_path, monkeypatch):
     assert load_settings().whisper_model == "medium"
 
 
+def test_hugging_face_model_id_survives_config_loading(tmp_path, monkeypatch):
+    """A repo ID is an identifier, not a path: its separator must stay a slash.
+
+    Path normalisation turns "owner/model" into "owner\\model" on Windows and
+    the download then fails with an invalid model size.
+    """
+    _write_config(tmp_path, monkeypatch, {
+        "whisper_model": "deepdml/faster-whisper-large-v3-turbo-ct2",
+    })
+
+    assert load_settings().whisper_model == "deepdml/faster-whisper-large-v3-turbo-ct2"
+
+
+def test_a_local_whisper_model_directory_is_still_a_path(tmp_path, monkeypatch):
+    """Directories that exist keep being normalised for the loader."""
+    model_dir = tmp_path / "models" / "faster-whisper-medium"
+    model_dir.mkdir(parents=True)
+    _write_config(tmp_path, monkeypatch, {"whisper_model": str(model_dir)})
+
+    assert load_settings().whisper_model == str(model_dir)
+
+
 def test_absolute_and_unset_paths_are_untouched(tmp_path, monkeypatch):
     """Absolute paths pass through unchanged; unset optional paths stay None."""
     db = tmp_path / "jarvis.db"


### PR DESCRIPTION
## Summary
- `whisper_model` accepts a size name (\`medium\`), a Hugging Face repo ID (\`owner/model\`), or a local directory, but every value went through path expansion.
- On Windows, path expansion rewrote the separator in a repo ID like `deepdml/faster-whisper-large-v3-turbo-ct2` to a backslash, and the loader then rejected the result as an invalid model size, so no model outside the built-in size names could be used on that platform.
- Expansion now only applies to what is recognisably a path (a tilde, an absolute path, or something that exists on disk); everything else is treated as an identifier and passed through unchanged.

## Test plan
- [x] `pytest tests/test_config_path_expansion.py` (7 tests, new coverage for the size/repo-ID/path distinction)
- [x] Verified against the real model: `deepdml/faster-whisper-large-v3-turbo-ct2` loads correctly with `HF_HUB_OFFLINE=1` on Windows after this fix