### PR TITLE
feat(listening): expose low-confidence transcript events

### DIFF
--- a/src/jarvis/listening/__init__.py
+++ b/src/jarvis/listening/__init__.py
@@ -12,6 +12,7 @@ def __getattr__(name: str):
     """Lazily import public names on first access."""
     _imports = {
         "VoiceListener": ".listener",
+        "LowConfidenceEvent": ".listener",
         "EchoDetector": ".echo_detection",
         "StateManager": ".state_manager",
         "ListeningState": ".state_manager",
@@ -33,6 +34,7 @@ def __getattr__(name: str):
 
 __all__ = [
     "VoiceListener",
+    "LowConfidenceEvent",
     "EchoDetector",
     "StateManager",
     "ListeningState",

--- a/src/jarvis/listening/listener.py
+++ b/src/jarvis/listening/listener.py
@@ -13,7 +13,8 @@ import queue
 import sys
 import platform
 from collections import deque
-from typing import Optional, TYPE_CHECKING, Any
+from typing import Optional, TYPE_CHECKING, Any, Callable, Literal
+from dataclasses import dataclass
 from datetime import datetime
 
 from rapidfuzz import fuzz
@@ -37,6 +38,15 @@ from ..utils.location import is_location_available
 if TYPE_CHECKING:
     from ..memory.db import Database
     from ..memory.conversation import DialogueMemory
+
+
+@dataclass(frozen=True)
+class LowConfidenceEvent:
+    """A rejected Whisper segment, available in memory to listener consumers."""
+
+    confidence: float
+    transcript: str
+    reason: Literal["low_confidence"] = "low_confidence"
 
 
 def is_whisper_hallucination(no_speech_prob: float, threshold: float) -> bool:
@@ -377,7 +387,8 @@ class VoiceListener(threading.Thread):
     """Main voice listening thread that orchestrates all voice processing."""
 
     def __init__(self, db: "Database", cfg, tts: Optional[Any],
-                 dialogue_memory: "DialogueMemory"):
+                 dialogue_memory: "DialogueMemory", *,
+                 on_low_confidence: Optional[Callable[[LowConfidenceEvent], None]] = None):
         """
         Initialise voice listener.
 
@@ -386,6 +397,9 @@ class VoiceListener(threading.Thread):
             cfg: Configuration object
             tts: Text-to-speech engine (optional)
             dialogue_memory: Dialogue memory instance
+            on_low_confidence: Optional per-segment rejection callback. Runs
+                synchronously on the transcription thread and must not block;
+                consumers should enqueue work for their own thread if needed.
         """
         super().__init__(daemon=True)
 
@@ -393,6 +407,7 @@ class VoiceListener(threading.Thread):
         self.cfg = cfg
         self.tts = tts
         self.dialogue_memory = dialogue_memory
+        self.on_low_confidence = on_low_confidence
         self._should_stop = False
         self._dictation_active = False  # Pause flag set by dictation engine
         self._first_utterance = True  # Suppress turn separator before the very first transcription
@@ -1337,6 +1352,15 @@ class VoiceListener(threading.Thread):
         except Exception:
             return False
 
+    def _emit_low_confidence(self, confidence: float, transcript: str) -> None:
+        """Notify a consumer without allowing its failure to interrupt transcription."""
+        if self.on_low_confidence is None:
+            return
+        try:
+            self.on_low_confidence(LowConfidenceEvent(confidence, transcript))
+        except Exception as exc:
+            debug_log(f"low-confidence callback failed ({type(exc).__name__})", "voice")
+
     def _filter_noisy_segments(self, segments):
         """Filter out low-confidence Whisper segments."""
         min_confidence = getattr(self.cfg, "whisper_min_confidence", 0.3)
@@ -1363,6 +1387,7 @@ class VoiceListener(threading.Thread):
                 confidence = 1.0 - seg.no_speech_prob
 
             if confidence is not None and confidence < min_confidence:
+                self._emit_low_confidence(confidence, seg.text)
                 if confidence >= marginal_threshold:
                     # Marginal confidence - show in log viewer (not debug)
                     print(f"🔇 Low confidence ({confidence:.2f}): \"{seg.text.strip()[:50]}...\"", flush=True)
@@ -2473,6 +2498,7 @@ class VoiceListener(threading.Thread):
                             continue
 
                         if confidence < min_confidence:
+                            self._emit_low_confidence(confidence, seg.get("text", ""))
                             if confidence >= marginal_threshold:
                                 # Marginal confidence - show in log viewer (not debug)
                                 print(f"🔇 Low confidence ({confidence:.2f}): \"{seg_text[:50]}...\"", flush=True)

--- a/src/jarvis/listening/listening.spec.md
+++ b/src/jarvis/listening/listening.spec.md
@@ -302,6 +302,30 @@ If the intent judge later rejects the query (and no hot window override applies)
 
 **Face state is not set during TTS** — the beep is suppressed while TTS is playing to avoid self-triggering.
 
+## Low-Confidence Rejection Events
+
+`VoiceListener` accepts an optional keyword-only `on_low_confidence` callback.
+Both faster-whisper and MLX emit one immutable `LowConfidenceEvent` per segment
+discarded because its confidence is below `whisper_min_confidence`, including
+very low-confidence segments that only appear in debug logs. The event contains:
+
+- `confidence`: the same score used by the rejection check.
+- `transcript`: the full raw segment text, without trimming or truncation.
+- `reason`: `"low_confidence"`.
+
+The event is available from `jarvis.listening`. The callback runs synchronously
+on the transcription thread and must not block. Consumers that need to update
+another thread must enqueue their own work. Callback exceptions are logged by
+exception type, without payloads, and do not interrupt filtering or transcription.
+The listener does not retain or persist these events.
+
+Segments rejected by the earlier no-speech gate do not emit low-confidence
+events. Accepted segments and segments without confidence metadata retain their
+existing backend-specific filtering behaviour. These events do not trigger TTS,
+UI updates, transcript-buffer entries, or query dispatch; accepted speech in a
+mixed utterance continues through the normal pipeline. Without a callback, the
+listener filters and logs rejected segments without notifying any consumer.
+
 ## Configuration
 
 ```json

--- a/tests/test_low_confidence_events.py
+++ b/tests/test_low_confidence_events.py
@@ -1,0 +1,147 @@
+"""Low-confidence events expose rejected speech without changing voice behaviour."""
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+import time
+
+import numpy as np
+import pytest
+
+from jarvis.listening import listener as listener_module
+
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def make_listener(monkeypatch):
+    monkeypatch.setattr(listener_module, "create_intent_judge", lambda cfg: None)
+    monkeypatch.setattr(listener_module, "np", np)
+
+    def make(**kwargs):
+        cfg = SimpleNamespace(
+            vad_enabled=False,
+            voice_debug=False,
+            whisper_min_confidence=0.5,
+            whisper_no_speech_threshold=0.6,
+            whisper_min_audio_duration=0.1,
+        )
+        return listener_module.VoiceListener(None, cfg, None, None, **kwargs)
+
+    return make
+
+
+@pytest.fixture(params=["faster-whisper", "mlx"])
+def transcribe(request, monkeypatch):
+    """Run the real utterance pipeline with deterministic speech-model output."""
+    def run(listener, segments):
+        listener._whisper_backend = request.param
+        if request.param == "mlx":
+            model = SimpleNamespace(transcribe=lambda *args, **kwargs: {
+                "segments": segments, "language": "en",
+            })
+            monkeypatch.setattr(listener_module, "mlx_whisper", model, raising=False)
+        else:
+            listener.model = SimpleNamespace(transcribe=lambda *args, **kwargs: (
+                iter(SimpleNamespace(**seg) for seg in segments),
+                SimpleNamespace(language="en"),
+            ))
+        listener._utterance_frames = [np.zeros(listener._samplerate, dtype=np.float32)]
+        listener.echo_detector._utterance_start_time = time.time() - 1
+        listener._process_transcript = Mock()
+        listener._finalize_utterance()
+        return [call.args[0] for call in listener._process_transcript.call_args_list]
+
+    return run
+
+
+def segment(text, confidence, no_speech_prob=0):
+    return {"text": text, "avg_logprob": confidence - 1,
+            "no_speech_prob": no_speech_prob}
+
+
+def test_rejections_expose_raw_transcript_confidence_and_reason(make_listener, transcribe):
+    events = []
+    listener = make_listener(on_low_confidence=events.append)
+    threshold = listener.cfg.whisper_min_confidence
+    rejected = [
+        segment("  Could you repeat that? " * 4, threshold / 2),
+        segment(" unclear speech ", threshold / 10),
+    ]
+
+    assert transcribe(listener, rejected) == []
+    assert len(events) == len(rejected)
+    for event, original in zip(events, rejected):
+        assert isinstance(event, listener_module.LowConfidenceEvent)
+        assert event.transcript == original["text"]
+        assert event.confidence == pytest.approx(original["avg_logprob"] + 1)
+        assert event.reason == "low_confidence"
+
+
+def test_accepted_segments_and_no_speech_rejections_do_not_emit(make_listener, transcribe):
+    events = []
+    listener = make_listener(on_low_confidence=events.append)
+    threshold = listener.cfg.whisper_min_confidence
+    segments = [
+        segment("hello", threshold),
+        segment("world", (threshold + 1) / 2),
+        segment("background noise", threshold / 2,
+                listener.cfg.whisper_no_speech_threshold),
+    ]
+
+    assert transcribe(listener, segments) == ["hello world"]
+    assert events == []
+
+
+def test_mixed_utterance_preserves_accepted_speech(make_listener, transcribe):
+    events = []
+    listener = make_listener(on_low_confidence=events.append)
+    threshold = listener.cfg.whisper_min_confidence
+
+    assert transcribe(listener, [
+        segment("hello", threshold),
+        segment("unclear", threshold / 2),
+        segment("world", threshold),
+    ]) == ["hello world"]
+    assert [event.transcript for event in events] == ["unclear"]
+
+
+def test_callback_is_optional(make_listener, transcribe):
+    listener = make_listener()
+    threshold = listener.cfg.whisper_min_confidence
+
+    assert transcribe(listener, [
+        segment("unclear", threshold / 2),
+        segment("hello", threshold),
+    ]) == ["hello"]
+
+
+def test_callback_failure_does_not_discard_accepted_speech(make_listener, transcribe):
+    events = []
+
+    def failing_callback(event):
+        events.append(event)
+        raise RuntimeError("Consumer failed")
+
+    listener = make_listener(on_low_confidence=failing_callback)
+    threshold = listener.cfg.whisper_min_confidence
+
+    assert transcribe(listener, [
+        segment("unclear", threshold / 2),
+        segment("hello", threshold),
+        segment("also unclear", threshold / 10),
+    ]) == ["hello"]
+    assert [event.transcript for event in events] == ["unclear", "also unclear"]
+
+
+def test_faster_whisper_confidence_fallback(make_listener):
+    events = []
+    listener = make_listener(on_low_confidence=events.append)
+    listener.cfg.whisper_no_speech_threshold = 0.9
+    rejected = SimpleNamespace(text="unclear", no_speech_prob=0.75)
+    unknown = SimpleNamespace(text="no confidence metadata")
+
+    assert listener._filter_noisy_segments([rejected, unknown]) == [unknown]
+    assert len(events) == 1
+    assert events[0].confidence == pytest.approx(1 - rejected.no_speech_prob)
+    assert events[0].transcript == rejected.text


### PR DESCRIPTION
Whisper segments rejected for low confidence are only logged, leaving downstream consumers without their confidence score or raw transcript. Add an optional `on_low_confidence` callback to `VoiceListener` that delivers an immutable `LowConfidenceEvent` with the score, full raw transcript, and rejection reason from both faster-whisper and MLX.

Events are emitted once per rejected segment, after the separate no-speech filter. Accepted speech keeps its existing processing, and callback exceptions cannot interrupt transcription. The listener spec documents the synchronous callback contract. No spoken or visual feedback is added.

Validation: **276 tests passed**, including 11 new regression cases covering both backends, mixed accepted/rejected speech, optional callbacks, and callback failures. The new event tests were verified to fail before implementation.

Tested on Windows with Python 3.11 and NumPy 1.26.4. The local environment used `webrtcvad-wheels==2.0.14` because the pinned source package needs unavailable C++ build tools; repository dependencies are unchanged. Speech-model output is mocked; live microphone/model and macOS hardware testing were not performed.

Closes #373
